### PR TITLE
Api: fix validations for presign operations.

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1046,7 +1046,7 @@ catch(MinioException e)
 ## 4. Presigned operations
 <a name="presignedGetObject"></a>
 
-### PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt);
+### PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt, Dictionary<string,string> reqParams = null);
 `Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt)`
 
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
@@ -1059,12 +1059,13 @@ __Parameters__
 | ``bucketName``  | _String_ | Name of the bucket  |
 | ``objectName``  | _String_  | Object name in the bucket |
 | ``expiresInt``  | _Integer_  | Expiry in seconds. Default expiry is set to 7 days. |
-
+| ``reqParams``   | _Dictionary<string,string>_ | Additional response header overrides supports response-expires, response-content-type, response-cache-control, response-content-disposition.|
 | Return Type	  | Exceptions	  |
 |:--- |:--- |
 |  ``Task<string>`` : string contains URL to download the object | Listed Exceptions: |
 |        |  ``InvalidBucketNameException`` : upon invalid bucket name |
 |        | ``ConnectionException`` : upon connection error            |
+|        | ``InvalidExpiryRangeException`` : upon invalid expiry range.            |
 
 
 __Example__
@@ -1104,6 +1105,7 @@ __Parameters__
 |        |  ``InvalidBucketNameException`` : upon invalid bucket name |
 |        | ``InvalidKeyException`` : upon an invalid access key or secret key           |
 |        | ``ConnectionException`` : upon connection error            |
+|        | ``InvalidExpiryRangeException`` : upon invalid expiry range.            |
 
 
 __Example__

--- a/Minio.Core/Minio.Core.csproj
+++ b/Minio.Core/Minio.Core.csproj
@@ -104,6 +104,8 @@
     <Compile Include="..\Minio\Exceptions\ObjectNotFoundException.cs" Link="Exceptions\ObjectNotFoundException.cs" />
     <Compile Include="..\Minio\Exceptions\RedirectionException.cs" Link="Exceptions\RedirectionException.cs" />
     <Compile Include="..\Minio\Exceptions\UnexpectedShortReadException.cs" Link="Exceptions\UnexpectedShortReadException.cs" />
+    <Compile Include="..\Minio\Exceptions\InvalidExpiryRangeException.cs" Link="Exceptions\InvalidExpiryRangeException.cs" />
+    
     <Compile Include="..\Minio\Helper\Constants.cs" Link="Helper\Constants.cs" />
     <Compile Include="..\Minio\Helper\Enum.cs" Link="Helper\Enum.cs" />
     <Compile Include="..\Minio\Helper\RequestUtil.cs" Link="Helper\RequestUtil.cs" />

--- a/Minio.Examples/Cases/PresignedGetObject.cs
+++ b/Minio.Examples/Cases/PresignedGetObject.cs
@@ -16,6 +16,7 @@
 
 using System;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 
 namespace Minio.Examples.Cases
@@ -28,7 +29,8 @@ namespace Minio.Examples.Cases
         {
             try
             {
-                string presigned_url = await client.PresignedGetObjectAsync(bucketName, objectName, 1000);
+                Dictionary<string,string> reqParams = new Dictionary<string, string>(){{"response-content-type", "application/json"}};
+                string presigned_url = await client.PresignedGetObjectAsync(bucketName, objectName, 1000, reqParams);
                 Console.Out.WriteLine(presigned_url);
             } 
             catch (Exception e)

--- a/Minio.Net452/Minio.Net452.csproj
+++ b/Minio.Net452/Minio.Net452.csproj
@@ -302,6 +302,9 @@
     <Compile Include="..\Minio\Exceptions\UnexpectedShortReadException.cs">
       <Link>Exceptions\UnexpectedShortReadException.cs</Link>
     </Compile>
+     <Compile Include="..\Minio\Exceptions\InvalidExpiryRangeException.cs">
+      <Link>Exceptions\InvalidExpiryRangeException.cs</Link>
+    </Compile>
     <Compile Include="..\Minio\Helper\Constants.cs">
       <Link>Helper\Constants.cs</Link>
     </Compile>

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -129,15 +129,18 @@ namespace Minio
         Task GetObjectAsync(string bucketName, string objectName, string filePath, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
-        /// Presigned Get url.
+        /// Presigned get url - returns a presigned url to access an object's data without credentials.URL can have a maximum expiry of 
+        /// upto 7 days or a minimum of 1 second.Additionally, you can override a set of response headers using reqParams.
         /// </summary>
         /// <param name="bucketName">Bucket to retrieve object from</param>
         /// <param name="objectName">Key of object to retrieve</param>
-        /// <param name="expiresInt">Expiration time in seconds</param>
-        Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt);
+        /// <param name="expiresInt">Expiration time in seconds.</param>
+        /// <param name="reqParams">optional override response headers</param>
+        Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt, Dictionary<string,string> reqParams = null);
 
         /// <summary>
-        /// Presigned Put url.
+        /// Presigned Put url - returns a presigned url to upload an object without credentials.URL can have a maximum expiry of 
+        /// upto 7 days or a minimum of 1 second.
         /// </summary>
         /// <param name="bucketName">Bucket to retrieve object from</param>
         /// <param name="objectName">Key of object to retrieve</param>

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -945,29 +945,42 @@ namespace Minio
 
 
         /// <summary>
-        /// Presigned Get url.
+        /// Presigned get url - returns a presigned url to access an object's data without credentials.URL can have a maximum expiry of 
+        /// upto 7 days or a minimum of 1 second.Additionally, you can override a set of response headers using reqParams.
         /// </summary>
         /// <param name="bucketName">Bucket to retrieve object from</param>
         /// <param name="objectName">Key of object to retrieve</param>
         /// <param name="expiresInt">Expiration time in seconds</param>
+        /// <param name="reqParams">optional override response headers</param>
         /// <returns></returns>
-        public async Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt)
+        public async Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt, Dictionary<string,string> reqParams = null)
         {
+            if (!utils.IsValidExpiry(expiresInt))
+            {
+                throw new InvalidExpiryRangeException("expiry range should be between 1 and " + Constants.DefaultExpiryTime.ToString());
+            }
             var request = await this.CreateRequest(Method.GET, bucketName,
-                                                    objectName: objectName);
+                                                    objectName: objectName,
+                                                    headerMap: reqParams);
 
             return this.authenticator.PresignURL(this.restClient, request, expiresInt);
         }
 
         /// <summary>
-        /// Presigned Put url.
+        /// Presigned Put url -returns a presigned url to upload an object without credentials.URL can have a maximum expiry of 
+        /// upto 7 days or a minimum of 1 second.
         /// </summary>
         /// <param name="bucketName">Bucket to retrieve object from</param>
         /// <param name="objectName">Key of object to retrieve</param>
         /// <param name="expiresInt">Expiration time in seconds</param>
+
         /// <returns></returns>
         public async Task<string> PresignedPutObjectAsync(string bucketName, string objectName, int expiresInt)
         {
+            if (!utils.IsValidExpiry(expiresInt))
+            {
+                throw new InvalidExpiryRangeException("expiry range should be between 1 and " + Constants.DefaultExpiryTime.ToString());
+            }
             var request = await this.CreateRequest(Method.PUT, bucketName,
                                                     objectName: objectName);
             return this.authenticator.PresignURL(this.restClient, request, expiresInt);

--- a/Minio/Exceptions/InvalidExpiryRangeException.cs
+++ b/Minio/Exceptions/InvalidExpiryRangeException.cs
@@ -1,0 +1,30 @@
+/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Minio.Exceptions
+{
+    public class InvalidExpiryRangeException : MinioException
+    {
+        public InvalidExpiryRangeException(string message) : base(message)
+        {
+        }
+
+        public override string ToString()
+        {
+            return base.ToString();
+        }
+    }
+}

--- a/Minio/Helper/Constants.cs
+++ b/Minio/Helper/Constants.cs
@@ -40,6 +40,6 @@ namespace Minio.Helper
         // through Read operation.
         public static long OptimalReadBufferSize = 1024L * 1024L * 5;
 
-
+        public static int DefaultExpiryTime = 7 * 24 * 3600;
     }
 }

--- a/Minio/Helper/utils.cs
+++ b/Minio/Helper/utils.cs
@@ -248,5 +248,16 @@ namespace Minio
             obj.lastPartSize = lastPartSize;
             return obj;
         }
+
+        /// <summary>
+        /// Check if input expires value is valid.
+        /// </summary>
+        /// <param name="expiryInt">time to expiry in seconds</param>
+        /// <returns>bool</returns>
+
+        public static bool IsValidExpiry(int expiryInt)
+        {
+            return (expiryInt > 0) && (expiryInt <= Constants.DefaultExpiryTime); 
+        }
     }
 }


### PR DESCRIPTION
Fixes #170  and the missing presigned Get/Put functional tests for Mint in #156 


Add validation of expiry for presign get and put.Add optional override response
headers as argument for PresignedGetObjectAsync method.
 