### PR TITLE
Bumped RestSharp version to 106.10.1

### DIFF
--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -36,7 +36,7 @@
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All" />
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All" />
 
-    <PackageReference Include="RestSharp" Version="106.3.1" />
+    <PackageReference Include="RestSharp" Version="106.10.1" />
     <PackageReference Include="System.Reactive.Linq" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I am working on a project that uses Minio. A different package in this project uses a more recent version of RestSharp, which causes trouble. This request just bumps the version to 106.10.1, there are no breaking changes between the RestSharp versions.