### PR TITLE
Perf tests

### DIFF
--- a/Minio.Examples/Cases/PutObjectWithRealStream.cs
+++ b/Minio.Examples/Cases/PutObjectWithRealStream.cs
@@ -1,0 +1,53 @@
+﻿/*
+ * Minio .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Minio.Examples.Cases
+{
+    class PutObjectWithRealStream
+    {
+        private static int MB = 1024 * 1024;
+
+        // Put an object from a local stream into bucket
+        public async static Task Run(Minio.MinioClient minio,
+                                     string bucketName = "my-bucket-name", 
+                                     string objectName = "my-object-name",
+                                     string fileName="location-of-file")
+        {
+            try
+            {
+                using (var filestream = new System.IO.FileStream(fileName, FileMode.Open, FileAccess.Read))
+                {
+                    await minio.PutObjectAsyncFast(bucketName,
+                                               objectName,
+                                               filestream,
+                                               "application/octet-stream");
+                }
+            
+                Console.Out.WriteLine("Uploaded object " + objectName + " to bucket " + bucketName);
+                Console.Out.WriteLine();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("[Bucket]  Exception: {0}", e);
+            }
+        }
+      
+    }
+}

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -4,6 +4,9 @@
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Minio\Minio.csproj" />

--- a/Minio.Examples/PrefTests.cs
+++ b/Minio.Examples/PrefTests.cs
@@ -1,0 +1,116 @@
+﻿using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace Minio.Examples
+{
+    [MemoryDiagnoser]
+    [GcServer]
+    public class PrefTests
+    {
+        private static Random rnd = new Random();
+        private static int UNIT_MB = 1024 * 1024;
+
+        // Create a file of given size from random byte array
+        private static String CreateFile(int size)
+        {
+            String fileName = GetRandomName();
+            byte[] data = new byte[size];
+            rnd.NextBytes(data);
+
+            File.WriteAllBytes(fileName, data);
+
+            return fileName;
+        }
+
+        // Generate a random string
+        public static String GetRandomName()
+        {
+            string characters = "0123456789abcdefghijklmnopqrstuvwxyz";
+            StringBuilder result = new StringBuilder(5);
+            for (int i = 0; i < 5; i++)
+            {
+                result.Append(characters[rnd.Next(characters.Length)]);
+            }
+            return "minio-dotnet-example-" + result.ToString();
+        }
+        MinioClient minioClient;
+        private string bucketName;
+        private string smallFileName;
+        private string bigFileName;
+        private string objectName;
+
+        [GlobalSetup]
+        public void Init()
+        {
+            String endPoint = null;
+            String accessKey = null;
+            String secretKey = null;
+            bool enableHTTPS = false;
+            if (Environment.GetEnvironmentVariable("SERVER_ENDPOINT") != null)
+            {
+                endPoint = Environment.GetEnvironmentVariable("SERVER_ENDPOINT");
+                accessKey = Environment.GetEnvironmentVariable("ACCESS_KEY");
+                secretKey = Environment.GetEnvironmentVariable("SECRET_KEY");
+                if (Environment.GetEnvironmentVariable("ENABLE_HTTPS") != null)
+                    enableHTTPS = Environment.GetEnvironmentVariable("ENABLE_HTTPS").Equals("1");
+            }
+            else
+            {
+                endPoint = "play.minio.io:9000";
+                accessKey = "Q3AM3UQ867SPQQA43P2F";
+                secretKey = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG";
+                enableHTTPS = true;
+            }
+
+            minioClient = null;
+            if (enableHTTPS)
+                minioClient = new Minio.MinioClient(endPoint, accessKey, secretKey).WithSSL();
+            else
+                minioClient = new Minio.MinioClient(endPoint, accessKey, secretKey);
+
+            bucketName = GetRandomName();
+            smallFileName = CreateFile(1 * UNIT_MB);
+            bigFileName = CreateFile(6 * UNIT_MB);
+            objectName = GetRandomName();
+            minioClient.SetAppInfo("app-name", "app-version");
+
+            Cases.MakeBucket.Run(minioClient, bucketName).Wait();
+        }
+
+        [GlobalCleanup]
+        public void Clean()
+        {
+            //Cases.RemoveBucket.Run(minioClient, bucketName).Wait();
+
+            File.Delete(smallFileName);
+            File.Delete(bigFileName);
+        }
+
+        [Benchmark]
+        public void PutObjectAsync_small()
+        {
+            Cases.PutObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
+        }
+
+        [Benchmark]
+        public void PutObjectAsyncFast_small()
+        {
+            Cases.PutObjectWithRealStream.Run(minioClient, bucketName, objectName, smallFileName).Wait();
+        }
+
+        [Benchmark]
+        public void PutObjectAsync_big()
+        {
+            Cases.PutObject.Run(minioClient, bucketName, objectName, bigFileName).Wait();
+        }
+
+        [Benchmark]
+        public void PutObjectAsyncFast_big()
+        {
+            Cases.PutObjectWithRealStream.Run(minioClient, bucketName, objectName, bigFileName).Wait();
+        }
+    }
+}

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -18,6 +18,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using BenchmarkDotNet.Running;
 using Minio.DataModel;
 using Minio.Exceptions;
 
@@ -25,183 +26,16 @@ namespace Minio.Examples
 {
     public class Program
     {
-        private static Random rnd = new Random();
-        private static int UNIT_MB = 1024 * 1024;
-
-        // Create a file of given size from random byte array
-        private static String CreateFile(int size)
-        {
-            String fileName = GetRandomName();
-            byte[] data = new byte[size];
-            rnd.NextBytes(data);
-
-            File.WriteAllBytes(fileName, data);
-
-            return fileName;
-        }
-
-        // Generate a random string
-        public static String GetRandomName()
-        {
-            string characters = "0123456789abcdefghijklmnopqrstuvwxyz";
-            StringBuilder result = new StringBuilder(5);
-            for (int i = 0; i < 5; i++)
-            {
-                result.Append(characters[rnd.Next(characters.Length)]);
-            }
-            return "minio-dotnet-example-" + result.ToString();
-        }
-
         public static void Main(string[] args)
         {
-            String endPoint = null;
-            String accessKey = null;
-            String secretKey = null;
-            bool enableHTTPS = false;
-            if (Environment.GetEnvironmentVariable("SERVER_ENDPOINT") != null)
-            {
-                endPoint = Environment.GetEnvironmentVariable("SERVER_ENDPOINT");
-                accessKey = Environment.GetEnvironmentVariable("ACCESS_KEY");
-                secretKey = Environment.GetEnvironmentVariable("SECRET_KEY");
-                if (Environment.GetEnvironmentVariable("ENABLE_HTTPS") != null)
-                    enableHTTPS = Environment.GetEnvironmentVariable("ENABLE_HTTPS").Equals("1"); 
-            }
-            else
-            {
-                endPoint = "play.minio.io:9000";
-                accessKey = "Q3AM3UQ867SPQQA43P2F";
-                secretKey = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG";
-                enableHTTPS = true;
-            }
+            //var t = new PrefTests();
+            //t.Init();
+            //t.PutObjectAsync_small();
+            //t.PutObjectAsyncFast_small();
+            //t.PutObjectAsync_big();
+            //t.PutObjectAsyncFast_big();
 
-            // WithSSL() enables SSL support in Minio client
-            MinioClient minioClient = null;
-            if (enableHTTPS)
-                minioClient = new Minio.MinioClient(endPoint, accessKey, secretKey).WithSSL();
-            else
-                minioClient = new Minio.MinioClient(endPoint, accessKey, secretKey);
-
-            try
-            {
-                // Assign parameters before starting the test 
-                string bucketName = GetRandomName();
-                string smallFileName = CreateFile(1 * UNIT_MB);
-                string bigFileName = CreateFile(6 * UNIT_MB);
-                string objectName = GetRandomName();
-                string destBucketName = GetRandomName();
-                string destObjectName = GetRandomName();
-                List<string> objectsList = new List<string>();
-                for (int i = 0; i < 10; i++)
-                {
-                    objectsList.Add(objectName + i.ToString());
-                }
-                // Set app Info 
-                minioClient.SetAppInfo("app-name", "app-version");
-
-                // Set HTTP Tracing On
-                // minioClient.SetTraceOn();
-
-
-                // Set HTTP Tracing Off
-                // minioClient.SetTraceOff();
-                // Check if bucket exists
-                Cases.BucketExists.Run(minioClient, bucketName).Wait();
-
-                // Create a new bucket
-                Cases.MakeBucket.Run(minioClient, bucketName).Wait();
- 
-                Cases.MakeBucket.Run(minioClient, destBucketName).Wait();
-
-
-                // List all the buckets on the server
-                Cases.ListBuckets.Run(minioClient).Wait();
-
-                // Put an object to the new bucket
-                Cases.PutObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
-
-                // Get object metadata
-                Cases.StatObject.Run(minioClient, bucketName, objectName).Wait();
-
-                // List the objects in the new bucket
-                Cases.ListObjects.Run(minioClient, bucketName);
-
-                // Delete the file and Download the object as file
-                Cases.GetObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
-               
-                // Delete the file and Download partial object as file
-                Cases.GetPartialObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
-
-                // Server side copyObject
-                Cases.CopyObject.Run(minioClient, bucketName, objectName, destBucketName, objectName).Wait();
-
-                // Server side copyObject with metadata replacement
-                Cases.CopyObjectMetadata.Run(minioClient, bucketName, objectName, destBucketName, objectName).Wait();
-
-                // Upload a File with PutObject
-                Cases.FPutObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
-
-                // Delete the file and Download the object as file
-                Cases.FGetObject.Run(minioClient, bucketName, objectName, smallFileName).Wait();
-
-                // Automatic Multipart Upload with object more than 5Mb
-                Cases.PutObject.Run(minioClient, bucketName, objectName, bigFileName).Wait();
-
-                // List the incomplete uploads
-                Cases.ListIncompleteUploads.Run(minioClient, bucketName);
-
-                // Remove all the incomplete uploads
-                Cases.RemoveIncompleteUpload.Run(minioClient, bucketName, objectName).Wait();
-
-                // Set a policy for given bucket
-                Cases.SetBucketPolicy.Run(minioClient, bucketName).Wait();
-                // Get the policy for given bucket
-                Cases.GetBucketPolicy.Run(minioClient, bucketName).Wait();
- 
-                // Set bucket notifications
-                Cases.SetBucketNotification.Run(minioClient, bucketName).Wait();
-
-                // Get bucket notifications
-                Cases.GetBucketNotification.Run(minioClient, bucketName).Wait();
-
-                // Remove all bucket notifications
-                Cases.RemoveAllBucketNotifications.Run(minioClient, bucketName).Wait();
-
-                // Get the presigned url for a GET object request
-                Cases.PresignedGetObject.Run(minioClient, bucketName, objectName).Wait();
-
-                // Get the presigned POST policy curl url
-                Cases.PresignedPostPolicy.Run(minioClient).Wait();
-
-                // Get the presigned url for a PUT object request
-                Cases.PresignedPutObject.Run(minioClient, bucketName, objectName).Wait();
-
-                // Delete the list of objects
-                Cases.RemoveObjects.Run(minioClient, bucketName, objectsList).Wait();
-
-                // Delete the object
-                Cases.RemoveObject.Run(minioClient, bucketName, objectName).Wait();
-
-                // Delete the object
-                Cases.RemoveObject.Run(minioClient, destBucketName, objectName).Wait();
-
-                // Tacing request with custom logger
-                Cases.CustomRequestLogger.Run(minioClient).Wait();
-
-                // Remove the buckets
-                Cases.RemoveBucket.Run(minioClient, bucketName).Wait();
-                Cases.RemoveBucket.Run(minioClient, destBucketName).Wait();
-                
-                // Remove the binary files created for test
-                File.Delete(smallFileName);
-                File.Delete(bigFileName);
-
-                Console.ReadLine();
-            }
-            catch (MinioException ex)
-            {
-                Console.Out.WriteLine(ex.Message);
-            }
-
+            BenchmarkRunner.Run<PrefTests>();
         }
     }
 }

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -31,6 +31,8 @@
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
 
     <PackageReference Include="RestSharp" Version="106.3.1" />
+
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Hi!

I found that you using streams wrong
It's very bad with real big files

![image](https://user-images.githubusercontent.com/5781038/47038159-38a05300-d19a-11e8-9125-62c370ca2ccf.png)

Below performance tests and PR only for review good approaches
I didn't know how to use RestSharp, but it's enough for demo

``` ini

BenchmarkDotNet=v0.11.1, OS=Windows 10.0.17134.345 (1803/April2018Update/Redstone4)
Intel Core i7-4770 CPU 3.40GHz (Haswell), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.1.402
  [Host]     : .NET Core 2.1.4 (CoreCLR 4.6.26814.03, CoreFX 4.6.26814.02), 64bit RyuJIT
  Job-KQRNGT : .NET Core 2.1.4 (CoreCLR 4.6.26814.03, CoreFX 4.6.26814.02), 64bit RyuJIT

Server=False  

```
|                   Method |    Mean |    Error |   StdDev |     Gen 0 |     Gen 1 |     Gen 2 |  Allocated |
|------------------------- |--------:|---------:|---------:|----------:|----------:|----------:|-----------:|
|     PutObjectAsync_small | 2.156 s | 0.0416 s | 0.0408 s | 1000.0000 | 1000.0000 | 1000.0000 | 3137.93 KB |
| PutObjectAsyncFast_small | 2.137 s | 0.0413 s | 0.0507 s |         - |         - |         - |   60.06 KB |
|       PutObjectAsync_big | 7.121 s | 0.0878 s | 0.0779 s | 1000.0000 | 1000.0000 | 1000.0000 | 6221.46 KB |
|   PutObjectAsyncFast_big | 2.847 s | 0.0553 s | 0.0637 s |         - |         - |         - |   60.06 KB |

[BenchmarkDotNet.Artifacts.zip](https://github.com/minio/minio-dotnet/files/2484446/BenchmarkDotNet.Artifacts.zip)
