### PR TITLE
Update to use request.Parameters to form PresignGetUrl.

### DIFF
--- a/Minio.Tests/AuthenticatorTest.cs
+++ b/Minio.Tests/AuthenticatorTest.cs
@@ -97,8 +97,8 @@ namespace Minio.Tests
             authenticator.Authenticate(restClient, request);
             var presignedUrl = authenticator.PresignURL(restClient, request, 5000);
 
-            Assert.IsTrue(presignedUrl.Contains("response-content-disposition"));
-            Assert.IsTrue(presignedUrl.Contains("response-content-type"));
+            Assert.IsTrue(presignedUrl.Contains("&response-content-disposition"));
+            Assert.IsTrue(presignedUrl.Contains("&response-content-type"));
 
             Assert.IsTrue(hasPayloadHeader(request, "x-amz-content-sha256"));
             Assert.IsTrue(hasPayloadHeader(request, "Content-Md5"));

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -277,11 +277,7 @@ namespace Minio
                 + expires
                 + "&";
             requestQuery += "X-Amz-SignedHeaders=host";
-
-            foreach(Parameter requestParam in request.Parameters)
-            {
-                requestQuery += $"&{requestParam.Name}={Uri.EscapeDataString((string)requestParam.Value)}";
-            }
+            requestQuery += string.Join("&", request.Parameters.Select(rp => $"{rp.Name}={Uri.EscapeDataString((string)rp.Value)}"));
 
             string canonicalRequest = GetPresignCanonicalRequest(client, request, requestQuery);
             byte[] canonicalRequestBytes = System.Text.Encoding.UTF8.GetBytes(canonicalRequest);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -277,7 +277,7 @@ namespace Minio
                 + expires
                 + "&";
             requestQuery += "X-Amz-SignedHeaders=host";
-            requestQuery += string.Join("&", request.Parameters.Select(rp => $"{rp.Name}={Uri.EscapeDataString((string)rp.Value)}"));
+            requestQuery += string.Join("", request.Parameters.Select(rp => $"&{rp.Name}={utils.UrlEncode((string)rp.Value)}"));
 
             string canonicalRequest = GetPresignCanonicalRequest(client, request, requestQuery);
             byte[] canonicalRequestBytes = System.Text.Encoding.UTF8.GetBytes(canonicalRequest);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -278,6 +278,11 @@ namespace Minio
                 + "&";
             requestQuery += "X-Amz-SignedHeaders=host";
 
+            foreach(Parameter requestParam in request.Parameters)
+            {
+                requestQuery += $"&{requestParam.Name}={Uri.EscapeDataString((string)requestParam.Value)}";
+            }
+
             string canonicalRequest = GetPresignCanonicalRequest(client, request, requestQuery);
             byte[] canonicalRequestBytes = System.Text.Encoding.UTF8.GetBytes(canonicalRequest);
             string canonicalRequestHash = BytesToHex(ComputeSha256(canonicalRequestBytes));


### PR DESCRIPTION
The current version of the SDK is not using the parameters included in the Request dictionary for the PresignedGetObjectAsync () function. As raised in issue #214 .

I set the V4Authenticator class to consider the parameters when mounting the URL.

I would like to ask for support for code validation and if necessary indicate where and how I should create unit or integration tests.

I hope it helps.