### PR TITLE
Fix canned ACLs being treated as metadata

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -446,8 +446,7 @@ namespace Minio.Functional.Tests
             string contentType = "custom/contenttype";
             var metaData = new Dictionary<string, string>
             {
-                { "customheader", "minio   dotnet" },
-                { "x-amz-acl", "public-read" }
+                { "customheader", "minio   dotnet" }
             };
             var args = new Dictionary<string, string>
             {
@@ -467,8 +466,6 @@ namespace Minio.Functional.Tests
                 var statMeta = new Dictionary<string, string>(statObject.MetaData, StringComparer.OrdinalIgnoreCase);
                 Assert.IsTrue(statMeta.ContainsKey("X-Amz-Meta-Customheader"));
                 Assert.IsTrue(statObject.MetaData.ContainsKey("Content-Type") && statObject.MetaData["Content-Type"].Equals("custom/contenttype"));
-                Assert.IsTrue(statObject.MetaData.ContainsKey("x-amz-acl"));
-                Assert.AreEqual("public-read", statObject.MetaData["x-amz-acl"]);
                 await TearDown(minio, bucketName);
                 new MintLogger(nameof(PutObject_Test4), putObjectSignature1, "Tests whether PutObject with different content-type passes", TestStatus.PASS, (DateTime.Now - startTime), args:args).Log();
             }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -446,7 +446,8 @@ namespace Minio.Functional.Tests
             string contentType = "custom/contenttype";
             var metaData = new Dictionary<string, string>
             {
-                { "customheader", "minio   dotnet" }
+                { "customheader", "minio   dotnet" },
+                { "x-amz-acl", "public-read" }
             };
             var args = new Dictionary<string, string>
             {
@@ -466,6 +467,8 @@ namespace Minio.Functional.Tests
                 var statMeta = new Dictionary<string, string>(statObject.MetaData, StringComparer.OrdinalIgnoreCase);
                 Assert.IsTrue(statMeta.ContainsKey("X-Amz-Meta-Customheader"));
                 Assert.IsTrue(statObject.MetaData.ContainsKey("Content-Type") && statObject.MetaData["Content-Type"].Equals("custom/contenttype"));
+                Assert.IsTrue(statObject.MetaData.ContainsKey("x-amz-acl"));
+                Assert.AreEqual("public-read", statObject.MetaData["x-amz-acl"]);
                 await TearDown(minio, bucketName);
                 new MintLogger(nameof(PutObject_Test4), putObjectSignature1, "Tests whether PutObject with different content-type passes", TestStatus.PASS, (DateTime.Now - startTime), args:args).Log();
             }

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -34,7 +34,7 @@ namespace Minio
 {
     public partial class MinioClient : IObjectOperations
     {
-        List<string> supportedHeaders = new List<string> { "cache-control", "content-encoding", "content-type" };
+        List<string> supportedHeaders = new List<string> { "cache-control", "content-encoding", "content-type", "x-amz-acl" };
 
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.


### PR DESCRIPTION
Fixes #361 in the simplest manner I could find.