### PR TITLE
Add ListObjectEnumerableAsync and fix await of RemoveObjectAsync

### DIFF
--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;netstandard2.0;net46</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <Optimize>true</Optimize>
@@ -40,6 +40,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Framework References">
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'" Label="Framework References">
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently when using ListObjectsAsync the call doesn't stop until the observable gets destroyed.
Also the Observable doesn't wait and just spams the API with requests no matter if the result is actually consumed. This is bad if there are a lot of files in the bucket.

With this PR I added a new implementation that uses the new IAsyncEnumerable which is part of .netstandard2.1 to only query for new files once they are actually required. That's why I added .netstandard2.1 as multitarget framework.

Also I changed the result of RemoveObjectAsync to be an enumerable instead of an Observable cause in my opinion an observable doesn't make sense in that case at all. This problem even caused our production environment to become unstable when we did a cleanup cause I didn't await the returned observable and it flooded our prod environment with requests. `Task<IObservable<DeleteError>>` doesn't make sense at all as even so I do "await RemoveObjectAsync(...)", it returns the Observable which I then have to await again?! It just doesn't make sense to me.
I was thinking about implementing IAsyncEnumerable aswell but that would require an enumeration for files to get deleted so I think the most obvious result would be an IEnumerable with the errors once everything is done.

I will implement/fix tests that's why it's a draft right now but would love to hear your thoughts