### PR TITLE
Fix multipart upload failure on linux for .net sdk

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -66,8 +66,8 @@ namespace Minio.Functional.Tests
             String endPoint = null;
             String accessKey = null;
             String secretKey = null;
-            bool useAWS = true;
-            if (useAWS && Environment.GetEnvironmentVariable("AWS_ENDPOINT") != null)
+            bool useAWS = Environment.GetEnvironmentVariable("AWS_ENDPOINT") != null;
+            if (useAWS)
             {
                 endPoint = Environment.GetEnvironmentVariable("AWS_ENDPOINT");
                 accessKey = Environment.GetEnvironmentVariable("MY_AWS_ACCESS_KEY");
@@ -108,8 +108,12 @@ namespace Minio.Functional.Tests
                 // Create a new bucket
                 MakeBucket_Test1(minioClient).Wait();
                 MakeBucket_Test2(minioClient).Wait();
-                MakeBucket_Test3(minioClient).Wait();
-                MakeBucket_Test4(minioClient).Wait();
+                if (useAWS)
+                {
+                    MakeBucket_Test3(minioClient).Wait();
+                    MakeBucket_Test4(minioClient).Wait();
+                }
+               
 
                 // Test removal of bucket
                 RemoveBucket_Test1(minioClient).Wait();

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp1.1</TargetFramework>
     <RuntimeIdentifiers>
       ubuntu.16.04-x64;linuxmint.17.3-x64;win10-x64
     </RuntimeIdentifiers>
@@ -11,8 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Minio.NetCore" Version="1.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Minio.Core\Minio.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio.sln
+++ b/Minio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C8111804-63DA-4E74-9C1F-FEC46632A33B}"
 	ProjectSection(SolutionItems) = preProject
@@ -135,7 +135,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.Client.Examples.Net45
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minio.Client.Examples.Core", "Minio.Examples\Minio.Client.Examples.Core\Minio.Client.Examples.Core.csproj", "{54F8F8A7-B4DA-49AE-831F-5C867E58C936}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.Functional.Tests", "Minio.Functional.Tests\Minio.Functional.Tests.csproj", "{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minio.Functional.Tests", "Minio.Functional.Tests\Minio.Functional.Tests.csproj", "{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Notification", "Notification", "{EEA2902C-62E0-4A9A-BAEE-0E56343A0D5B}"
 	ProjectSection(SolutionItems) = preProject
@@ -373,34 +373,34 @@ Global
 		{54F8F8A7-B4DA-49AE-831F-5C867E58C936}.testexclude|x86.ActiveCfg = Release|x86
 		{54F8F8A7-B4DA-49AE-831F-5C867E58C936}.testexclude|x86.Build.0 = Release|x86
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|Any CPU.ActiveCfg = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|Any CPU.Build.0 = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.ActiveCfg = Debug|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.Build.0 = Debug|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.ActiveCfg = Debug|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.Build.0 = Debug|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.Build.0 = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|Any CPU.ActiveCfg = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|Any CPU.Build.0 = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -469,7 +469,7 @@ namespace Minio
             string etag = null;
             foreach (Parameter parameter in response.Headers)
             {
-                if (parameter.Name == "ETag")
+                if (parameter.Name.Equals("ETag",StringComparison.OrdinalIgnoreCase))
                 {
                     etag = parameter.Value.ToString();
                 }


### PR DESCRIPTION
Fixes #148 .

There is a discrepancy in casing of strings for RestResponse headers between Linux and Windows environment. 
The response headers come back as "ETag" in Windows vs "Etag" in Linux. Earlier the codebase used == string comparison operator and this resulted in etag of uploaded parts not being captured. This error cascaded down to CompleteMultipartUpload failing because of missing etag.

Changed code to make a case insensitive comparison of  ETag.

Also made region specific MakeBucket tests run only for AWS.