### PR TITLE
Disable SHA-256 computation for https

### DIFF
--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -248,6 +248,7 @@ namespace Minio
             restClient.UserAgent = this.FullUserAgent;
 
             authenticator = new V4Authenticator(this.AccessKey, this.SecretKey);
+            authenticator.SetScheme(scheme);
             restClient.Authenticator = authenticator;
         }
 


### PR DESCRIPTION
Currently minio-dotnet sdk computes sha256 for https requests. This change fixes #101. 