### PR TITLE
Fix case-sensitive comparison for `ETag`

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -865,7 +865,7 @@ namespace Minio
                 {
                     lastModified = DateTime.Parse(parameter.Value.ToString());
                 }
-                else if (parameter.Name.Equals("ETag"))
+                else if (parameter.Name.Equals("ETag", StringComparison.OrdinalIgnoreCase))
                 {
                     etag = parameter.Value.ToString().Replace("\"", "");
                 }


### PR DESCRIPTION
We were having issues where sometimes the `ETag` header parameter would come as `Etag`, which would cause `ObjectStat.ETag` to be an empty string.

Making the string comparison case-insensitive fixed the issue.