### PR TITLE
Prevent deadlock by adding ConfigureAwait(false)

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -274,7 +274,7 @@ namespace Minio
             using (var stream = new MemoryStream(contentBytes))
             using (var streamReader = new StreamReader(stream))
             {
-                policyString = await streamReader.ReadToEndAsync();
+                policyString = await streamReader.ReadToEndAsync().ConfigureAwait(false);
             }
             return policyString;
         }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -364,7 +364,7 @@ namespace Minio
                 Console.WriteLine($"Full URL of Request {fullUrl}");
             }
 
-            IRestResponse response = await this.restClient.ExecuteTaskAsync(request, cancellationToken);
+            IRestResponse response = await this.restClient.ExecuteTaskAsync(request, cancellationToken).ConfigureAwait(false);
 
             this.HandleIfErrorResponse(response, errorHandlers, startTime);
             return response;


### PR DESCRIPTION
Fixes #325 - A couple of calls are still passing caller context
to continuation tasks - add ConfigureAwait(false) to disallow
continuation after await from running in caller context.