### PR TITLE
Fix malformed authorization header.

### DIFF
--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -156,7 +156,7 @@ namespace Minio
         private string GetAuthorizationHeader(string signedHeaders, string signature, DateTime signingDate, string region)
         {
             var scope = this.GetScope(region, signingDate);
-            return $"AWS4-HMAC-SHA256 Credential={this.accessKey}/{scope}/, SignedHeaders={signedHeaders} Signature={signature}";
+            return $"AWS4-HMAC-SHA256 Credential={this.accessKey}/{scope}, SignedHeaders={signedHeaders}, Signature={signature}";
         }
 
         /// <summary>


### PR DESCRIPTION
#322 Introduced a bug in V4Authenticator class that generates malformed Authorization header and authentication to the minio server fails.
This change addresses the issue.