### PR TITLE
Pass region into presigned methods

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1076,7 +1076,7 @@ namespace Minio
                                                     headerMap: reqParams)
                                     .ConfigureAwait(false);
 
-            return this.authenticator.PresignURL(this.restClient, request, expiresInt);
+            return this.authenticator.PresignURL(this.restClient, request, expiresInt, Region);
         }
 
         /// <summary>
@@ -1095,7 +1095,7 @@ namespace Minio
                 throw new InvalidExpiryRangeException("expiry range should be between 1 and " + Constants.DefaultExpiryTime.ToString());
             }
             var request = await this.CreateRequest(Method.PUT, bucketName, objectName: objectName).ConfigureAwait(false);
-            return this.authenticator.PresignURL(this.restClient, request, expiresInt);
+            return this.authenticator.PresignURL(this.restClient, request, expiresInt, Region);
         }
 
         /// <summary>

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -257,20 +257,25 @@ namespace Minio
                 
             return signature;
         }
-        
+
         /// <summary>
         /// Presigns any input client object with a requested expiry.
         /// </summary>
         /// <param name="client">Instantiated client</param>
         /// <param name="request">Instantiated request</param>
         /// <param name="expires">Expiration in seconds</param>
+        /// <param name="region">Region of storage</param>
         /// <returns>Presigned url</returns>      
-        public string PresignURL(IRestClient client, IRestRequest request, int expires)
+        public string PresignURL(IRestClient client, IRestRequest request, int expires, string region = "")
         {
             DateTime signingDate = DateTime.UtcNow;
             string requestQuery = "";
             string path = request.Resource;
-            string region = this.getRegion(client.BaseUrl.Host);
+
+            if (string.IsNullOrWhiteSpace(region))
+            {
+                region = this.getRegion(client.BaseUrl.Host);
+            }
 
             requestQuery = "X-Amz-Algorithm=AWS4-HMAC-SHA256&";
             requestQuery += "X-Amz-Credential="


### PR DESCRIPTION
Hi!
I caught the bug with regions
My infrastructure splitted by DC and.. each DC is a region
but presigned url always contains **us-east-1**
this PR fixes problem