### PR TITLE
Remove unnecessary Newtonsoft

### DIFF
--- a/Minio.Functional.Tests/MintLogger.cs
+++ b/Minio.Functional.Tests/MintLogger.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text;
 
 namespace Minio.Functional.Tests
 {
@@ -77,10 +77,37 @@ namespace Minio.Functional.Tests
         this.args = args;
         this.status = status.AsText();
       }  
-      public void Log() {
+      public void Log()
+      {
+            var sb = new StringBuilder();
 
-          Console.Out.WriteLine(JsonConvert.SerializeObject(this,Formatting.None,
-            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            sb.Append("function="); sb.AppendLine(this.function);
+            sb.Append("duration="); sb.AppendLine(this.duration.ToString() );
+            sb.Append("name=");     sb.AppendLine(this.name     );
+            sb.Append("alert=");    sb.AppendLine(this.alert    );
+            sb.Append("message=");  sb.AppendLine(this.message  );
+            sb.Append("error=");    sb.AppendLine(this.error    );
+            sb.Append("status=");   sb.AppendLine(this.status   );
+            sb.Append("args=");
+
+            if (this.args == null)
+            {
+                sb.AppendLine("[]");
+            }
+            else
+            {
+                foreach (var kv in this.args)
+                {
+                    sb.Append("[");
+                    sb.Append(kv.Key);
+                    sb.Append("]=");
+
+                    sb.AppendLine(kv.Value);
+                }
+            }
+
+
+            Console.Out.WriteLine(sb.ToString());
       }
     }
 }

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RestSharp" Version="106.3.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
   </ItemGroup>
@@ -42,4 +41,4 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'" Label="Framework References">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-</Project>
+</Project>  

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -24,7 +24,6 @@ using System.Xml.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Minio.Helper;
-using Newtonsoft.Json;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -552,10 +551,40 @@ namespace Minio
                 errorMessage = response.ErrorMessage,
             };
 
-            Console.Out.WriteLine(string.Format("Request completed in {0} ms, Request: {1}, Response: {2}",
-                    durationMs,
-                    JsonConvert.SerializeObject(requestToLog, Formatting.Indented),
-                    JsonConvert.SerializeObject(responseToLog, Formatting.Indented)));
+            var sb = new StringBuilder("Request completed in ");
+
+            sb.Append(durationMs);
+            sb.AppendLine(" ms, ");
+            sb.AppendLine("Request: ");
+
+            sb.Append(" method: "); sb.AppendLine(requestToLog.method);
+            sb.Append(" uri: "); sb.AppendLine(requestToLog.uri.ToString());
+            sb.Append(" resource: "); sb.AppendLine(requestToLog.resource);
+
+            sb.Append(" parameters: ");
+
+            foreach (var item in requestToLog.parameters)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.name);
+                sb.Append("  type:"); sb.AppendLine(item.type);
+                sb.Append("  value:"); sb.AppendLine(item.value.ToString());
+            }
+
+            sb.AppendLine("Response: ");
+            sb.Append(" statusCode: "); sb.AppendLine(responseToLog.statusCode.ToString());
+            sb.Append(" responseUri: "); sb.AppendLine(responseToLog.responseUri.ToString());
+            sb.Append(" headers: ");
+
+            foreach (RestSharp.Parameter item in responseToLog.headers)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.Name);
+                sb.Append("  value:"); sb.AppendLine(item.Value.ToString());
+            }
+
+            sb.Append(" content: "); sb.AppendLine(responseToLog.content);
+            sb.Append(" errorMessage: "); sb.AppendLine(responseToLog.errorMessage);
+
+            Console.Out.WriteLine(sb.ToString());
         }
 
     }


### PR DESCRIPTION
I have a little problem - big solution, with references to Newtonsoft Json 9 version
And I wanto to use your library
But reference to Newtonsoft version of 11 breaks my project
After review your code I understood, that Newtonsoft uses only for tracing to console
Not for production ;)
So.. I changed it to StringBuilder

![image](https://user-images.githubusercontent.com/5781038/45316730-4f2b0d00-b551-11e8-8376-68f55642acc9.png)

And I think build/deploy will be faster ;)