### PR TITLE
Improve region matching regex performance (fixes #393)

### DIFF
--- a/Minio.Tests/RegionTest.cs
+++ b/Minio.Tests/RegionTest.cs
@@ -30,6 +30,8 @@ namespace Minio.Tests
         [DataRow("s3.us-west-1.amazonaws.com", "us-west-1")]
         [DataRow("mybucket-s3-us-west-1.amazonaws.com", "us-west-1")]
         [DataRow("wests3iss.s3-us-west-1.amazonaws.com", "us-west-1")]
+        [DataRow("test.s3-s3.bucket.s3-us-west-1.amazonaws.com", "us-west-1")]
+        [DataRow("test-s3.s3-bucket.s3-us-west-1.amazonaws.com", "us-west-1")]
         public void TestGetRegion(string endpoint, string expectedRegion)
         {
             Assert.AreEqual(Regions.GetRegionFromEndpoint(endpoint), expectedRegion);

--- a/Minio.Tests/RegionTest.cs
+++ b/Minio.Tests/RegionTest.cs
@@ -34,7 +34,7 @@ namespace Minio.Tests
         [DataRow("test-s3.s3-bucket.s3-us-west-1.amazonaws.com", "us-west-1")]
         public void TestGetRegion(string endpoint, string expectedRegion)
         {
-            Assert.AreEqual(Regions.GetRegionFromEndpoint(endpoint), expectedRegion);
+            Assert.AreEqual(expectedRegion, Regions.GetRegionFromEndpoint(endpoint));
         }
     }
 }

--- a/Minio.Tests/RegionTest.cs
+++ b/Minio.Tests/RegionTest.cs
@@ -22,24 +22,17 @@ namespace Minio.Tests
     [TestClass]
     public class TestRegion
     {
-        [TestMethod]
-        public void TestGetRegion()
+        [DataTestMethod]
+        [DataRow("s3.us-east-2.amazonaws.com", "us-east-2")]
+        [DataRow("s3.amazonaws.com", "")]
+        [DataRow("testbucket.s3-ca-central-1.amazonaws.com", "ca-central-1")]
+        [DataRow("mybucket-s3-us-east-2.amazonaws.com", "us-east-2")]
+        [DataRow("s3.us-west-1.amazonaws.com", "us-west-1")]
+        [DataRow("mybucket-s3-us-west-1.amazonaws.com", "us-west-1")]
+        [DataRow("wests3iss.s3-us-west-1.amazonaws.com", "us-west-1")]
+        public void TestGetRegion(string endpoint, string expectedRegion)
         {
-            var endpoint2Region = new Dictionary<string, string>
-            {
-                {"s3.us-east-2.amazonaws.com", "us-east-2"},
-                {"s3.amazonaws.com", ""},
-                {"testbucket.s3-ca-central-1.amazonaws.com", "ca-central-1"},
-                {"mybucket-s3-us-east-2.amazonaws.com", "us-east-2"},
-                {"s3.us-west-1.amazonaws.com", "us-west-1"},
-                {"mybucket-s3-us-west-1.amazonaws.com", "us-west-1"},
-                {"wests3iss.s3-us-west-1.amazonaws.com", "us-west-1"},
-            };
-
-            foreach (KeyValuePair<string, string> testCase in endpoint2Region)
-            {
-                Assert.AreEqual(Regions.GetRegionFromEndpoint(testCase.Key), testCase.Value);
-            }
+            Assert.AreEqual(Regions.GetRegionFromEndpoint(endpoint), expectedRegion);
         }
     }
 }

--- a/Minio/Regions.cs
+++ b/Minio/Regions.cs
@@ -18,11 +18,9 @@ using System.Text.RegularExpressions;
 
 namespace Minio
 {
-    public class Regions
+    public static class Regions
     {
-        private Regions()
-        {
-        }
+        private static readonly Regex endpointRegex = new Regex(@".*s3[.\-]?(.*?)\.amazonaws\.com$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
         /// <summary>
         /// Get corresponding region for input host.
@@ -31,20 +29,14 @@ namespace Minio
         /// <returns>Region corresponding to the endpoint. Default is 'us-east-1'</returns>
         public static string GetRegionFromEndpoint(string endpoint)
         {
-            string region = null;
-            Regex endpointrgx = new Regex("^([a-z0-9][a-z0-9\\.\\-]{1,61}[a-z0-9])*?.?s3[.\\-]?(.*?)\\.amazonaws\\.com$", RegexOptions.IgnoreCase);
-            Regex regionrgx = new Regex("^(s3[.\\-])?(.*?)$");
-            MatchCollection matches = endpointrgx.Matches(endpoint);
-            if (matches.Count > 0 && matches[0].Groups.Count > 1)
+            Match match = endpointRegex.Match(endpoint);
+
+            if (match.Success)
             {
-                string regionStr = matches[0].Groups[2].Value;
-                matches = regionrgx.Matches(regionStr);
-                if (matches.Count > 0 && matches[0].Groups.Count > 1)
-                {
-                    region = matches[0].Groups[0].Value;
-                }
+                return match.Groups[1].Value;
             }
-            return region ?? string.Empty;
+
+            return string.Empty;
         }
     }
 }

--- a/Minio/Regions.cs
+++ b/Minio/Regions.cs
@@ -18,9 +18,9 @@ using System.Text.RegularExpressions;
 
 namespace Minio
 {
-    public static class Regions
-    {
-        private static readonly Regex endpointRegex = new Regex(@".*s3[.\-]?(.*?)\.amazonaws\.com$", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+	public static class Regions
+	{
+		private static readonly Regex endpointRegex = new Regex(@"s3[.\-](.*?)\.amazonaws\.com$", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.RightToLeft);
 
         /// <summary>
         /// Get corresponding region for input host.


### PR DESCRIPTION
In addition to simplifying the regex, I have also modified it to be compiled. This introduces a slight startup delay (measured to be around 4ms on my machine) but speeds up all subsequent evaluations. Endpoints under 200 characters in length consistently get evaluated in under 1ms during my tests.

Fixes #393.