### PR TITLE
Prevent deadlocks in async methods

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -50,7 +50,7 @@ namespace Minio
             //PrepareClient();
 
             var request = new RestRequest("/", Method.GET);
-            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 
             ListAllMyBucketsResult bucketList = new ListAllMyBucketsResult();
             if (HttpStatusCode.OK.Equals(response.StatusCode))
@@ -86,7 +86,7 @@ namespace Minio
                 request.AddBody(config);
             }
 
-            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 
         }
 
@@ -101,9 +101,8 @@ namespace Minio
         {
             try
             {
-                var request = await this.CreateRequest(Method.HEAD,
-                                                   bucketName);
-                var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+                var request = await this.CreateRequest(Method.HEAD, bucketName).ConfigureAwait(false);
+                var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -124,9 +123,9 @@ namespace Minio
         /// <returns>Task</returns>
         public async Task RemoveBucketAsync(string bucketName, CancellationToken cancellationToken = default(CancellationToken))
         {
-            var request = await this.CreateRequest(Method.DELETE, bucketName, resourcePath: null);
+            var request = await this.CreateRequest(Method.DELETE, bucketName, resourcePath: null).ConfigureAwait(false);
 
-            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 
         }
 
@@ -147,7 +146,7 @@ namespace Minio
                   string marker = null;
                   while (isRunning)
                   {
-                      Tuple<ListBucketResult, List<Item>> result = await GetObjectListAsync(bucketName, prefix, recursive, marker, cancellationToken);
+                      Tuple<ListBucketResult, List<Item>> result = await GetObjectListAsync(bucketName, prefix, recursive, marker, cancellationToken).ConfigureAwait(false);
                       Item lastItem = null;
                       foreach (Item item in result.Item2)
                       {
@@ -203,11 +202,10 @@ namespace Minio
 
             var request = await this.CreateRequest(Method.GET,
                                                      bucketName,
-                                                     resourcePath: "?" + query);
-
-
-
-            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+                                                     resourcePath: "?" + query)
+                                        .ConfigureAwait(false);
+            
+            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 
             var contentBytes = System.Text.Encoding.UTF8.GetBytes(response.Content);
             ListBucketResult listBucketResult = null;
@@ -254,9 +252,10 @@ namespace Minio
 
             var request = await this.CreateRequest(Method.GET, bucketName,
                                  contentType: "application/json",
-                                 resourcePath: "?policy");
+                                 resourcePath: "?policy")
+                            .ConfigureAwait(false);
             string policyString = null;
-            response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
             var contentBytes = System.Text.Encoding.UTF8.GetBytes(response.Content);
 
             using (var stream = new MemoryStream(contentBytes))
@@ -278,9 +277,10 @@ namespace Minio
             var request = await this.CreateRequest(Method.PUT, bucketName,
                                            resourcePath: "?policy",
                                            contentType: "application/json",
-                                           body: policyJson);
+                                           body: policyJson)
+                                .ConfigureAwait(false);
 
-            IRestResponse response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            IRestResponse response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -294,10 +294,11 @@ namespace Minio
             utils.validateBucketName(bucketName);
             var request = await this.CreateRequest(Method.GET,
                                                bucketName,
-                                               resourcePath: "?notification");
+                                               resourcePath: "?notification")
+                                    .ConfigureAwait(false);
             BucketNotification notification = null;
            
-            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
             var contentBytes = System.Text.Encoding.UTF8.GetBytes(response.Content);
             using (var stream = new MemoryStream(contentBytes))
             {
@@ -316,13 +317,14 @@ namespace Minio
         {
             utils.validateBucketName(bucketName);
             var request = await this.CreateRequest(Method.PUT, bucketName,
-                                           resourcePath: "?notification");
+                                           resourcePath: "?notification")
+                                .ConfigureAwait(false);
     
             request.XmlSerializer = new RestSharp.Serializers.DotNetXmlSerializer();
             request.RequestFormat = DataFormat.Xml;
             request.AddBody(notification);
             
-            IRestResponse response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken);
+            IRestResponse response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -335,7 +337,7 @@ namespace Minio
         {
             utils.validateBucketName(bucketName);
             BucketNotification notification = new BucketNotification();
-            await SetBucketNotificationsAsync(bucketName, notification, cancellationToken);
+            await SetBucketNotificationsAsync(bucketName, notification, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/Minio/BucketRegionCache.cs
+++ b/Minio/BucketRegionCache.cs
@@ -102,7 +102,7 @@ namespace Minio
 
                 var request = new RestRequest(path, Method.GET);
 
-                var response = await client.ExecuteTaskAsync(client.NoErrorHandlers, request);
+                var response = await client.ExecuteTaskAsync(client.NoErrorHandlers, request).ConfigureAwait(false);
 
                 if (HttpStatusCode.OK.Equals(response.StatusCode))
                 {

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -115,7 +115,7 @@ namespace Minio
             {
                 if (!BucketRegionCache.Instance.Exists(bucketName))
                 {
-                    region = await BucketRegionCache.Instance.Update(this, bucketName);
+                    region = await BucketRegionCache.Instance.Update(this, bucketName).ConfigureAwait(false);
                 }
                 else
                 {
@@ -159,7 +159,7 @@ namespace Minio
             string host = this.BaseUrl;
 
             // Fetch correct region for bucket
-            string region = await getRegion(bucketName);
+            string region = await getRegion(bucketName).ConfigureAwait(false);
             
             this.restClient.Authenticator = new V4Authenticator(this.Secure, this.AccessKey, this.SecretKey, region);
 
@@ -349,7 +349,7 @@ namespace Minio
                                             });
             cancellationToken.ThrowIfCancellationRequested();
 
-            IRestResponse response = await tcs.Task;
+            IRestResponse response = await tcs.Task.ConfigureAwait(false);
             HandleIfErrorResponse(response, errorHandlers, startTime);
             return response;
         }


### PR DESCRIPTION
We experienced deadlocks while using Minio because we were not able to use await in some parts of our web application. By applying the best practice to disable continuation on captured context for library code, any possible deadlocks are avoided. Details https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f