### PR TITLE
Fix .NET Core host header generation if using default ports

### DIFF
--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -414,30 +414,10 @@ namespace Minio
             {
                 string headerName = header.Name.ToLower();
                 string headerValue = header.Value.ToString();
-#if NET46
                 if (!ignoredHeaders.Contains(headerName))
                 {
                     sortedHeaders.Add(headerName, headerValue);
                 }
-#else
-                if (headerName.Equals("host"))
-                {
-                    var host = headerValue.Split(':')[0];
-                    var port = headerValue.Split(':')[1];
-                    if (port.Equals("80") || port.Equals("443"))
-                    {
-                        sortedHeaders.Add(headerName, host);
-                    }
-                    else
-                    {
-                        sortedHeaders.Add(headerName, headerValue);
-                    }
-                }
-                else if (!ignoredHeaders.Contains(headerName))
-                {
-                    sortedHeaders.Add(headerName, headerValue);
-                }
-#endif
             }
 
             return sortedHeaders;


### PR DESCRIPTION
When using .NET Core and a reverse proxy with default ports, then the signed Headers create a header with "domain.com" instead of "domain.com:443" when using .NET Core. It seems the Server however always includes the Port. This results in a signature mismatch.

I can't see why this should be different for .NET Core and .NET Framework.

For .NET 4.6.2 it produces the following request that is signed:
```PUT\n/test\n\nhost:domain.com:443\nx-amz-content-sha256:....```
For Core it generates it like that:
```PUT\n/test\n\nhost:domain.com\nx-amz-content-sha256:....```

This PR removes the switch between Core and Framework and handles everything like the Framework version.
