### PR TITLE
Trim extra spaces in metadata for canonicalized request

### DIFF
--- a/Minio.Examples/Cases/PutObject.cs
+++ b/Minio.Examples/Cases/PutObject.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using Minio.DataModel;
@@ -47,11 +48,16 @@ namespace Minio.Examples.Cases
                     {
                         Console.Out.WriteLine("Running example for API: PutObjectAsync with Stream and MultiPartUpload");
                     }
+                    var metaData = new Dictionary<string, string>()
+                                    {
+                                        {"X-Amz-Meta-Test", "Test  Test"}
+                                    };
                     await minio.PutObjectAsync(bucketName,
                                                objectName,
                                                filestream,
                                                filestream.Length,
                                                "application/octet-stream",
+                                               metaData: metaData,
                                                sse:sse);
                 }
             

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -565,7 +565,7 @@ namespace Minio.Functional.Tests
             string fileName = CreateFile(1 * MB, dataFile1MB);
             string contentType = "custom/contenttype";
             Dictionary<string, string> metaData = new Dictionary<string, string>(){
-                { "x-amz-meta-customheader", "minio-dotnet"}
+                { "x-amz-meta-customheader", "minio   dotnet"}
             };
             Dictionary<string,string> args = new Dictionary<string,string>
             {
@@ -1408,7 +1408,7 @@ namespace Minio.Functional.Tests
                 {
                     await minio.PutObjectAsync(bucketName,
                                             objectName,
-                                            filestream, filestream.Length, metaData:new Dictionary<string,string>{{"X-Amz-Meta-Orig", "orig-val"}});
+                                            filestream, filestream.Length, metaData:new Dictionary<string,string>{{"X-Amz-Meta-Orig", "orig-val with  spaces"}});
                 }
                 ObjectStat stats = await minio.StatObjectAsync(bucketName, objectName);
                 Assert.IsTrue(stats.metaData["X-Amz-Meta-Orig"] != null);
@@ -1420,7 +1420,7 @@ namespace Minio.Functional.Tests
                 Dictionary<string,string> metadata = new Dictionary<string,string>()
                 {
                     { "Content-Type", "application/css"},
-                    {"X-Amz-Meta-Mynewkey","my-new-value"}
+                    {"X-Amz-Meta-Mynewkey","test   test"}
                 };
                 await minio.CopyObjectAsync(bucketName, objectName, destBucketName, destObjectName,copyConditions:copyCond,metadata: metadata);
 

--- a/Minio/Helper/s3utils.cs
+++ b/Minio/Helper/s3utils.cs
@@ -16,11 +16,15 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 namespace Minio.Helper
 {
     internal class s3utils
     {
+
+        internal static readonly Regex TrimWhitespaceRegex = new Regex("\\s+");
+
         internal static bool IsAmazonEndPoint(string endpoint)
         {
             if (IsAmazonChinaEndPoint(endpoint))
@@ -92,6 +96,13 @@ namespace Minio.Helper
             byte tempForParsing;
 
             return splitValues.All(r => byte.TryParse(r, out tempForParsing));
+        }
+
+        // TrimAll trims leading and trailing spaces and replace sequential spaces with one space, following Trimall()
+        // in http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+        internal static string TrimAll(string s)
+        {
+            return TrimWhitespaceRegex.Replace(s, " ").Trim();
         }
     }
 }

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -345,7 +345,7 @@ namespace Minio
                 path = "/" + path;
             }
             canonicalStringList.AddLast(path);
-            String query = headersToSign.Aggregate(requestQuery, (pv, cv) => $"{pv}&{utils.UrlEncode(cv.Key)}={utils.UrlEncode(cv.Value)}");
+            String query = headersToSign.Aggregate(requestQuery, (pv, cv) => $"{pv}&{utils.UrlEncode(cv.Key)}={utils.UrlEncode(s3utils.TrimAll(cv.Value))}");
             canonicalStringList.AddLast(query);
             if (client.BaseUrl.Port > 0 && (client.BaseUrl.Port != 80 && client.BaseUrl.Port != 443))
             {
@@ -409,7 +409,7 @@ namespace Minio
 
             foreach (string header in headersToSign.Keys)
             {
-                canonicalStringList.AddLast(header + ":" + headersToSign[header]);
+                canonicalStringList.AddLast(header + ":" + s3utils.TrimAll(headersToSign[header]));
             }
             canonicalStringList.AddLast("");
             canonicalStringList.AddLast(string.Join(";", headersToSign.Keys));


### PR DESCRIPTION
S3 Spec requires canonicalized header string to have all extra
spaces trimmed down to a single space. This PR fixes #277, where
metadata with extra spaces in the value was causing a signature
verification mismatch.