### PR TITLE
PresignGetObject support

### DIFF
--- a/Minio.Examples/PresignGetObject.cs
+++ b/Minio.Examples/PresignGetObject.cs
@@ -1,0 +1,37 @@
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Minio;
+
+namespace Minio.Examples
+{
+    class GetObject
+    {
+        static int Main(string[] args)
+        {
+            var client = new MinioClient("https://s3.amazonaws.com", "ACCESSKEY", "SECRETKEY");
+            Console.Out.WriteLine(client.PresignGetObject("bucket", "object", 1000));
+            return 0;
+        }
+    }
+}

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -34,6 +34,7 @@ namespace Minio
 
         private RestClient client;
         private string region;
+        private V4Authenticator authenticator;
 
         private string SystemUserAgent
         {
@@ -100,6 +101,7 @@ namespace Minio
             this.client.UserAgent = this.FullUserAgent;
             if (accessKey != null && secretKey != null)
             {
+                this.authenticator = new V4Authenticator(accessKey, secretKey);
                 this.client.Authenticator = new V4Authenticator(accessKey, secretKey);
             }
         }
@@ -331,6 +333,18 @@ namespace Minio
             }
 
             throw ParseError(response);
+        }
+
+        /// <summary>
+        /// Presign Get request.
+        /// </summary>
+        /// <param name="bucket">Bucket to retrieve object from</param>
+        /// <param name="key">Key of object to retrieve</param>
+        /// <param name="expiresInt">Expiration time in seconds</param>
+        public string PresignGetObject(string bucket, string key, int expiresInt)
+        {
+            RestRequest request = new RestRequest(bucket + "/" + UrlEncode(key), Method.GET);
+            return this.authenticator.PresignURL(this.client, request, expiresInt);
         }
 
         /// <summary>


### PR DESCRIPTION
@harshavardhana I have hard coded "host" header instead of doing getsignedheaders() to keep the code simple as we won't be signing anything other than host header for presign API. We are also not exposing presign api to app developers to specify the headers to sign so it should be fine I think.