### PR TITLE
Set encoding-type to url for ListObjectsAsync call

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -209,6 +209,7 @@ namespace Minio
             queries.Add("prefix=" + Uri.EscapeDataString(prefix));
             queries.Add("max-keys=1000");
             queries.Add("marker=" + Uri.EscapeDataString(marker));
+            queries.Add("encoding-type=url");
 
             string query = string.Join("&", queries);
 


### PR DESCRIPTION
Needed to avoid illegal characters in xml documents - see context in https://github.com/minio/minio-go/pull/1161
