### PR TITLE
Change order of cancellation token and metadata in sync with Api doc

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -101,6 +101,7 @@ namespace Minio.Functional.Tests
 
                 // Set HTTP Tracing Off
                 // minioClient.SetTraceOff();
+                PutObject_Test5(minioClient).Wait();
 
                 // Check if bucket exists
                 BucketExists_Test(minioClient).Wait();
@@ -414,7 +415,7 @@ namespace Minio.Functional.Tests
                                            filestream,
                                            size,
                                            contentType,
-                                           metaData: metaData);
+                                           metaData:metaData);
                 await minio.GetObjectAsync(bucketName, objectName,
                (stream) =>
                {
@@ -1070,12 +1071,13 @@ namespace Minio.Functional.Tests
                 byte[] bs = File.ReadAllBytes(fileName);
                 System.IO.MemoryStream filestream = new System.IO.MemoryStream(bs);
                 long file_write_size = filestream.Length;
-
+               
+                
                 await minio.PutObjectAsync(bucketName,
                                            objectName,
                                            filestream,
                                            filestream.Length,
-                                           contentType, cts.Token);
+                                           contentType, cancellationToken:cts.Token);
 
             }
             catch (OperationCanceledException)

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -11,8 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Minio.NetCore" Version="1.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.1.11" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Minio.Core\Minio.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio.sln
+++ b/Minio.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26206.0
+VisualStudioVersion = 15.0.26430.15
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{C8111804-63DA-4E74-9C1F-FEC46632A33B}"
 	ProjectSection(SolutionItems) = preProject
@@ -135,7 +135,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.Client.Examples.Net45
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minio.Client.Examples.Core", "Minio.Examples\Minio.Client.Examples.Core\Minio.Client.Examples.Core.csproj", "{54F8F8A7-B4DA-49AE-831F-5C867E58C936}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.Functional.Tests", "Minio.Functional.Tests\Minio.Functional.Tests.csproj", "{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Minio.Functional.Tests", "Minio.Functional.Tests\Minio.Functional.Tests.csproj", "{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Notification", "Notification", "{EEA2902C-62E0-4A9A-BAEE-0E56343A0D5B}"
 	ProjectSection(SolutionItems) = preProject
@@ -373,34 +373,34 @@ Global
 		{54F8F8A7-B4DA-49AE-831F-5C867E58C936}.testexclude|x86.ActiveCfg = Release|x86
 		{54F8F8A7-B4DA-49AE-831F-5C867E58C936}.testexclude|x86.Build.0 = Release|x86
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|Any CPU.ActiveCfg = Debug|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..net4.5.2|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|Any CPU.ActiveCfg = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|Any CPU.Build.0 = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}..netcore|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.ActiveCfg = Debug|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.Build.0 = Debug|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.ActiveCfg = Debug|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.Build.0 = Debug|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x64.Build.0 = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Debug|x86.Build.0 = Debug|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.Release|x86.Build.0 = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|Any CPU.ActiveCfg = Release|Any CPU
 		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|Any CPU.Build.0 = Release|Any CPU
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.ActiveCfg = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.Build.0 = Release|x64
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.ActiveCfg = Release|x86
-		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.Build.0 = Release|x86
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x64.Build.0 = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.ActiveCfg = Release|Any CPU
+		{9A754E7C-2D22-4AD7-BF1A-CA731920C8D4}.testexclude|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -55,7 +55,7 @@ namespace Minio
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <param name="metaData">Optional Object metadata to be stored. Defaults to null.</param>
-        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metadata = null);
+        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metaData = null,CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Removes an object with given name in specific bucket
@@ -116,7 +116,7 @@ namespace Minio
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <param name="metaData">Optional Object metadata to be stored. Defaults to null.</param>
-        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metadata = null);
+        Task PutObjectAsync(string bucketName, string objectName, string filePath, string contentType = null, Dictionary<string, string> metaData = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -167,14 +167,14 @@ namespace Minio
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <param name="metaData">Object metadata to be stored. Defaults to null.</param>
-        public async Task PutObjectAsync(string bucketName, string objectName, string fileName, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metaData = null)
+        public async Task PutObjectAsync(string bucketName, string objectName, string fileName, string contentType = null, Dictionary<string, string> metaData = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             utils.ValidateFile(fileName, contentType);
             FileInfo fileInfo = new FileInfo(fileName);
             long size = fileInfo.Length;
             using (FileStream file = new FileStream(fileName, FileMode.Open, FileAccess.Read))
             {
-                await PutObjectAsync(bucketName, objectName, file, size, contentType, cancellationToken, metaData);
+                await PutObjectAsync(bucketName, objectName, file, size, contentType, metaData, cancellationToken);
             }
 
         }
@@ -189,7 +189,7 @@ namespace Minio
         /// <param name="data">Stream of bytes to send</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <param name="metaData">Object metadata to be stored. Defaults to null.</param>
-        public async Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, CancellationToken cancellationToken = default(CancellationToken), Dictionary<string, string> metaData = null)
+        public async Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metaData = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             utils.validateBucketName(bucketName);
             utils.validateObjectName(objectName);


### PR DESCRIPTION
Fixes #153. The API documentation correctly gives cancellation token as last argument to the PutObjectAsync call, whereas the implementation put metaData as the last argument. Change the order of arguments in the implementation to be consistent with documentation. There is no impact to users because this feature has not been published to Nuget yet.