### PR TITLE
Remove resuming multipart uploads

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -803,7 +803,7 @@ __Parameters__
 __Example__
 
 
-The maximum size of a single object is limited to 5TB. putObject transparently uploads objects larger than 5MiB in multiple parts. This allows failed uploads to resume safely by only uploading the missing parts. Uploaded data is carefully verified using MD5SUM signatures.
+The maximum size of a single object is limited to 5TB. putObject transparently uploads objects larger than 5MiB in multiple parts. Uploaded data is carefully verified using MD5SUM signatures.
 
 
 ```cs
@@ -864,7 +864,7 @@ __Parameters__
 __Example__
 
 
-The maximum size of a single object is limited to 5TB. putObject transparently uploads objects larger than 5MiB in multiple parts. This allows failed uploads to resume safely by only uploading the missing parts. Uploaded data is carefully verified using MD5SUM signatures.
+The maximum size of a single object is limited to 5TB. putObject transparently uploads objects larger than 5MiB in multiple parts. Uploaded data is carefully verified using MD5SUM signatures.
 
 
 ```cs

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -187,13 +187,11 @@ namespace Minio.Functional.Tests
             // Test Putobject function
             PutObject_Test1(minioClient).Wait();
             PutObject_Test2(minioClient).Wait();
-
             PutObject_Test3(minioClient).Wait();
             PutObject_Test4(minioClient).Wait();
             PutObject_Test5(minioClient).Wait();
             PutObject_Test6(minioClient).Wait();
             PutObject_Test7(minioClient).Wait();
-            PutObject_Test8(minioClient).Wait();
 
             // Test StatObject function
             StatObject_Test1(minioClient).Wait();
@@ -562,53 +560,6 @@ namespace Minio.Functional.Tests
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(15);
             string objectName = GetRandomName(10);
-            string contentType = "application/octet-stream";
-            Dictionary<string,string> args = new Dictionary<string,string>
-            {
-                { "bucketName", bucketName},
-                {"objectName",objectName},
-                {"contentType", contentType},
-                {"data","1MB"},
-                {"size","4MB"},
-            };
-            try
-            {
-                // Putobject call with incorrect size of stream. See if PutObjectAsync call resumes 
-                await Setup_Test(minio, bucketName);
-                using (System.IO.MemoryStream filestream = rsg.GenerateStreamFromSeed(1 * MB))
-                {
-                    try
-                    {
-                        long size = 4 * MB;
-                        long file_write_size = filestream.Length;
-
-                        await minio.PutObjectAsync(bucketName,
-                                                objectName,
-                                                filestream,
-                                                size,
-                                                contentType);
-                    }
-                    catch (UnexpectedShortReadException)
-                    {
-                        // PutObject failed as expected since the stream size is incorrect
-                        // default to actual stream size and complete the upload
-                        await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,rsg.GenerateStreamFromSeed(1 * MB));
-                    }
-                }
-                await TearDown(minio, bucketName);
-                new MintLogger("PutObject_Test4",putObjectSignature1,"Tests whether PutObject with incorrect stream-size passes",TestStatus.PASS,(DateTime.Now - startTime),args:args).Log();
-            }
-            catch (Exception ex)
-            {
-                new MintLogger("PutObject_Test4",putObjectSignature1,"Tests whether PutObject with incorrect stream-size passes",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(),args).Log();
-            }
-        }
-
-        private async static Task PutObject_Test5(MinioClient minio)
-        {
-            DateTime startTime = DateTime.Now;
-            string bucketName = GetRandomName(15);
-            string objectName = GetRandomName(10);
             string fileName = CreateFile(1 * MB, dataFile1MB);
             string contentType = "custom/contenttype";
             Dictionary<string, string> metaData = new Dictionary<string, string>(){
@@ -634,19 +585,18 @@ namespace Minio.Functional.Tests
                 Assert.IsTrue(statMeta.ContainsKey("x-amz-meta-customheader"));
                 Assert.IsTrue(statObject.metaData.ContainsKey("Content-Type") && statObject.metaData["Content-Type"].Equals("custom/contenttype"));
                 await TearDown(minio, bucketName);
-                new MintLogger("PutObject_Test5",putObjectSignature1,"Tests whether PutObject with different content-type passes",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
+                new MintLogger("PutObject_Test4",putObjectSignature1,"Tests whether PutObject with different content-type passes",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
             }
             catch (MinioException ex)
             {
-                new MintLogger("PutObject_Test5",putObjectSignature1,"Tests whether PutObject with different content-type passes",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(),args).Log();
+                new MintLogger("PutObject_Test4",putObjectSignature1,"Tests whether PutObject with different content-type passes",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(),args).Log();
             }
             if (!IsMintEnv())
             {
                 File.Delete(fileName);
             }
         }
-
-        private async static Task PutObject_Test6(MinioClient minio)
+        private async static Task PutObject_Test5(MinioClient minio)
         {
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(15);
@@ -663,14 +613,14 @@ namespace Minio.Functional.Tests
                 await Setup_Test(minio, bucketName);
                 await PutObject_Tester(minio, bucketName, objectName, null, null, 0, null, rsg.GenerateStreamFromSeed(1 * MB));
                 await TearDown(minio, bucketName);
-                new MintLogger("PutObject_Test6",putObjectSignature1,"Tests whether PutObject with no content-type passes for small object",TestStatus.PASS,(DateTime.Now - startTime),args:args).Log();
+                new MintLogger("PutObject_Test5",putObjectSignature1,"Tests whether PutObject with no content-type passes for small object",TestStatus.PASS,(DateTime.Now - startTime),args:args).Log();
             }
             catch (Exception ex)
             {
-                new MintLogger("PutObject_Test6",putObjectSignature1,"Tests whether PutObject with no content-type passes for small object",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
+                new MintLogger("PutObject_Test5",putObjectSignature1,"Tests whether PutObject with no content-type passes for small object",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
             }
         }
-        private async static Task PutObject_Test7(MinioClient minio)
+        private async static Task PutObject_Test6(MinioClient minio)
         {
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(15);
@@ -692,14 +642,14 @@ namespace Minio.Functional.Tests
                 await Task.WhenAll(tasks);
                 await minio.RemoveObjectAsync(bucketName, objectName);
                 await TearDown(minio, bucketName);
-                new MintLogger("PutObject_Test7",putObjectSignature1,"Tests thread safety of minioclient on a parallel put operation",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
+                new MintLogger("PutObject_Test6",putObjectSignature1,"Tests thread safety of minioclient on a parallel put operation",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
             }
             catch (Exception ex)
             {
-                new MintLogger("PutObject_Test7",putObjectSignature1,"Tests thread safety of minioclient on a parallel put operation",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
+                new MintLogger("PutObject_Test6",putObjectSignature1,"Tests thread safety of minioclient on a parallel put operation",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
             }
         }
-        private async static Task PutObject_Test8(MinioClient minio)
+        private async static Task PutObject_Test7(MinioClient minio)
         {
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(15);
@@ -731,11 +681,11 @@ namespace Minio.Functional.Tests
                         await minio.RemoveObjectAsync(bucketName, objectName);
                         await TearDown(minio, bucketName);
                 }
-                new MintLogger("PutObject_Test8",putObjectSignature1,"Tests whether PutObject with unknown stream-size passes",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
+                new MintLogger("PutObject_Test7",putObjectSignature1,"Tests whether PutObject with unknown stream-size passes",TestStatus.PASS,(DateTime.Now - startTime), args:args).Log();
             }
             catch (Exception ex)
             {
-                new MintLogger("PutObject_Test8",putObjectSignature1,"Tests whether PutObject with unknown stream-size passes",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
+                new MintLogger("PutObject_Test7",putObjectSignature1,"Tests whether PutObject with unknown stream-size passes",TestStatus.FAIL,(DateTime.Now - startTime),"",ex.Message, ex.ToString(), args).Log();
             }
         }
         private async static Task PutGetStatEncryptedObject_Test1(MinioClient minio)

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -126,7 +126,7 @@ namespace Minio
         }
 
         /// <summary>
-        /// Constructs a RestRequest. For AWS, this function has the side-effect of overriding the baseUrl 
+        /// Constructs a RestRequest. For AWS, this function has the side-effect of overriding the baseUrl
         /// in the RestClient with region specific host path or virtual style path.
         /// </summary>
         /// <param name="method">HTTP method</param>
@@ -162,7 +162,8 @@ namespace Minio
             {
                 this.restClient.Authenticator = new V4Authenticator(this.Secure, this.AccessKey, this.SecretKey);
             }
-            else {
+            else
+            {
                 this.restClient.Authenticator = new V4Authenticator(this.Secure, this.AccessKey, this.SecretKey, this.Region);
             }
 
@@ -213,7 +214,7 @@ namespace Minio
                 resource += utils.EncodePath(objectName);
             }
 
-            // Append query string passed in 
+            // Append query string passed in
             if (resourcePath != null)
             {
                 resource += resourcePath;
@@ -303,7 +304,7 @@ namespace Minio
             this.AccessKey = accessKey;
             this.SecretKey = secretKey;
             this.Region = region;
-            // Instantiate a region cache 
+            // Instantiate a region cache
             this.regionCache = BucketRegionCache.Instance;
 
             initClient();
@@ -436,7 +437,7 @@ namespace Minio
                                 BucketRegionCache.Instance.Remove(resource);
                                 e = new BucketNotFoundException(resource, "Not found.");
                             }
-                    
+
                         }
                         else
                         {
@@ -470,11 +471,11 @@ namespace Minio
             if (response.StatusCode.Equals(HttpStatusCode.NotFound) && response.Request.Resource.EndsWith("?policy")
                 && response.Request.Method.Equals(Method.GET) && (errResponse.Code.Equals("NoSuchBucketPolicy")))
             {
-                
+
                 ErrorResponseException ErrorException = new ErrorResponseException(errResponse.Message,errResponse.Code);
                 ErrorException.Response = errResponse;
                 ErrorException.XmlError = response.Content;
-                throw ErrorException;          
+                throw ErrorException;
             }
 
             MinioException MinioException = new MinioException(errResponse.Message);
@@ -505,7 +506,7 @@ namespace Minio
             foreach (var handler in handlers)
             {
                 handler(response);
-            }            
+            }
             // Fall back default error handler
             _defaultErrorHandlingDelegate(response);
 
@@ -527,7 +528,7 @@ namespace Minio
         }
 
         /// <summary>
-        /// Logs the request sent to server and corresponding response 
+        /// Logs the request sent to server and corresponding response
         /// </summary>
         /// <param name="request"></param>
         /// <param name="response"></param>


### PR DESCRIPTION
ListParts is never fully complete in its output,
there is always a possibility that the List is
partial where another PutObjectPart() is being
uploaded in parallel.

While it may seem like ListParts and ListMultipartUploads
provide the possibility of resuming an upload, it would
be a mistake as these APIs were inherently never meant do
these things. This is one of the reasons why Amazon
recommends that one should avoid using these API calls to
complete or add parts to an upload - they instead
recommend to remember the parts being uploaded at the client.