### PR TITLE
Remove unnecessary Newtonsoft

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1246,17 +1246,26 @@ __Example__
 minioClient.SetAppInfo("myCloudApp", "1.0.0")
 ```
 <a name="SetTraceOn"></a>
-### SetTraceOn()
+### SetTraceOn(IRequestLogger logger = null)
 Enables HTTP tracing. The trace is written to the stdout.
 
+__Parameters__
+
+| Param  | Type  | Description  |
+|---|---|---|
+|`logger`  | _IRequestLogger_  | Implementation of interface `Minio.IRequestLogger` for serialization models for trace HTTP |
 
 __Example__
 
-
 ```cs
-// Set HTTP tracing on.
+// Set HTTP tracing on with default trace logger.
 minioClient.SetTraceOn()
+
+// Set custom logger for HTTP trace
+minioClient.SetTraceOn(new JsonNetLogger())
 ```
+
+
 <a name="SetTraceOff"></a>
 ### SetTraceOff()
 Disables HTTP tracing.

--- a/Minio.Examples/Cases/CustomRequestLogger.cs
+++ b/Minio.Examples/Cases/CustomRequestLogger.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Minio.DataModel.Tracing;
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Minio.Examples.Cases
+{
+    public class CustomRequestLogger
+    {
+        // Check if a bucket exists
+        public async static Task Run(MinioClient minio)
+        {
+            try
+            {
+                Console.Out.WriteLine("Running example for: set custom request logger");
+
+                minio.SetTraceOn(new MyRequestLogger());
+
+                await minio.ListBucketsAsync();
+
+                minio.SetTraceOff();
+
+                Console.Out.WriteLine();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("[Bucket]  Exception: {0}", e);
+            }
+        }
+    }
+
+    internal class MyRequestLogger : IRequestLogger
+    {
+        public void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs)
+        {
+            var sb = new StringBuilder();
+
+            sb.AppendLine("My logger says:");
+            sb.Append("statusCode: ");
+            sb.AppendLine(responseToLog.statusCode.ToString());
+            sb.AppendLine();
+
+            sb.AppendLine("Response: ");
+            sb.Append(responseToLog.content);
+
+            Console.Out.WriteLine(sb.ToString());
+        }
+    }
+}

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -184,10 +184,13 @@ namespace Minio.Examples
                 // Delete the object
                 Cases.RemoveObject.Run(minioClient, destBucketName, objectName).Wait();
 
+                // Tacing request with custom logger
+                Cases.CustomRequestLogger.Run(minioClient).Wait();
+
                 // Remove the buckets
                 Cases.RemoveBucket.Run(minioClient, bucketName).Wait();
                 Cases.RemoveBucket.Run(minioClient, destBucketName).Wait();
-
+                
                 // Remove the binary files created for test
                 File.Delete(smallFileName);
                 File.Delete(bigFileName);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -151,7 +151,7 @@ namespace Minio.Functional.Tests
             // Set app Info 
             minioClient.SetAppInfo("app-name", "app-version");
             // Set HTTP Tracing On
-            // minioClient.SetTraceOn();
+             //minioClient.SetTraceOn(new JsonNetLogger());
 
             // Set HTTP Tracing Off
             // minioClient.SetTraceOff();

--- a/Minio.Functional.Tests/JsonNetLogger.cs
+++ b/Minio.Functional.Tests/JsonNetLogger.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using Minio.DataModel.Tracing;
 using Newtonsoft.Json;
 

--- a/Minio.Functional.Tests/JsonNetLogger.cs
+++ b/Minio.Functional.Tests/JsonNetLogger.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Minio.DataModel.Tracing;
+using Newtonsoft.Json;
+
+namespace Minio.Functional.Tests
+{
+    internal class JsonNetLogger: IRequestLogger
+    {
+        public void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs)
+        {
+            Console.Out.WriteLine(string.Format("Request completed in {0} ms, Request: {1}, Response: {2}",
+                durationMs,
+                JsonConvert.SerializeObject(requestToLog, Formatting.Indented),
+                JsonConvert.SerializeObject(responseToLog, Formatting.Indented)));
+        }
+    }
+}

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <Choose>

--- a/Minio.Functional.Tests/MintLogger.cs
+++ b/Minio.Functional.Tests/MintLogger.cs
@@ -14,9 +14,9 @@
 * limitations under the License.
 */
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json;
 
 namespace Minio.Functional.Tests
 {
@@ -77,10 +77,10 @@ namespace Minio.Functional.Tests
         this.args = args;
         this.status = status.AsText();
       }  
-      public void Log() {
-
-          Console.Out.WriteLine(JsonConvert.SerializeObject(this,Formatting.None,
-            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
-      }
+      public void Log()
+      {
+            Console.Out.WriteLine(JsonConvert.SerializeObject(this, Formatting.None,
+                new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+        }
     }
 }

--- a/Minio/DataModel/Tracing/RequestParameter.cs
+++ b/Minio/DataModel/Tracing/RequestParameter.cs
@@ -1,6 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 namespace Minio.DataModel.Tracing
 {

--- a/Minio/DataModel/Tracing/RequestParameter.cs
+++ b/Minio/DataModel/Tracing/RequestParameter.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class RequestParameter
+    {
+        public string name { get; internal set; }
+        public object value { get; internal set; }
+        public string type { get; internal set; }
+    }
+}

--- a/Minio/DataModel/Tracing/RequestToLog.cs
+++ b/Minio/DataModel/Tracing/RequestToLog.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 
 namespace Minio.DataModel.Tracing

--- a/Minio/DataModel/Tracing/RequestToLog.cs
+++ b/Minio/DataModel/Tracing/RequestToLog.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class RequestToLog
+    {
+        public string resource { get; internal set; }
+        public IEnumerable<RequestParameter> parameters { get; internal set; }
+        public string method { get; internal set; }
+        public Uri uri { get; internal set; }
+    }
+}

--- a/Minio/DataModel/Tracing/ResponseToLog.cs
+++ b/Minio/DataModel/Tracing/ResponseToLog.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using RestSharp;
+
+namespace Minio.DataModel.Tracing
+{
+    public sealed class ResponseToLog
+    {
+        public string content { get; internal set; }
+        public IEnumerable<Parameter> headers { get; internal set; }
+        public HttpStatusCode statusCode { get; internal set; }
+        public Uri responseUri { get; internal set; }
+        public string errorMessage { get; internal set; }
+        public double durationMs { get; internal set; }
+    }
+}

--- a/Minio/DataModel/Tracing/ResponseToLog.cs
+++ b/Minio/DataModel/Tracing/ResponseToLog.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using System.Net;
 using RestSharp;

--- a/Minio/DefaultRequestLogger.cs
+++ b/Minio/DefaultRequestLogger.cs
@@ -1,4 +1,20 @@
-﻿using System;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
 using System.Text;
 using Minio.DataModel.Tracing;
 

--- a/Minio/DefaultRequestLogger.cs
+++ b/Minio/DefaultRequestLogger.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Text;
+using Minio.DataModel.Tracing;
+
+namespace Minio
+{
+    internal sealed class DefaultRequestLogger : IRequestLogger
+    {
+        public void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs)
+        {
+            var sb = new StringBuilder("Request completed in ");
+
+            sb.Append(durationMs);
+            sb.AppendLine(" ms, ");
+            sb.AppendLine("Request: ");
+
+            sb.Append(" method: "); sb.AppendLine(requestToLog.method);
+            sb.Append(" uri: "); sb.AppendLine(requestToLog.uri.ToString());
+            sb.Append(" resource: "); sb.AppendLine(requestToLog.resource);
+
+            sb.Append(" parameters: ");
+
+            foreach (var item in requestToLog.parameters)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.name);
+                sb.Append("  type:"); sb.AppendLine(item.type);
+                sb.Append("  value:"); sb.AppendLine(item.value.ToString());
+            }
+
+            sb.AppendLine("Response: ");
+            sb.Append(" statusCode: "); sb.AppendLine(responseToLog.statusCode.ToString());
+            sb.Append(" responseUri: "); sb.AppendLine(responseToLog.responseUri.ToString());
+            sb.Append(" headers: ");
+
+            foreach (RestSharp.Parameter item in responseToLog.headers)
+            {
+                sb.Append("  name:"); sb.AppendLine(item.Name);
+                sb.Append("  value:"); sb.AppendLine(item.Value.ToString());
+            }
+
+            sb.Append(" content: "); sb.AppendLine(responseToLog.content);
+            sb.Append(" errorMessage: "); sb.AppendLine(responseToLog.errorMessage);
+
+            Console.Out.WriteLine(sb.ToString());
+        }
+    }
+}

--- a/Minio/IRequestLogger.cs
+++ b/Minio/IRequestLogger.cs
@@ -1,4 +1,20 @@
-﻿using Minio.DataModel.Tracing;
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Minio.DataModel.Tracing;
 
 namespace Minio
 {

--- a/Minio/IRequestLogger.cs
+++ b/Minio/IRequestLogger.cs
@@ -1,0 +1,9 @@
+﻿using Minio.DataModel.Tracing;
+
+namespace Minio
+{
+    public interface IRequestLogger
+    {
+        void LogRequest(RequestToLog requestToLog, ResponseToLog responseToLog, double durationMs);
+    }
+}

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup Label="Package">
     <Product>Minio</Product>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <Description>Minio .NET SDK for Amazon S3 Compatible Cloud Storage.</Description>
     <Copyright>Copyright (c) 2018.  All rights reserved.</Copyright>
     <Authors>Minio, Inc.</Authors>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
 
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="RestSharp" Version="106.3.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
   </ItemGroup>
@@ -42,4 +41,4 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'" Label="Framework References">
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
-</Project>
+</Project>  

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -541,7 +541,7 @@ namespace Minio
                 // ToString() here to have the method as a nice string otherwise it will just show the enum value
                 method = request.Method.ToString(),
                 // This will generate the actual Uri used in the request
-                uri = restClient.BuildUri(request),
+                uri = restClient.BuildUri(request)
             };
 
             var responseToLog = new ResponseToLog

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -24,9 +24,8 @@ using System.Xml.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
 using Minio.Helper;
-using Newtonsoft.Json;
+using Minio.DataModel.Tracing;
 using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Minio
 {
@@ -54,6 +53,8 @@ namespace Minio
 
         // Cache holding bucket to region mapping for buckets seen so far.
         internal BucketRegionCache regionCache;
+
+        private IRequestLogger logger;
 
         // Enables HTTP tracing if set to true
         private bool trace = false;
@@ -505,8 +506,9 @@ namespace Minio
         /// <summary>
         /// Sets HTTP tracing On.Writes output to Console
         /// </summary>
-        public void SetTraceOn()
+        public void SetTraceOn(IRequestLogger logger = null)
         {
+            this.logger = logger ?? new DefaultRequestLogger();
             this.trace = true;
         }
         /// <summary>
@@ -525,12 +527,12 @@ namespace Minio
         /// <param name="durationMs"></param>
         private void LogRequest(IRestRequest request, IRestResponse response, double durationMs)
         {
-            var requestToLog = new
+            var requestToLog = new RequestToLog
             {
                 resource = request.Resource,
                 // Parameters are custom anonymous objects in order to have the parameter type as a nice string
                 // otherwise it will just show the enum value
-                parameters = request.Parameters.Select(parameter => new
+                parameters = request.Parameters.Select(parameter => new RequestParameter
                 {
                     name = parameter.Name,
                     value = parameter.Value,
@@ -542,7 +544,7 @@ namespace Minio
                 uri = restClient.BuildUri(request),
             };
 
-            var responseToLog = new
+            var responseToLog = new ResponseToLog
             {
                 statusCode = response.StatusCode,
                 content = response.Content,
@@ -550,12 +552,10 @@ namespace Minio
                 // The Uri that actually responded (could be different from the requestUri if a redirection occurred)
                 responseUri = response.ResponseUri,
                 errorMessage = response.ErrorMessage,
+                durationMs = durationMs
             };
 
-            Console.Out.WriteLine(string.Format("Request completed in {0} ms, Request: {1}, Response: {2}",
-                    durationMs,
-                    JsonConvert.SerializeObject(requestToLog, Formatting.Indented),
-                    JsonConvert.SerializeObject(responseToLog, Formatting.Indented)));
+            this.logger.LogRequest(requestToLog, responseToLog, durationMs);
         }
 
     }

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -414,30 +414,10 @@ namespace Minio
             {
                 string headerName = header.Name.ToLower();
                 string headerValue = header.Value.ToString();
-#if NET46
                 if (!ignoredHeaders.Contains(headerName))
                 {
                     sortedHeaders.Add(headerName, headerValue);
                 }
-#else
-                if (headerName.Equals("host"))
-                {
-                    var host = headerValue.Split(':')[0];
-                    var port = headerValue.Split(':')[1];
-                    if (port.Equals("80") || port.Equals("443"))
-                    {
-                        sortedHeaders.Add(headerName, host);
-                    }
-                    else
-                    {
-                        sortedHeaders.Add(headerName, headerValue);
-                    }
-                }
-                else if (!ignoredHeaders.Contains(headerName))
-                {
-                    sortedHeaders.Add(headerName, headerValue);
-                }
-#endif
             }
 
             return sortedHeaders;


### PR DESCRIPTION
I have a little problem - big solution, with references to Newtonsoft Json 9 version
And I want to use your library
But reference to Newtonsoft version of 11 breaks my project
After review your code I understood, that Newtonsoft used only for tracing to console
Not for production ;)

So.. I created interface `IRequestLogger` with default implemetation via `StringBuilder`
And if anybody wants to use newtonsoft, csv or yet another logger - he could create himself implemetation )