### PR TITLE
Remove unnecessary Newtonsoft from main package

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -151,7 +151,7 @@ namespace Minio.Functional.Tests
             // Set app Info 
             minioClient.SetAppInfo("app-name", "app-version");
             // Set HTTP Tracing On
-            // minioClient.SetTraceOn();
+             minioClient.SetTraceOn(new JsonNetLogger());
 
             // Set HTTP Tracing Off
             // minioClient.SetTraceOff();

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -151,7 +151,7 @@ namespace Minio.Functional.Tests
             // Set app Info 
             minioClient.SetAppInfo("app-name", "app-version");
             // Set HTTP Tracing On
-             minioClient.SetTraceOn(new JsonNetLogger());
+             //minioClient.SetTraceOn(new JsonNetLogger());
 
             // Set HTTP Tracing Off
             // minioClient.SetTraceOff();

--- a/Minio.Functional.Tests/JsonNetLogger.cs
+++ b/Minio.Functional.Tests/JsonNetLogger.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Minio.DataModel.Tracing;
+using Newtonsoft.Json;
+
+namespace Minio.Functional.Tests
+{
+    internal class JsonNetLogger: IRequestLogger
+    {
+        public void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs)
+        {
+            Console.Out.WriteLine(string.Format("Request completed in {0} ms, Request: {1}, Response: {2}",
+                durationMs,
+                JsonConvert.SerializeObject(requestToLog, Formatting.Indented),
+                JsonConvert.SerializeObject(responseToLog, Formatting.Indented)));
+        }
+    }
+}

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <Choose>

--- a/Minio.Functional.Tests/MintLogger.cs
+++ b/Minio.Functional.Tests/MintLogger.cs
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace Minio.Functional.Tests
 {
@@ -79,35 +79,8 @@ namespace Minio.Functional.Tests
       }  
       public void Log()
       {
-            var sb = new StringBuilder();
-
-            sb.Append("function="); sb.AppendLine(this.function);
-            sb.Append("duration="); sb.AppendLine(this.duration.ToString() );
-            sb.Append("name=");     sb.AppendLine(this.name     );
-            sb.Append("alert=");    sb.AppendLine(this.alert    );
-            sb.Append("message=");  sb.AppendLine(this.message  );
-            sb.Append("error=");    sb.AppendLine(this.error    );
-            sb.Append("status=");   sb.AppendLine(this.status   );
-            sb.Append("args=");
-
-            if (this.args == null)
-            {
-                sb.AppendLine("[]");
-            }
-            else
-            {
-                foreach (var kv in this.args)
-                {
-                    sb.Append("[");
-                    sb.Append(kv.Key);
-                    sb.Append("]=");
-
-                    sb.AppendLine(kv.Value);
-                }
-            }
-
-
-            Console.Out.WriteLine(sb.ToString());
-      }
+            Console.Out.WriteLine(JsonConvert.SerializeObject(this, Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+        }
     }
 }

--- a/Minio.Functional.Tests/MintLogger.cs
+++ b/Minio.Functional.Tests/MintLogger.cs
@@ -16,7 +16,7 @@
 
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text;
 
 namespace Minio.Functional.Tests
 {
@@ -77,10 +77,37 @@ namespace Minio.Functional.Tests
         this.args = args;
         this.status = status.AsText();
       }  
-      public void Log() {
+      public void Log()
+      {
+            var sb = new StringBuilder();
 
-          Console.Out.WriteLine(JsonConvert.SerializeObject(this,Formatting.None,
-            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            sb.Append("function="); sb.AppendLine(this.function);
+            sb.Append("duration="); sb.AppendLine(this.duration.ToString() );
+            sb.Append("name=");     sb.AppendLine(this.name     );
+            sb.Append("alert=");    sb.AppendLine(this.alert    );
+            sb.Append("message=");  sb.AppendLine(this.message  );
+            sb.Append("error=");    sb.AppendLine(this.error    );
+            sb.Append("status=");   sb.AppendLine(this.status   );
+            sb.Append("args=");
+
+            if (this.args == null)
+            {
+                sb.AppendLine("[]");
+            }
+            else
+            {
+                foreach (var kv in this.args)
+                {
+                    sb.Append("[");
+                    sb.Append(kv.Key);
+                    sb.Append("]=");
+
+                    sb.AppendLine(kv.Value);
+                }
+            }
+
+
+            Console.Out.WriteLine(sb.ToString());
       }
     }
 }

--- a/Minio/DataModel/Tracing/RequestParameter.cs
+++ b/Minio/DataModel/Tracing/RequestParameter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class RequestParameter
+    {
+        public string name { get; internal set; }
+        public object value { get; internal set; }
+        public string type { get; internal set; }
+    }
+}

--- a/Minio/DataModel/Tracing/RequestToLog.cs
+++ b/Minio/DataModel/Tracing/RequestToLog.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class RequestToLog
+    {
+        public string resource { get; internal set; }
+        public IEnumerable<RequestParameter> parameters { get; internal set; }
+        public string method { get; internal set; }
+        public Uri uri { get; internal set; }
+    }
+}

--- a/Minio/DataModel/Tracing/ResponseToLog.cs
+++ b/Minio/DataModel/Tracing/ResponseToLog.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using RestSharp;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class ResponseToLog
+    {
+        public string content { get; internal set; }
+        public IEnumerable<Parameter> headers { get; internal set; }
+        public HttpStatusCode statusCode { get; internal set; }
+        public Uri responseUri { get; internal set; }
+        public string errorMessage { get; internal set; }
+        public double durationMs { get; internal set; }
+    }
+}

--- a/Minio/DefaultRequestLogger.cs
+++ b/Minio/DefaultRequestLogger.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using Minio.DataModel.Tracing;
+
+namespace Minio
+{
+    internal sealed class DefaultRequestLogger : IRequestLogger
+    {
+        public void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs)
+        {
+            var sb = new StringBuilder("Request completed in ");
+
+            sb.Append(durationMs);
+            sb.AppendLine(" ms, ");
+            sb.AppendLine("Request: ");
+
+            sb.Append(" method: "); sb.AppendLine(requestToLog.method);
+            sb.Append(" uri: "); sb.AppendLine(requestToLog.uri.ToString());
+            sb.Append(" resource: "); sb.AppendLine(requestToLog.resource);
+
+            sb.Append(" parameters: ");
+
+            foreach (var item in requestToLog.parameters)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.name);
+                sb.Append("  type:"); sb.AppendLine(item.type);
+                sb.Append("  value:"); sb.AppendLine(item.value.ToString());
+            }
+
+            sb.AppendLine("Response: ");
+            sb.Append(" statusCode: "); sb.AppendLine(responseToLog.statusCode.ToString());
+            sb.Append(" responseUri: "); sb.AppendLine(responseToLog.responseUri.ToString());
+            sb.Append(" headers: ");
+
+            foreach (RestSharp.Parameter item in responseToLog.headers)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.Name);
+                sb.Append("  value:"); sb.AppendLine(item.Value.ToString());
+            }
+
+            sb.Append(" content: "); sb.AppendLine(responseToLog.content);
+            sb.Append(" errorMessage: "); sb.AppendLine(responseToLog.errorMessage);
+
+            Console.Out.WriteLine(sb.ToString());
+        }
+    }
+}

--- a/Minio/IRequestLogger.cs
+++ b/Minio/IRequestLogger.cs
@@ -1,0 +1,9 @@
+﻿using Minio.DataModel.Tracing;
+
+namespace Minio
+{
+    public interface IRequestLogger
+    {
+        void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs);
+    }
+}

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RestSharp" Version="106.3.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
   </ItemGroup>
@@ -42,4 +41,4 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'" Label="Framework References">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-</Project>
+</Project>  

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -24,7 +24,6 @@ using System.Xml.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Minio.Helper;
-using Newtonsoft.Json;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -552,10 +551,40 @@ namespace Minio
                 errorMessage = response.ErrorMessage,
             };
 
-            Console.Out.WriteLine(string.Format("Request completed in {0} ms, Request: {1}, Response: {2}",
-                    durationMs,
-                    JsonConvert.SerializeObject(requestToLog, Formatting.Indented),
-                    JsonConvert.SerializeObject(responseToLog, Formatting.Indented)));
+            var sb = new StringBuilder("Request completed in ");
+
+            sb.Append(durationMs);
+            sb.AppendLine(" ms, ");
+            sb.AppendLine("Request: ");
+
+            sb.Append(" method: "); sb.AppendLine(requestToLog.method);
+            sb.Append(" uri: "); sb.AppendLine(requestToLog.uri.ToString());
+            sb.Append(" resource: "); sb.AppendLine(requestToLog.resource);
+
+            sb.Append(" parameters: ");
+
+            foreach (var item in requestToLog.parameters)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.name);
+                sb.Append("  type:"); sb.AppendLine(item.type);
+                sb.Append("  value:"); sb.AppendLine(item.value.ToString());
+            }
+
+            sb.AppendLine("Response: ");
+            sb.Append(" statusCode: "); sb.AppendLine(responseToLog.statusCode.ToString());
+            sb.Append(" responseUri: "); sb.AppendLine(responseToLog.responseUri.ToString());
+            sb.Append(" headers: ");
+
+            foreach (RestSharp.Parameter item in responseToLog.headers)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.Name);
+                sb.Append("  value:"); sb.AppendLine(item.Value.ToString());
+            }
+
+            sb.Append(" content: "); sb.AppendLine(responseToLog.content);
+            sb.Append(" errorMessage: "); sb.AppendLine(responseToLog.errorMessage);
+
+            Console.Out.WriteLine(sb.ToString());
         }
 
     }


### PR DESCRIPTION
I have a little problem - big solution, with references to Newtonsoft Json 9 version
And I want to use your library
But reference to Newtonsoft version of 11 breaks my project
After review your code I understood, that Newtonsoft used only for tracing to console
Not for production ;)

So.. I created interface `IRequestLogger` with default implemetation via `StringBuilder`
And if anybody wants to use newtonsoft, csv or yet another logger - he could create himself implemetation )