### PR TITLE
fix GetObjectAsync api call to check if object is present

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -47,6 +47,8 @@ namespace Minio
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         public async Task GetObjectAsync(string bucketName, string objectName, Action<Stream> cb, CancellationToken cancellationToken = default(CancellationToken))
         {
+            await StatObjectAsync(bucketName, objectName, cancellationToken).ConfigureAwait(false);
+
             var request = await this.CreateRequest(Method.GET,
                                                 bucketName,
                                                 objectName: objectName)
@@ -73,6 +75,9 @@ namespace Minio
                 throw new ArgumentException("Offset should be zero or greater");
             if (length < 0)
                 throw new ArgumentException("Length should be greater than zero");
+
+            await StatObjectAsync(bucketName, objectName, cancellationToken).ConfigureAwait(false);
+
             Dictionary<string, string> headerMap = new Dictionary<string, string>();
             if (length > 0)
                 headerMap.Add("Range", "bytes=" + offset.ToString() + "-" + (offset + length - 1).ToString());


### PR DESCRIPTION
fixes https://github.com/minio/minio/issues/6980

GetObjectAsync api needs to fail with ObjectNotFoundException if GET is attempted on a non-existent object. 

To test this pr, run  GetObject_Test2, GetObject_Test3 and FGetObject_Test1 functional tests with non-existent objects for the GetObjectAsync api overload - with this change, it should fail with ObjectNotFoundException.