### PR TITLE
Make multipart sizes configurable and increase defaults

### DIFF
--- a/Minio.Tests/UtilsTest.cs
+++ b/Minio.Tests/UtilsTest.cs
@@ -29,6 +29,8 @@ namespace Minio.Tests
     [TestClass]
     public class UtilsTest
     {
+        private const long minimumPartSize = 5 * 1024L * 1024L;
+
         [TestMethod]
         [ExpectedException(typeof(InvalidBucketNameException))]
         public void TestValidBucketName()
@@ -125,7 +127,7 @@ namespace Minio.Tests
         {
             try
             {
-                Object multiparts = utils.CalculateMultiPartSize(5000000000000000000);
+                (long partSize, int partCount, long lastPartSize) multiparts = utils.CalculateMultiPartSize(5_000_000_000_000_000_000, minimumPartSize);
             }
             catch (EntityTooLargeException ex)
             {
@@ -138,25 +140,28 @@ namespace Minio.Tests
         public void TestValidPartSize1()
         {
             // { partSize = 550502400, partCount = 9987, lastPartSize = 241172480 }
-            dynamic partSizeObject = utils.CalculateMultiPartSize(5497558138880);
-            double partSize = partSizeObject.partSize;
-            double partCount = partSizeObject.partCount;
-            double lastPartSize = partSizeObject.lastPartSize;
-            Assert.AreEqual(partSize, 550502400);
-            Assert.AreEqual(partCount, 9987);
-            Assert.AreEqual(lastPartSize, 241172480);
+            (long partSize, int partCount, long lastPartSize) = utils.CalculateMultiPartSize(5_497_558_138_880, minimumPartSize);
+            Assert.AreEqual(partSize, 550_502_400);
+            Assert.AreEqual(partCount, 9_987);
+            Assert.AreEqual(lastPartSize, 241_172_480);
         }
 
         [TestMethod]
         public void TestValidPartSize2()
         {
-            dynamic partSizeObject = utils.CalculateMultiPartSize(5000000000);
-            double partSize = partSizeObject.partSize;
-            double partCount = partSizeObject.partCount;
-            double lastPartSize = partSizeObject.lastPartSize;
-            Assert.AreEqual(partSize, 5242880);
+            (long partSize, int partCount, long lastPartSize) = utils.CalculateMultiPartSize(5_000_000_000, minimumPartSize);
+            Assert.AreEqual(partSize, 5_242_880);
             Assert.AreEqual(partCount, 954);
-            Assert.AreEqual(lastPartSize, 3535360);
+            Assert.AreEqual(lastPartSize, 3_535_360);
+        }
+
+        [TestMethod]
+        public void TestValidPartSize3()
+        {
+            (long partSize, int partCount, long lastPartSize) = utils.CalculateMultiPartSize(5_000_000_000, 512 * 1024L * 1024L);
+            Assert.AreEqual(partSize, 536_870_912);
+            Assert.AreEqual(partCount, 10);
+            Assert.AreEqual(lastPartSize, 168_161_792);
         }
 
         [TestMethod]

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -64,12 +64,23 @@ namespace Minio
         /// <param name="bucketName">Bucket to create object in</param>
         /// <param name="objectName">Key of the new object</param>
         /// <param name="data">Stream of file to upload</param>
-        /// <param name="size">Size of stream</param>
+        /// <param name="size">Total size of bytes to be written, must match stream length</param>
         /// <param name="contentType">Content type of the new object, null defaults to "application/octet-stream"</param>
         /// <param name="metaData">Optional Object metadata to be stored. Defaults to null.</param>
         /// <param name="sse">Optional Server-side encryption option. Defaults to null.</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, string contentType = null, Dictionary<string, string> metaData = null, ServerSideEncryption sse = null, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Creates an object from file input stream
+        /// </summary>
+        /// <param name="bucketName">Bucket to create object in</param>
+        /// <param name="objectName">Key of the new object</param>
+        /// <param name="data">Stream of bytes to send</param>
+        /// <param name="size">Total size of bytes to be written, must match stream length</param>
+        /// <param name="options">Allows user to set optional custom metadata, content headers, encryption keys, and transfer limits. Can be null.</param>
+        /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+        Task PutObjectAsync(string bucketName, string objectName, Stream data, long size, MinioPutObjectOptions options, CancellationToken cancellationToken);
 
         /// <summary>
         /// Removes an object with given name in specific bucket

--- a/Minio/ApiEndpoints/MinioPutObjectOptions.cs
+++ b/Minio/ApiEndpoints/MinioPutObjectOptions.cs
@@ -1,0 +1,47 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+using Minio.DataModel;
+
+namespace Minio
+{
+    public class MinioPutObjectOptions
+    {
+        public static readonly long DefaultUploadPartSize = 64 * 1024L * 1024L;
+
+        /// <summary>
+        /// Content type of the new object, null defaults to "application/octet-stream"
+        /// </summary>
+        public string ContentType { get; set; } = null;
+
+        /// <summary>
+        /// Object metadata to be stored. Defaults to null.
+        /// </summary>
+        public Dictionary<string, string> MetaData { get; set; } = null;
+
+        /// <summary>
+        /// Server-side encryption option. Defaults to null.
+        /// </summary>
+        public ServerSideEncryption ServerSideEncryption { get; set; } = null;
+        
+        /// <summary>
+        /// Change the default for multipart part sizes when uploading through client
+        /// </summary>
+        public long? PartSize { get; set; } = DefaultUploadPartSize;
+    }
+}

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -37,6 +37,7 @@
 
     <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Framework References">

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -62,6 +62,8 @@ namespace Minio
         // Cache holding bucket to region mapping for buckets seen so far.
         internal BucketRegionCache regionCache;
 
+        private readonly long defaultServerTransferPartSize;
+
         private IRequestLogger logger;
 
         // Enables HTTP tracing if set to true
@@ -309,15 +311,26 @@ namespace Minio
         /// <param name="sessionToken">Optional session token</param>
         /// <returns>Client initialized with user credentials</returns>
         public MinioClient(string endpoint, string accessKey = "", string secretKey = "", string region = "", string sessionToken = "")
+            : this(new MinioClientConfig {Endpoint = endpoint, AccessKey = accessKey, SecretKey = secretKey, Region = region, SessionToken = sessionToken})
         {
-            this.Secure = false;
+        }
+
+        /// <summary>
+        /// Creates and returns an Cloud Storage client 
+        /// </summary>
+        /// <param name="config">Configuration overrides</param>
+        /// <returns>Client initialized with user credentials</returns>
+        public MinioClient(MinioClientConfig config)
+        {
+            this.Secure = config.Secure;
 
             // Save user entered credentials
-            this.BaseUrl = endpoint;
-            this.AccessKey = accessKey;
-            this.SecretKey = secretKey;
-            this.SessionToken = sessionToken;
-            this.Region = region;
+            this.BaseUrl = config.Endpoint;
+            this.AccessKey = config.AccessKey;
+            this.SecretKey = config.SecretKey;
+            this.SessionToken = config.SessionToken;
+            this.Region = config.Region;
+            this.defaultServerTransferPartSize = config.DefaultServerTransferPartSize;
             // Instantiate a region cache
             this.regionCache = BucketRegionCache.Instance;
 

--- a/Minio/MinioClientConfig.cs
+++ b/Minio/MinioClientConfig.cs
@@ -1,0 +1,60 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Minio
+{
+    /// <summary>
+    /// Configuration parameters for <see cref="MinioClient"/>
+    /// </summary>
+    public class MinioClientConfig
+    {
+        /// <summary>
+        /// Location of the server, supports HTTP and HTTPS
+        /// </summary>
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// Connect to Cloud Storage with HTTPS
+        /// </summary>
+        public bool Secure { get; set; } = false;
+
+        /// <summary>
+        /// Access Key for authenticated requests (Optional, can be omitted for anonymous requests)
+        /// </summary>
+        public string AccessKey { get; set; } = "";
+
+        /// <summary>
+        /// Secret Key for authenticated requests (Optional, can be omitted for anonymous requests)
+        /// </summary>
+        public string SecretKey { get; set; } = "";
+
+        /// <summary>
+        /// Optional custom region
+        /// </summary>
+        public string Region { get; set; } = "";
+
+        /// <summary>
+        /// Optional session token
+        /// </summary>
+        public string SessionToken { get; set; } = "";
+
+        /// <summary>
+        /// Change the default for multipart part sizes when transferring between servers
+        /// </summary>
+        public long DefaultServerTransferPartSize { get; set; } = 512 * 1024L * 1024L;
+    }
+}


### PR DESCRIPTION
Addresses issue #372 to speed up multipart uploads and inter-server transfers by making the client more configurable with higher defaults for multipart part sizes.

* Adds a constructor to `MinioClient` that takes a single `MinioClientConfig` object for future extensibility.
* Adds new option `DefaultServerTransferPartSize`, with a default of 512 MiB
* Removes use of `dynamic` and uses value tuple returns from `CalculateMultiPartSize()`
* Added additional tests for a configurable `minimumPartSize` in `CalculateMultiPartSize()`.
* Adds `MinioPutObjectOptions` object for `PutObjectAsync`, reflecting Go client.  Includes a new option `PartSize`, with a default of 64 MiB