### PR TITLE
Fix nested paths

### DIFF
--- a/Minio/Helper/utils.cs
+++ b/Minio/Helper/utils.cs
@@ -22,6 +22,7 @@ using Microsoft.Win32;
 using Minio.Helper;
 using System.Dynamic;
 using System.Linq;
+using System.Text;
 
 namespace Minio
 {
@@ -99,10 +100,49 @@ namespace Minio
 
         internal static string UrlEncode(string input)
         {
-            return Uri.EscapeDataString(input).Replace("%2F", "/");
+            return Uri.EscapeDataString(input).Replace("\\!", "%21")
+                                              .Replace("\\$", "%24")
+                                              .Replace("\\&", "%26")
+                                              .Replace("\\'", "%27")
+                                              .Replace("\\(", "%28")
+                                              .Replace("\\)", "%29")
+                                              .Replace("\\*", "%2A")
+                                              .Replace("\\+", "%2B")
+                                              .Replace("\\,", "%2C")
+                                              .Replace("\\/", "%2F")
+                                              .Replace("\\:", "%3A")
+                                              .Replace("\\;", "%3B")
+                                              .Replace("\\=", "%3D")
+                                              .Replace("\\@", "%40")
+                                              .Replace("\\[", "%5B")
+                                              .Replace("\\]", "%5D"); 
         }
 
+        internal static string EncodePath(string path)
+        {
+            StringBuilder encodedPathBuf = new StringBuilder();
+            foreach (string pathSegment in path.Split('/'))
+            {
+                if (pathSegment.Length != 0)
+                {
+                    if (encodedPathBuf.Length > 0)
+                    {
+                        encodedPathBuf.Append("/");
+                    }
+                    encodedPathBuf.Append(utils.UrlEncode(pathSegment));
+                }
+            }
 
+            if (path.StartsWith("/"))
+            {
+                encodedPathBuf.Insert(0, "/");
+            }
+            if (path.EndsWith("/"))
+            {
+                encodedPathBuf.Append("/");
+            }
+            return encodedPathBuf.ToString();
+        }
         internal static bool isAnonymousClient(string accessKey, string secretKey)
         {
             return (secretKey == "" || accessKey == "");

--- a/Minio/Helper/utils.cs
+++ b/Minio/Helper/utils.cs
@@ -97,7 +97,7 @@ namespace Minio
             }
             return;
         }
-
+        // Return url encoded string where reserved characters have been percent-encoded
         internal static string UrlEncode(string input)
         {
             return Uri.EscapeDataString(input).Replace("\\!", "%21")
@@ -117,7 +117,7 @@ namespace Minio
                                               .Replace("\\[", "%5B")
                                               .Replace("\\]", "%5D"); 
         }
-
+        // Return encoded path where extra "/" are trimmed off.
         internal static string EncodePath(string path)
         {
             StringBuilder encodedPathBuf = new StringBuilder();
@@ -143,10 +143,12 @@ namespace Minio
             }
             return encodedPathBuf.ToString();
         }
+
         internal static bool isAnonymousClient(string accessKey, string secretKey)
         {
             return (secretKey == "" || accessKey == "");
         }
+
         internal static void ValidateFile(string filePath, string contentType = null)
         {
             if (filePath == null || filePath == "")

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 using Minio.Helper;
 using Newtonsoft.Json;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace Minio
 {
@@ -145,7 +146,7 @@ namespace Minio
 
             // This section reconstructs the url with scheme followed by location specific endpoint( s3.region.amazonaws.com)
             // or Virtual Host styled endpoint (bucketname.s3.region.amazonaws.com) for Amazon requests.
-            string resource = "";              //Resource being requested  
+            string resource = "";
             bool usePathStyle = false;
             if (s3utils.IsAmazonEndPoint(this.BaseUrl))
             {
@@ -169,13 +170,13 @@ namespace Minio
 
                 if (usePathStyle)
                 {
-                    resource = utils.UrlEncode(bucketName) + "/";
+                    resource += utils.UrlEncode(bucketName) + "/";
                 }
 
             }
             else
             {
-                resource = utils.UrlEncode(bucketName) + "/";
+                resource += utils.UrlEncode(bucketName) + "/";
             }
 
             // Set Target URL
@@ -185,11 +186,7 @@ namespace Minio
             if (objectName != null)
             {
                 // Limitation: OkHttp does not allow to add '.' and '..' as path segment.
-                foreach (String pathSegment in objectName.Split('/'))
-                {
-                    resource += utils.UrlEncode(pathSegment);
-                }
-
+                resource += utils.EncodePath(objectName);
             }
 
             // Append query string passed in 

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -185,7 +185,6 @@ namespace Minio
 
             if (objectName != null)
             {
-                // Limitation: OkHttp does not allow to add '.' and '..' as path segment.
                 resource += utils.EncodePath(objectName);
             }
 


### PR DESCRIPTION
minio-dotnet erroneously constructs nested paths without / delimiter. Put object to nested path should succeed seamlessly. This PR fixes #144