### PR TITLE
Support metadata for PutObject and StatObject calls

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -765,7 +765,7 @@ catch (MinioException e)
 <a name="putObject"></a>
 ### PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType)
 
-` Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType, CancellationToken cancellationToken = default(CancellationToken))`
+` Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType,Dictionary<string,string> metaData=null, CancellationToken cancellationToken = default(CancellationToken))`
 
 
 Uploads contents from a stream to objectName.
@@ -781,6 +781,8 @@ __Parameters__
 | ``data``  | _Stream_  | Stream to upload |
 | ``size``  | _long_    | size of stream   |
 | ``contentType``  | _string_ | Content type of the file. Defaults to "application/octet-stream" |
+| ``metaData``  | _Dictionary<string,string>_ | Dictionary of metadata headers. Defaults to null. |
+
 | ``cancellationToken``| _System.Threading.CancellationToken_ | Optional parameter. Defaults to default(CancellationToken) |
 
 
@@ -822,7 +824,7 @@ catch(MinioException e)
 <a name="putObject"></a>
 ### PutObjectAsync(string bucketName, string objectName, string filePath, string contentType=null)
 
-` Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType=null, CancellationToken cancellationToken = default(CancellationToken))`
+` Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType=null,Dictionary<string,string> metaData=null, CancellationToken cancellationToken = default(CancellationToken))`
 
 
 Uploads contents from a file to objectName.
@@ -837,6 +839,8 @@ __Parameters__
 | ``objectName``  | _string_  | Object name in the bucket |
 | ``fileName``  | _string_  | File to upload |
 | ``contentType``  | _string_ | Content type of the file. Defaults to " |
+| ``metadata``  | _Dictionary<string,string>_ | Dictionary of meta data headers and their values.Defaults to null.|
+
 | ``cancellationToken``| _System.Threading.CancellationToken_ | Optional parameter. Defaults to default(CancellationToken) |
 
 

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -379,7 +379,9 @@ namespace Minio.Functional.Tests
             ObjectStat statObject = await PutObject_Tester(minio, bucketName, objectName, fileName, contentType:contentType, metaData:metaData);
             Assert.IsTrue(statObject != null);
             Assert.IsTrue(statObject.metaData != null);
-            Assert.IsTrue(statObject.metaData.ContainsKey("x-amz-meta-customheader"));
+            Dictionary<string, string> statMeta = new Dictionary<string, string>(statObject.metaData,StringComparer.OrdinalIgnoreCase);
+
+            Assert.IsTrue(statMeta.ContainsKey("x-amz-meta-customheader"));
             Assert.IsTrue(statObject.metaData.ContainsKey("Content-Type") && statObject.metaData["Content-Type"].Equals("custom/contenttype"));
             await TearDown(minio, bucketName);
             File.Delete(fileName);
@@ -412,7 +414,7 @@ namespace Minio.Functional.Tests
                                            filestream,
                                            size,
                                            contentType,
-                                           metaData);
+                                           metaData: metaData);
                 await minio.GetObjectAsync(bucketName, objectName,
                (stream) =>
                {
@@ -1073,7 +1075,7 @@ namespace Minio.Functional.Tests
                                            objectName,
                                            filestream,
                                            filestream.Length,
-                                           contentType,null, cts.Token);
+                                           contentType, cts.Token);
 
             }
             catch (OperationCanceledException)

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -53,9 +53,10 @@ namespace Minio
         /// <param name="data">Stream of file to upload</param>
         /// <param name="size">Size of stream</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
+        /// <param name="metaData">Dictionary of metadata headers. Optional, defaults to null</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
 
-        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metadata=null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Removes an object with given name in specific bucket
@@ -114,9 +115,10 @@ namespace Minio
         /// <param name="objectName">Key of the new object</param>
         /// <param name="fileName">Path of file to upload</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
+        /// <param name="metadata">Dictionary of metadata header k-v pairs.Defaults to null</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
 
-        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, Dictionary<string, string> metadata = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -53,10 +53,9 @@ namespace Minio
         /// <param name="data">Stream of file to upload</param>
         /// <param name="size">Size of stream</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
-        /// <param name="metaData">Dictionary of metadata headers. Optional, defaults to null</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-
-        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metadata=null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <param name="metaData">Optional Object metadata to be stored. Defaults to null.</param>
+        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metadata = null);
 
         /// <summary>
         /// Removes an object with given name in specific bucket
@@ -115,10 +114,9 @@ namespace Minio
         /// <param name="objectName">Key of the new object</param>
         /// <param name="fileName">Path of file to upload</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
-        /// <param name="metadata">Dictionary of metadata header k-v pairs.Defaults to null</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-
-        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, Dictionary<string, string> metadata = null, CancellationToken cancellationToken = default(CancellationToken));
+        /// <param name="metaData">Optional Object metadata to be stored. Defaults to null.</param>
+        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metadata = null);
 
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -166,15 +166,15 @@ namespace Minio
         /// <param name="fileName">Path of file to upload</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-
-        public async Task PutObjectAsync(string bucketName, string objectName, string fileName, string contentType = null, Dictionary<string, string> metaData=null, CancellationToken cancellationToken = default(CancellationToken))
+        /// <param name="metaData">Object metadata to be stored. Defaults to null.</param>
+        public async Task PutObjectAsync(string bucketName, string objectName, string fileName, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metaData = null)
         {
             utils.ValidateFile(fileName, contentType);
             FileInfo fileInfo = new FileInfo(fileName);
             long size = fileInfo.Length;
             using (FileStream file = new FileStream(fileName, FileMode.Open, FileAccess.Read))
             {
-                await PutObjectAsync(bucketName, objectName, file, size, contentType, metaData, cancellationToken);
+                await PutObjectAsync(bucketName, objectName, file, size, contentType, cancellationToken, metaData);
             }
 
         }
@@ -188,8 +188,8 @@ namespace Minio
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="data">Stream of bytes to send</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-
-        public async Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metaData = null,  CancellationToken cancellationToken = default(CancellationToken))
+        /// <param name="metaData">Object metadata to be stored. Defaults to null.</param>
+        public async Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metaData = null)
         {
             utils.validateBucketName(bucketName);
             utils.validateObjectName(objectName);

--- a/Minio/DataModel/ObjectStat.cs
+++ b/Minio/DataModel/ObjectStat.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 
 namespace Minio.DataModel
 {
@@ -28,20 +29,21 @@ namespace Minio.DataModel
         /// <param name="lastModified">Last when object was modified</param>
         /// <param name="etag">Unique entity tag for the object</param>
         /// <param name="contentType">Object content type</param>
-        public ObjectStat(string objectName, long size, DateTime lastModified, string etag, string contentType)
+        public ObjectStat(string objectName, long size, DateTime lastModified, string etag, string contentType, Dictionary<string, string> metadata)
         {
             this.ObjectName = objectName;
             this.Size = size;
             this.LastModified = lastModified;
             this.ETag = etag;
             this.ContentType = contentType;
+            this.metaData = metadata;
         }
         public string ObjectName { get; private set; }
         public long Size { get; private set; }
         public DateTime LastModified { get; private set;  }
         public string ETag { get; private set; }
         public string ContentType { get; private set; }
-
+        public Dictionary<string, string> metaData { get; private set; }
         public override string ToString()
         {
             return string.Format("{0} : Size({1}) LastModified({2}) ETag({3}) Content-Type({4})",this.ObjectName, this.Size, this.LastModified, this.ETag, this.ContentType);

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -111,7 +111,7 @@ namespace Minio
         /// <returns>A RestRequest</returns>
         internal async Task<RestRequest> CreateRequest(Method method, string bucketName, string objectName = null,
                                 Dictionary<string, string> headerMap = null,
-                                string contentType = "application/xml",
+                                string contentType = "application/octet-stream",
                                 Object body = null, string resourcePath = null, string region = null)
         {
             // Validate bucket name and object name
@@ -206,14 +206,14 @@ namespace Minio
 
             }
 
-            if (contentType != null)
-            {
-                request.AddHeader("Content-Type", contentType);
-            }
+            //if ((contentType != null) && (headerMap == null || !headerMap.ContainsKey("Content-Type")))
+            //{
+            //    request.AddHeader("Content-Type", contentType);
+            //}
 
             if (headerMap != null)
             {
-                foreach (KeyValuePair<string, string> entry in headerMap)
+                foreach (var entry in headerMap)
                 {
                     request.AddHeader(entry.Key, entry.Value);
                 }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -206,11 +206,6 @@ namespace Minio
 
             }
 
-            //if ((contentType != null) && (headerMap == null || !headerMap.ContainsKey("Content-Type")))
-            //{
-            //    request.AddHeader("Content-Type", contentType);
-            //}
-
             if (headerMap != null)
             {
                 foreach (var entry in headerMap)


### PR DESCRIPTION
Allows custom metadata to be set and retrieved via Put and Stat calls. This is w.r.t #142 