### PR TITLE
fix: remove etag assertion on CopyObject_Test3

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -957,7 +957,6 @@ namespace Minio.Functional.Tests
                 string outFileName = "outFileName";
                 ObjectStat dstats = await minio.StatObjectAsync(destBucketName, destObjectName);
                 Assert.IsNotNull(dstats);
-                Assert.AreEqual(dstats.ETag, stats.ETag);
                 Assert.AreEqual(dstats.ObjectName, destObjectName);
                 await minio.GetObjectAsync(destBucketName, destObjectName, outFileName);
                 File.Delete(outFileName);


### PR DESCRIPTION
Fixes #240.

Remove etag assertion that was expecting source ETag to match with  destination ETag. This is an incorrect comparison,x-amz-copy-source-if-match is intended for server to match whether ETag of source object is same as requested ETag for conditional copying. Dest object will/can have a different ETag. 