### PR TITLE
Added a new method SetUserMetadata to the PostPolicy

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1154,6 +1154,7 @@ try
 {
     PostPolicy policy = new PostPolicy();
     policy.SetContentType("image/png");
+    policy.SetUserSpecifiedMetadata("custom", "user");
     DateTime expiration = DateTime.UtcNow;
     policy.SetExpires(expiration.AddDays(10));
     policy.SetKey("my-objectname");

--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1154,7 +1154,7 @@ try
 {
     PostPolicy policy = new PostPolicy();
     policy.SetContentType("image/png");
-    policy.SetUserSpecifiedMetadata("custom", "user");
+    policy.SetUserMetadata("custom", "user");
     DateTime expiration = DateTime.UtcNow;
     policy.SetExpires(expiration.AddDays(10));
     policy.SetKey("my-objectname");

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1670,6 +1670,8 @@ namespace Minio.Functional.Tests
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(15);
             string objectName = GetRandomName(10);
+            string metadataKey = GetRandomName(10);
+            string metadataValue = GetRandomName(10);
             string fileName = CreateFile(1 * MB, dataFile1MB);
 
             try
@@ -1685,6 +1687,7 @@ namespace Minio.Functional.Tests
                 form.SetExpires(expiration.AddDays(10));
                 form.SetKey(objectName);
                 form.SetBucket(bucketName);
+                form.SetUserSpecifiedMetadata(metadataKey, metadataValue);
                 var pairs = new List<KeyValuePair<string, string>>();
                 string url = "https://s3.amazonaws.com/" + bucketName;
                 Tuple<string, System.Collections.Generic.Dictionary<string, string>> policyTuple = await minio.PresignedPostPolicyAsync(form);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1687,7 +1687,7 @@ namespace Minio.Functional.Tests
                 form.SetExpires(expiration.AddDays(10));
                 form.SetKey(objectName);
                 form.SetBucket(bucketName);
-                form.SetUserSpecifiedMetadata(metadataKey, metadataValue);
+                form.SetUserMetadata(metadataKey, metadataValue);
                 var pairs = new List<KeyValuePair<string, string>>();
                 string url = "https://s3.amazonaws.com/" + bucketName;
                 Tuple<string, System.Collections.Generic.Dictionary<string, string>> policyTuple = await minio.PresignedPostPolicyAsync(form);

--- a/Minio/DataModel/PostPolicy.cs
+++ b/Minio/DataModel/PostPolicy.cs
@@ -162,7 +162,7 @@ namespace Minio.DataModel
         /// </summary>
         /// <param name="status">Key and Value to insert in the metadata</param>
 
-        public void SetUserSpecifiedMetadata(string key, string value)
+        public void SetUserMetadata(string key, string value)
         {
             if (string.IsNullOrEmpty(key))
                 throw new ArgumentException("Key is Empty");

--- a/Minio/DataModel/PostPolicy.cs
+++ b/Minio/DataModel/PostPolicy.cs
@@ -158,6 +158,22 @@ namespace Minio.DataModel
         }
 
         /// <summary>
+        /// Set user specified metadata as a key/value couple.
+        /// </summary>
+        /// <param name="status">Key and Value to insert in the metadata</param>
+
+        public void SetUserSpecifiedMetadata(string key, string value)
+        {
+            if (string.IsNullOrEmpty(key))
+                throw new ArgumentException("Key is Empty");
+            if (string.IsNullOrEmpty(value))
+                throw new ArgumentException("Value is Empty");
+            string headerName = "x-amz-meta-" + key;
+            this.policies.Add(new Tuple<string, string, string>("eq", "$" + headerName, value));
+            this.formData.Add(headerName, value);
+        }
+
+        /// <summary>
         /// Set signature algorithm policy.
         /// </summary>
         /// <param name="algorithm">Set signature algorithm used for the policy</param>


### PR DESCRIPTION
Hi there,

here is a PR for a new feature I need for a project I am working on with @hnb2.

# Feature

```SetUserSpecifiedMetadata(key string, value string)``` allows you to add user specified metadata following this guide which mention:

| key | explanation|
| ---  | ----------- |
| x-amz-meta-* | User-specified metadata.This condition supports exact matching and starts-with condition match type. |