### PR TITLE
Make ReadFull asynchronous

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -246,7 +246,7 @@ namespace Minio
             // for sizes less than 5Mb , put a single object
             if (size < Constants.MinimumPartSize && size >= 0)
             {
-                var bytes = ReadFull(data, (int)size);
+                var bytes = await ReadFullAsync(data, (int)size).ConfigureAwait(false);
                 if (bytes != null && bytes.Length != (int)size)
                 {
                     throw new UnexpectedShortReadException($"Data read {bytes.Length} is shorter than the size {size} of input buffer.");
@@ -279,7 +279,7 @@ namespace Minio
             int numPartsUploaded = 0;
             for (partNumber = 1; partNumber <= partCount; partNumber++)
             {
-                byte[] dataToCopy = ReadFull(data, (int)partSize);
+                byte[] dataToCopy = await ReadFullAsync(data, (int)partSize).ConfigureAwait(false);
                 if (dataToCopy == null && numPartsUploaded > 0)
                 {
                     break;
@@ -827,14 +827,14 @@ namespace Minio
         /// <param name="data"></param>
         /// <param name="currentPartSize"></param>
         /// <returns>bytes read in a byte array</returns>
-        internal byte[] ReadFull(Stream data, int currentPartSize)
+        internal async Task<byte[]> ReadFullAsync(Stream data, int currentPartSize)
         {
             byte[] result = new byte[currentPartSize];
             int totalRead = 0;
             while (totalRead < currentPartSize)
             {
                 byte[] curData = new byte[currentPartSize - totalRead];
-                int curRead = data.Read(curData, 0, currentPartSize - totalRead);
+                int curRead = await data.ReadAsync(curData, 0, currentPartSize - totalRead).ConfigureAwait(false);
                 if (curRead == 0)
                 {
                     break;


### PR DESCRIPTION
The callers are already asynchronous, so there's no reason why reading from the input stream shouldn't be as well.

Plus Kestrel in its default configuration does not like synchronous operations:
```
System.InvalidOperationException: Synchronous operations are disallowed. Call ReadAsync or set AllowSynchronousIO to true instead.
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpRequestStream.Read(Byte[] buffer, Int32 offset, Int32 count)
   at Minio.MinioClient.ReadFull(Stream data, Int32 currentPartSize) in /q/.q/sources/minio-dotnet/Minio/ApiEndpoints/ObjectOperations.cs:line 838
```