### PR TITLE
Retry policy callback for the MinioClient

### DIFF
--- a/Minio.Examples/Cases/RetryPolicyObject.cs
+++ b/Minio.Examples/Cases/RetryPolicyObject.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio.Examples/Cases/RetryPolicyObject.cs
+++ b/Minio.Examples/Cases/RetryPolicyObject.cs
@@ -1,0 +1,116 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading.Tasks;
+
+using Minio.Exceptions;
+
+using Polly;
+
+using RestSharp;
+
+namespace Minio.Examples.Cases
+{
+    static class RetryPolicyHelper
+    {
+        private const int defaultRetryCount = 3;
+        private static readonly TimeSpan defaultRetryInterval = TimeSpan.FromMilliseconds(200);
+        private static readonly TimeSpan defaultMaxRetryInterval = TimeSpan.FromSeconds(10);
+
+        // exponential backoff with jitter, truncated by max retry interval
+        public static TimeSpan CalcBackoff(int retryAttempt, TimeSpan retryInterval, TimeSpan maxRetryInterval)
+        {
+            // 0.8..1.2
+            var jitter = 0.8 + new Random(Environment.TickCount).NextDouble() * 0.4;
+            // (2^retryCount - 1) * jitter
+            var scaleCoeff = (Math.Pow(2.0, retryAttempt) - 1.0) * jitter;
+            // Apply scale coefficient
+            var result = TimeSpan.FromMilliseconds(retryInterval.TotalMilliseconds * scaleCoeff);
+            // Truncate by max retry interval
+            return result < maxRetryInterval ? result : maxRetryInterval;
+        }
+
+        public static PolicyBuilder<IRestResponse> CreatePolicyBuilder()
+        {
+            return Policy<IRestResponse>
+                .Handle<ConnectionException>()
+                .Or<InternalClientException>(ex => ex.Message.StartsWith("Unsuccessful response from server"));
+        }
+
+        public static AsyncPolicy<IRestResponse> GetDefaultRetryPolicy() =>
+            GetDefaultRetryPolicy(defaultRetryCount, defaultRetryInterval, defaultMaxRetryInterval);
+
+        public static AsyncPolicy<IRestResponse> GetDefaultRetryPolicy(
+            int retryCount,
+            TimeSpan retryInterval,
+            TimeSpan maxRetryInterval) =>
+            CreatePolicyBuilder()
+                .WaitAndRetryAsync(
+                    retryCount,
+                    i => CalcBackoff(i, retryInterval, maxRetryInterval));
+
+        public static RetryPolicyHandlingDelegate AsRetryDelegate(this AsyncPolicy<IRestResponse> policy) =>
+            policy == null
+                ? (RetryPolicyHandlingDelegate)null
+                : async executeCallback => await policy.ExecuteAsync(executeCallback);
+
+        public static MinioClient WithRetryPolicy(this MinioClient client, AsyncPolicy<IRestResponse> policy) =>
+            client.WithRetryPolicy(policy.AsRetryDelegate());
+    }
+
+    class RetryPolicyObject
+    {
+        // Polly retry policy sample
+        public async static Task Run(MinioClient minio,
+            string bucketName = "my-bucket-name",
+            string bucketObject = "my-object-name")
+        {
+            try
+            {
+                var customPolicy = RetryPolicyHelper
+                    .CreatePolicyBuilder()
+                    .Or<BucketNotFoundException>()
+                    .RetryAsync(
+                        2,
+                        (r, i) => Console.WriteLine($"On retry #{i}. Result: {r.Exception?.Message}"));
+
+                minio.WithRetryPolicy(customPolicy);
+
+                Console.WriteLine("Running example for API: RetryPolicyObject");
+
+                try
+                {
+                    await minio.GetObjectAsync("bad-bucket", "bad-file", s => { });
+                }
+                catch (BucketNotFoundException ex)
+                {
+                    Console.WriteLine("Request failed: " + ex.Message);
+                }
+
+                Console.WriteLine();
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"[StatObject] {bucketName}-{bucketObject} Exception: {e}");
+            }
+            finally
+            {
+                minio.WithRetryPolicy(null);
+            }
+        }
+    }
+}

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -6,6 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Polly" Version="7.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -220,6 +220,9 @@ namespace Minio.Examples
                 // Delete the object
                 Cases.RemoveObject.Run(minioClient, destBucketName, objectName).Wait();
 
+                // Retry on failure
+                Cases.RetryPolicyObject.Run(minioClient, destBucketName, objectName).Wait();
+
                 // Tracing request with custom logger
                 Cases.CustomRequestLogger.Run(minioClient).Wait();
 

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -1,0 +1,78 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Minio.Exceptions;
+
+namespace Minio.Tests
+{
+    [TestClass]
+    public class RetryHandlerTest
+    {
+        [TestMethod]
+        public async Task TestRetryPolicyOnSuccess()
+        {
+            var client = new MinioClient("example.com");
+
+            int invokeCount = 0;
+            client.WithRetryPolicy(
+                async (callback) =>
+                {
+                    invokeCount++;
+                    return await callback();
+                });
+
+            var result = await client.BucketExistsAsync(Guid.NewGuid().ToString());
+            Assert.IsFalse(result);
+            Assert.AreEqual(invokeCount, 1);
+        }
+
+        [TestMethod]
+        public async Task TestRetryPolicyOnFailure()
+        {
+            var client = new MinioClient("example.com");
+
+            int invokeCount = 0;
+            var retryCount = 3;
+            client.WithRetryPolicy(
+                async (callback) =>
+                {
+                    Exception exception = null;
+                    for (int i = 0; i < retryCount; i++)
+                    {
+                        invokeCount++;
+                        try
+                        {
+                            return await callback();
+                        }
+                        catch (BucketNotFoundException ex)
+                        {
+                            exception = ex;
+                        }
+                    }
+                    throw exception;
+                });
+
+            await Assert.ThrowsExceptionAsync<BucketNotFoundException>(
+                () => client.GetObjectAsync(Guid.NewGuid().ToString(), "", s => { }));
+            Assert.AreEqual(invokeCount, retryCount);
+        }
+    }
+}

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -29,7 +29,9 @@ namespace Minio.Tests
         [TestMethod]
         public async Task TestRetryPolicyOnSuccess()
         {
-            var client = new MinioClient("example.com");
+            var client = new MinioClient("play.min.io",
+                                         "Q3AM3UQ867SPQQA43P2F",
+                                         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG").WithSSL();
 
             int invokeCount = 0;
             client.WithRetryPolicy(

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -47,7 +47,9 @@ namespace Minio.Tests
         [TestMethod]
         public async Task TestRetryPolicyOnFailure()
         {
-            var client = new MinioClient("example.com");
+            var client = new MinioClient("play.min.io",
+                                         "Q3AM3UQ867SPQQA43P2F",
+                                         "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG").WithSSL();
 
             int invokeCount = 0;
             var retryCount = 3;

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -413,14 +413,6 @@ namespace Minio
                                                                     resourcePath: "?" + query)
                                                         .ConfigureAwait(false);
 
-                            var startTime = DateTime.Now;
-                            // Logs full url when HTTPtracing is enabled (as in MinioClient.ExecuteTaskAsync)
-                            if (this.trace)
-                            {
-                                var fullUrl = this.restClient.BuildUri(request);
-                                Console.WriteLine($"Full URL of Request {fullUrl}");
-                            }
-
                             request.ResponseWriter = responseStream =>
                             {
                                 using (responseStream)
@@ -448,9 +440,7 @@ namespace Minio
                                 }
                             };
 
-
-                            IRestResponse response = await this.restClient.ExecuteTaskAsync(request, cancellationToken).ConfigureAwait(false);
-                            this.HandleIfErrorResponse(response, this.NoErrorHandlers, startTime);
+                            await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 
                             cts.Token.ThrowIfCancellationRequested();
                         }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -14,20 +14,22 @@
  * limitations under the License.
  */
 
-using Minio.DataModel.Tracing;
-using Minio.Exceptions;
-using Minio.Helper;
-using RestSharp;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Web;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Web;
 using System.Xml.Serialization;
+
+using Minio.DataModel.Tracing;
+using Minio.Exceptions;
+using Minio.Helper;
+
+using RestSharp;
 
 namespace Minio
 {
@@ -520,6 +522,12 @@ namespace Minio
                     XmlError = response.Content
                 };
             }
+            if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+                && response.Request.Method.Equals(Method.GET) && errResponse.Code == "NoSuchBucket")
+            {
+                throw new BucketNotFoundException(errResponse.BucketName, "Not found.");
+
+            }
 
             throw new MinioException(errResponse.Message)
             {
@@ -613,12 +621,7 @@ namespace Minio
 
             this.logger.LogRequest(requestToLog, responseToLog, durationMs);
         }
-            if (response.StatusCode.Equals(HttpStatusCode.NotFound)
-                && response.Request.Method.Equals(Method.GET) && errResponse.Code == "NoSuchBucket")
-            {
-                    throw new BucketNotFoundException(errResponse.BucketName, "Not found.");
 
-            }
         private Task<IRestResponse> ExecuteWithRetry(
             Func<Task<IRestResponse>> executeRequestCallback)
         {

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -613,7 +613,12 @@ namespace Minio
 
             this.logger.LogRequest(requestToLog, responseToLog, durationMs);
         }
+            if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+                && response.Request.Method.Equals(Method.GET) && errResponse.Code == "NoSuchBucket")
+            {
+                    throw new BucketNotFoundException(errResponse.BucketName, "Not found.");
 
+            }
         private Task<IRestResponse> ExecuteWithRetry(
             Func<Task<IRestResponse>> executeRequestCallback)
         {

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -65,7 +65,7 @@ namespace Minio
         //
         //     Is skipped for obvious reasons
         //
-        private static HashSet<string> ignoredHeaders = new HashSet<string>
+        private static HashSet<string> ignoredHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "authorization",
             "content-length",
@@ -131,7 +131,7 @@ namespace Minio
             string signature = this.BytesToHex(signatureBytes);
 
             string authorization = this.GetAuthorizationHeader(signedHeaders, signature, signingDate, region);
-            request.AddHeader("Authorization", authorization);
+            request.AddOrUpdateParameter("Authorization", authorization, ParameterType.HttpHeader);
         }
 
         /// <summary>
@@ -451,7 +451,7 @@ namespace Minio
         /// <param name="signingDate">Date for signature to be signed</param>
         private void SetDateHeader(IRestRequest request, DateTime signingDate)
         {
-            request.AddHeader("x-amz-date", signingDate.ToString("yyyyMMddTHHmmssZ"));
+            request.AddOrUpdateParameter("x-amz-date", signingDate.ToString("yyyyMMddTHHmmssZ"), ParameterType.HttpHeader);
         }
 
         /// <summary>
@@ -461,7 +461,7 @@ namespace Minio
         /// <param name="hostUrl">Host url</param>
         private void SetHostHeader(IRestRequest request, string hostUrl)
         {
-            request.AddHeader("Host", hostUrl);
+            request.AddOrUpdateParameter("Host", hostUrl, ParameterType.HttpHeader);
         }
 
         /// <summary>
@@ -473,7 +473,7 @@ namespace Minio
         {
             if (!string.IsNullOrEmpty(sessionToken))
             {
-                request.AddHeader("X-Amz-Security-Token", sessionToken);
+                request.AddOrUpdateParameter("X-Amz-Security-Token", sessionToken, ParameterType.HttpHeader);
             }
         }
 
@@ -488,7 +488,7 @@ namespace Minio
             // No need to compute SHA256 if endpoint scheme is https
             if (isSecure)
             {
-                request.AddHeader("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
+                request.AddOrUpdateParameter("x-amz-content-sha256", "UNSIGNED-PAYLOAD", ParameterType.HttpHeader);
                 return;
             }
             if (request.Method == Method.PUT || request.Method.Equals(Method.POST))
@@ -496,7 +496,7 @@ namespace Minio
                 var bodyParameter = request.Parameters.FirstOrDefault(p => p.Type.Equals(ParameterType.RequestBody));
                 if (bodyParameter == null)
                 {
-                    request.AddHeader("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+                    request.AddOrUpdateParameter("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ParameterType.HttpHeader);
                     return;
                 }
                 byte[] body = null;
@@ -515,11 +515,11 @@ namespace Minio
                 var sha256 = SHA256.Create();
                 byte[] hash = sha256.ComputeHash(body);
                 string hex = BitConverter.ToString(hash).Replace("-", string.Empty).ToLower();
-                request.AddHeader("x-amz-content-sha256", hex);
+                request.AddOrUpdateParameter("x-amz-content-sha256", hex, ParameterType.HttpHeader);
             }
             else
             {
-                request.AddHeader("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+                request.AddOrUpdateParameter("x-amz-content-sha256", "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", ParameterType.HttpHeader);
             }
         }
 
@@ -567,7 +567,7 @@ namespace Minio
                 byte[] hash = md5.ComputeHash(body);
 
                 string base64 = Convert.ToBase64String(hash);
-                request.AddHeader("Content-MD5", base64);
+                request.AddOrUpdateParameter("Content-MD5", base64, ParameterType.HttpHeader);
             }
         }
     }


### PR DESCRIPTION
See #387 for details.

This PR adds a new method, `minioClient.WithRetryPolicy(...)`, that allows to apply a custom retry policy for all calls performed by the client. The new API does not depend on specific retry policy framework so users may use any library they want.

The PR contains some tests and sample that shows how to use the new API together with Polly retry policy.