### PR TITLE
Fix: use default region if bucket not in cache

### DIFF
--- a/Minio.Examples/Minio.Client.Examples.Core/Minio.Client.Examples.Core.csproj
+++ b/Minio.Examples/Minio.Client.Examples.Core/Minio.Client.Examples.Core.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Net.Http.WinHttpHandler" Version="4.3.0" />
     <PackageReference Include="System.Reactive.Core" Version="3.1.1" />
     <PackageReference Include="System.Reactive.Interfaces" Version="3.1.1" />

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1000,7 +1000,7 @@ namespace Minio
             {
                 region = await BucketRegionCache.Instance.Update(this, policy.Bucket);
             }
-            else
+            if (region == null) 
             {
                 region = BucketRegionCache.Instance.Region(policy.Bucket);
             }


### PR DESCRIPTION
Fixes #164 

Region was not being initialized correctly for presigned post policy operation.
