### PR TITLE
Nuspec for .NetCore and .NET4.5.2 as separate packages

### DIFF
--- a/Minio.Core/Minio.Core.csproj
+++ b/Minio.Core/Minio.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netstandard1.6</TargetFramework>
     <AssemblyName>Minio</AssemblyName>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <RootNamespace>Minio</RootNamespace>
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\..\..\lib\</OutputPath>
+    <OutputPath>..\..\core\lib\</OutputPath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Minio.Net452/Minio.Net452.csproj
+++ b/Minio.Net452/Minio.Net452.csproj
@@ -24,7 +24,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>..\..\..\lib\net452\</OutputPath>
+    <OutputPath>..\..\lib\net452\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -36,7 +36,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>False</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/Minio.core.nuspec
+++ b/Minio.core.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package >
   <metadata>
-    <id>Minio</id>
+    <id>Minio.NetCore</id>
     <version>1.0.0</version>
     <authors>Minio, Inc.</authors>
     <owners>Minio, Inc</owners>
@@ -14,22 +14,18 @@
     <copyright>Copyright 2017</copyright>
     <tags>minio cloud storage</tags>
     <dependencies>
-     <group targetFramework="net452">
-        <dependency id="RestSharp" version="105.2.3" />
+      <group targetFramework=".NETStandard1.6">
+        <dependency id="RestSharp.NetCore" version="105.2.3" />
         <dependency id="Newtonsoft.Json" version="10.0.2" />
-        <dependency id="System.Reactive" version="3.1.1" />
-        <dependency id="System.Reactive.Core" version="3.1.1" />
-        <dependency id="System.Reactive.Interfaces" version="3.1.1" />
         <dependency id="System.Reactive.Linq" version="3.1.1" />
-        <dependency id="System.Reactive.PlatformServices" version="3.1.1" />
-        <dependency id="System.Reactive.Windows.Threading" version="3.1.1" />
-        <dependency id="System.Xml.Linq" version="3.5.21022.801" />
+        <dependency id="System.Runtime.Serialization.Xml" version="4.3.0" />
+        <dependency id="Microsoft.Win32.Registry" version="4.3.0" />
+        <dependency id="Microsoft.Build.Utilities.Core" version="15.1.548" />
       </group>
-   
     </dependencies>
     
   </metadata>
   <files>
-      <file src="..\lib\**" target="lib" />
+      <file src="..\core\lib\**" target="lib" />
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -3,17 +3,19 @@
 Minio Client SDK provides higher level APIs for Minio and Amazon S3 compatible cloud storage services.For a complete list of APIs and examples, please take a look at the [Dotnet Client API Reference](https://docs.minio.io/docs/dotnet-client-api-reference).This document assumes that you have a working VisualStudio development environment.  
 
 ## Minimum Requirements
- * .NET 4.5.2, .NetCoreApp 1.0.0  or higher
+ * .NET 4.5.2, .NetStandard1.6 or higher
  * Visual Studio 2017 RC 
   
 ## Install from NuGet
 
-To install Minio .NET package, run the following command in Nuget Package Manager Console.
+To install Minio .NET package for .NET Framework, run the following command in Nuget Package Manager Console.
 ```powershell
-
-PM> Install-Package Minio
+PM> Install-Package Minio 
 ```
-
+To install Minio .NET package for .NetCore, run the following command in Nuget Package Manager Console.
+```powershell
+PM> Install-Package Minio.NetCore
+```
 ## Minio Client Example
 To connect to an Amazon S3 compatible cloud storage service, you will need to specify the following parameters.
 
@@ -83,7 +85,7 @@ namespace FileUploader
             var bucketName = "mymusic";
             var location   = "us-east-1";
             var objectName = "golden-oldies.zip";
-            var filePath = "/tmp/golden-oldies.zip";
+            var filePath = "C:\\Users\\username\\Downloads\\golden_oldies.mp3";
             var contentType = "application/zip";
 
             try


### PR DESCRIPTION
Separate Nuget packages for the Minio SDK - one for .Netcore, the other for .NET4.5.2.  This is required because of inconsistencies in Nuget tool causing package errors when the SDK is imported into .Netcore project. 