### PR TITLE
Fix Presigned Operations tables in documentation

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1172,7 +1172,7 @@ __Parameters__
 
 | Return Type	  | Exceptions	  |
 |:--- |:--- |
-|  ``Task<string>`` : string contains URL to download the object | Listed Exceptions: |
+|  ``Task<string>`` : string contains URL to upload the object | Listed Exceptions: |
 |        |  ``InvalidBucketNameException`` : upon invalid bucket name |
 |        | ``InvalidKeyException`` : upon an invalid access key or secret key           |
 |        | ``ConnectionException`` : upon connection error            |

--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1131,6 +1131,7 @@ __Parameters__
 | ``objectName``  | _String_  | Object name in the bucket |
 | ``expiresInt``  | _Integer_  | Expiry in seconds. Default expiry is set to 7 days. |
 | ``reqParams``   | _Dictionary<string,string>_ | Additional response header overrides supports response-expires, response-content-type, response-cache-control, response-content-disposition.|
+
 | Return Type	  | Exceptions	  |
 |:--- |:--- |
 |  ``Task<string>`` : string contains URL to download the object | Listed Exceptions: |


### PR DESCRIPTION
Fix return type of PresignedPutObjectAsync:
- The return type for this function should be "string contains URL to
upload the object" instead of "string contains URL to download the
object"

Separate the two tables in PresignedGetObjectAsync:
- Add blank line to separate two tables in PresignedGetObjectAsync
- This gets rid of the row with two cells of `:---` between these tables