### PR TITLE
fix: Add missing AWS region endpoints

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -38,7 +38,7 @@ var s3Client = new MinioClient("s3.amazonaws.com",
 |  |
 |---|
 |`public MinioClient(string endpoint, string accessKey = "", string secretKey = "")`   |
-| Creates Minio client object with given endpoint.AccessKey and secretKey are optional parameters,and can be omitted for anonymous access. 
+| Creates Minio client object with given endpoint.AccessKey,secretKey and region are optional parameters,and can be omitted for anonymous access. 
   The client object uses Http access by default. To use Https, chain method WithSSL() to client object to use secure transfer protocol   |
 
 
@@ -53,6 +53,7 @@ __Parameters__
 | | |play.minio.io|
 | `accessKey`   | _string_   |accessKey is like user-id that uniquely identifies your account.This field is optional and can be omitted for anonymous access. |
 |`secretKey`  |  _string_   | secretKey is the password to your account.This field is optional and can be omitted for anonymous access.|
+|`region`  |  _string_   | region to which calls should be made.This field is optional and can be omitted.|
 
 __Secure Access__
 

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -34,7 +34,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release.Core|AnyCPU'">
     <OutputPath>bin\Release.Core\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
@@ -90,6 +89,7 @@
     <Compile Include="TestHelper.cs" />
     <Compile Include="PolicyTests.cs" />
     <Compile Include="AuthenticatorTest.cs" />
+    <Compile Include="RegionTest.cs" />
     <Compile Include="UtilsTest.cs" />
     <Compile Include="UrlTests.cs" />
   </ItemGroup>

--- a/Minio.Tests/RegionTest.cs
+++ b/Minio.Tests/RegionTest.cs
@@ -1,0 +1,49 @@
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+using System;
+using System.Text;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Net;
+using System.Configuration;
+using Minio.Exceptions;
+using Minio;
+using Minio.Helper;
+namespace Minio.Tests
+{
+    [TestClass]
+    public class TestRegion
+    {
+        [TestMethod]
+        public void TestGetRegion()
+        {
+            Dictionary<string, string> endpoint2Region = new Dictionary<string, string>
+            {
+                {"s3.us-east-2.amazonaws.com", "us-east-2"},
+                {"s3.amazonaws.com",""},
+                {"testbucket.s3-ca-central-1.amazonaws.com","ca-central-1"},
+                {"mybucket-s3-us-east-2.amazonaws.com", "us-east-2"},
+                {"s3.us-west-1.amazonaws.com", "us-west-1"},
+                {"mybucket-s3-us-west-1.amazonaws.com", "us-west-1"},
+            };
+            foreach (KeyValuePair<string, string> testCase in endpoint2Region)
+            {
+                Assert.AreEqual(Regions.GetRegionFromEndpoint(testCase.Key), testCase.Value);
+            }
+        }
+    }
+   
+}

--- a/Minio.Tests/UrlTests.cs
+++ b/Minio.Tests/UrlTests.cs
@@ -148,8 +148,7 @@ namespace Minio.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(InvalidEndpointException))]
-        public void TestEndpointFailure()
+        public void TestEndpointSuccess2()
         {
             new MinioClient("s3-us-west-1.amazonaws.com");
         }

--- a/Minio/BucketRegionCache.cs
+++ b/Minio/BucketRegionCache.cs
@@ -91,7 +91,7 @@ namespace Minio
         {
             string region = null;
 
-            if (bucketName != null && s3utils.IsAmazonEndPoint(client.BaseUrl) && client.AccessKey != null
+            if (bucketName != null && client.AccessKey != null
             && client.SecretKey != null && !Instance.Exists(bucketName))
             {
                 string location = null;

--- a/Minio/Helper/RequestUtil.cs
+++ b/Minio/Helper/RequestUtil.cs
@@ -111,12 +111,6 @@ namespace Minio
             {
                 throw new InvalidEndpointException(Endpoint, "Invalid scheme detected in endpoint.");
             }
-            string amzHost = uri.Host;
-            if ((utils.CaseInsensitiveContains(amzHost,".amazonaws.com"))
-                 && !s3utils.IsAmazonEndPoint(uri.Host))
-            {
-                throw new InvalidEndpointException(amzHost, "For Amazon S3, host should be \'s3.amazonaws.com\' in endpoint.");
-            }
         }
        
         /// <summary>

--- a/Minio/Helper/s3utils.cs
+++ b/Minio/Helper/s3utils.cs
@@ -16,7 +16,7 @@
 using System;
 using System.IO;
 using System.Linq;
-
+using System.Text.RegularExpressions;
 namespace Minio.Helper
 {
     internal class s3utils
@@ -27,7 +27,9 @@ namespace Minio.Helper
             {
                 return true;
             }
-            return endpoint == "s3.amazonaws.com";
+            Regex rgx = new Regex("^s3[.-]?(.*?)\\.amazonaws\\.com$", RegexOptions.IgnoreCase);
+            MatchCollection matches = rgx.Matches(endpoint);
+            return (matches.Count > 0);
         }
 
         // IsAmazonChinaEndpoint - Match if it is exactly Amazon S3 China endpoint.

--- a/Minio/Regions.cs
+++ b/Minio/Regions.cs
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+using System;
+using System.Text.RegularExpressions;
 namespace Minio
 {
     public class Regions
@@ -27,46 +28,16 @@ namespace Minio
         /// </summary>
         /// <param name="endpoint">S3 API endpoint</param>
         /// <returns>Region corresponding to the endpoint. Default is 'us-east-1'</returns>
-        internal static string GetRegion(string endpoint)
+        public static string GetRegionFromEndpoint(string endpoint)
         {
-            if (endpoint.EndsWith("s3 - ap - northeast - 1.amazonaws.com"))
+            string region = null;
+            Regex rgx = new Regex("s3[.-]?(.*?)\\.amazonaws\\.com$", RegexOptions.IgnoreCase);
+            MatchCollection matches = rgx.Matches(endpoint);
+            if ((matches.Count > 0) && (matches[0].Groups.Count> 1))
             {
-                return "ap-northeast-1";
+                region = matches[0].Groups[1].Value;
             }
-            if (endpoint.EndsWith("s3-ap-southeast-1.amazonaws.com"))
-            {
-                return "ap-southeast-1";
-            }
-            if (endpoint.EndsWith("s3-ap-southeast-2.amazonaws.com"))
-            {
-                return "ap-southeast-2";
-
-            }
-            if (endpoint.EndsWith("s3-eu-central-1.amazonaws.com"))
-            {
-                return "eu-central-1";
-            }
-            if (endpoint.EndsWith("s3-eu-west-1.amazonaws.com"))
-            {
-                return "eu-west-1";
-            }
-            if (endpoint.EndsWith("s3-sa-east-1.amazonaws.com"))
-            {
-                return "sa-east-1";
-            }
-            if (endpoint.EndsWith("s3.amazonaws.com"))
-            {
-                return "us-east-1";
-            }
-            if (endpoint.EndsWith("s3-us-west-1.amazonaws.com"))
-            {
-                return "us-west-1";
-            }
-            if (endpoint.EndsWith("s3-us-west-2.amazonaws.com"))
-            {
-                return "us-west-2";
-            }
-            return "us-east-1";
+            return (region == null) ? "" : region;
         }
        
     }


### PR DESCRIPTION
Fixes #183 

A few of the region specific endpoints were missing on .net sdk. Updating as per http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region