### PR TITLE
Fix for issue: MakeBucketAsync returns deserialization exception if BucketName is null

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -300,6 +300,28 @@ namespace Minio.Functional.Tests
             }
         }
 
+        internal async static Task MakeBucket_Test5(MinioClient minio)
+        {
+            DateTime startTime = DateTime.Now;
+            string bucketName = null;
+            var args = new Dictionary<string, string>
+            {
+                { "bucketName", bucketName },
+                { "region", "us-east-1" },
+            };
+
+            try
+            {
+                await Assert.ThrowsExceptionAsync<InvalidBucketNameException>(() =>
+                    minio.MakeBucketAsync(bucketName));
+                new MintLogger(nameof(MakeBucket_Test5), makeBucketSignature, "Tests whether MakeBucket throws InvalidBucketNameException when bucketName is null", TestStatus.PASS, (DateTime.Now - startTime), args: args).Log();
+            }
+            catch (MinioException ex)
+            {
+                new MintLogger(nameof(MakeBucket_Test5), makeBucketSignature, "Tests whether MakeBucket throws InvalidBucketNameException when bucketName is null", TestStatus.FAIL, (DateTime.Now - startTime), "", ex.Message, ex.ToString(), args).Log();
+            }
+        }
+
         #endregion
 
         internal async static Task RemoveBucket_Test1(MinioClient minio)

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -85,6 +85,8 @@ namespace Minio.Functional.Tests
             // Create a new bucket
             FunctionalTest.MakeBucket_Test1(minioClient).Wait();
             FunctionalTest.MakeBucket_Test2(minioClient).Wait();
+            FunctionalTest.MakeBucket_Test5(minioClient).Wait();
+
             if (useAWS)
             {
                 FunctionalTest.MakeBucket_Test3(minioClient).Wait();

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -63,8 +63,14 @@ namespace Minio
         /// <param name="location">Region</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <returns> Task </returns>
+        /// <exception cref="InvalidBucketNameException">When bucketName is null</exception>
         public async Task MakeBucketAsync(string bucketName, string location = "us-east-1", CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (bucketName == null)
+            {
+                throw new InvalidBucketNameException(bucketName, "buckentName cannot be null");
+            }
+
             if (location == "us-east-1")
             {
                 if (this.Region != string.Empty)

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -68,7 +68,7 @@ namespace Minio
         {
             if (bucketName == null)
             {
-                throw new InvalidBucketNameException(bucketName, "buckentName cannot be null");
+                throw new InvalidBucketNameException(bucketName, "bucketName cannot be null");
             }
 
             if (location == "us-east-1")


### PR DESCRIPTION
Throw ```InvalidBucketNameException``` from ```MakeBucketAsync``` when bucketName name is null.