### PR TITLE
Fix #396, #395: Use typed exceptions for minio client

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1185,7 +1185,7 @@ namespace Minio.Functional.Tests
             }
             catch (MinioException ex)
             {
-                if (ex.message.Equals("A header you provided implies functionality that is not implemented"))
+                if (ex.ServerMessage.Equals("A header you provided implies functionality that is not implemented"))
                 {
                     new MintLogger("CopyObject_Test5", copyObjectSignature, "Tests whether CopyObject  multi-part copy upload for large files works", TestStatus.NA, (DateTime.Now - startTime), args:args).Log();
                 }
@@ -1664,7 +1664,7 @@ namespace Minio.Functional.Tests
                 }
                 catch (ObjectNotFoundException ex)
                 {
-                    Assert.AreEqual(ex.message, "Not found.");
+                    Assert.AreEqual(ex.ServerMessage, "Not found.");
                 }
 
                 await TearDown(minio, bucketName);

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -1,0 +1,72 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Threading.Tasks;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using Minio.Exceptions;
+
+namespace Minio.Tests
+{
+    [TestClass]
+    public class NegativeTest
+    {
+        [TestMethod]
+        public async Task TestNoConnectionError()
+        {
+            // invalid uri
+            var minio = new MinioClient("localhost:12121");
+
+            var ex = await Assert.ThrowsExceptionAsync<ConnectionException>(() => minio.BucketExistsAsync("test"));
+            Assert.IsNotNull(ex.ServerResponse);
+        }
+
+        [TestMethod]
+        public async Task TestInvalidBucketNameError()
+        {
+            var badName = new string('A', 260);
+            var minio = new MinioClient("play.min.io", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+            await Assert.ThrowsExceptionAsync<InvalidBucketNameException>(() => minio.BucketExistsAsync(badName));
+        }
+
+        [TestMethod]
+        public async Task TestInvalidObjectNameError()
+        {
+            var badName = new string('A', 260);
+            var bucketName = Guid.NewGuid().ToString("N");
+            var minio = new MinioClient("play.min.io", "Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+
+            try
+            {
+                await minio.MakeBucketAsync(bucketName);
+
+                var ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
+                    () => minio.StatObjectAsync(bucketName, badName));
+                Assert.AreEqual(ex.Response.Code, "InvalidObjectName");
+
+                ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
+                    () => minio.GetObjectAsync(bucketName, badName, s => { }));
+                Assert.AreEqual(ex.Response.Code, "InvalidObjectName");
+            }
+            finally
+            {
+                await minio.RemoveBucketAsync(bucketName);
+            }
+        }
+    }
+}

--- a/Minio.Tests/UtilsTest.cs
+++ b/Minio.Tests/UtilsTest.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio.Tests/UtilsTest.cs
+++ b/Minio.Tests/UtilsTest.cs
@@ -73,7 +73,7 @@ namespace Minio.Tests
             }
             catch (InvalidObjectNameException ex)
             {
-                Assert.AreEqual(ex.message, "Object name cannot be empty.");
+                Assert.AreEqual(ex.ServerMessage, "Object name cannot be empty.");
             }
         }
 
@@ -87,7 +87,7 @@ namespace Minio.Tests
             }
             catch (InvalidObjectNameException ex)
             {
-                Assert.AreEqual(ex.message, "Object name cannot be greater than 1024 characters.");
+                Assert.AreEqual(ex.ServerMessage, "Object name cannot be greater than 1024 characters.");
             }
             
         }
@@ -120,7 +120,7 @@ namespace Minio.Tests
             }
             catch (EntityTooLargeException ex)
             {
-                Assert.AreEqual(ex.message, "Your proposed upload size 5000000000000000000 exceeds the maximum allowed object size " + Constants.MaxMultipartPutObjectSize);
+                Assert.AreEqual(ex.ServerMessage, "Your proposed upload size 5000000000000000000 exceeds the maximum allowed object size " + Constants.MaxMultipartPutObjectSize);
             }
         }
 

--- a/Minio/DataModel/Select/SelectResponseStream.cs
+++ b/Minio/DataModel/Select/SelectResponseStream.cs
@@ -180,7 +180,7 @@ namespace Minio.DataModel
                         string errorMessage = null;
                         headerMap.TryGetValue(":error-code", out errorCode);
                         headerMap.TryGetValue(":error-message", out errorMessage);
-                        throw new MinioException(errorCode + ":" + errorMessage);
+                        throw new SelectObjectContentException(errorCode + ":" + errorMessage);
                     }
                 }
                 if (headerMap.TryGetValue(":event-type", out value))

--- a/Minio/Exceptions/AccessDeniedException.cs
+++ b/Minio/Exceptions/AccessDeniedException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/AccessDeniedException.cs
+++ b/Minio/Exceptions/AccessDeniedException.cs
@@ -21,10 +21,6 @@ namespace Minio.Exceptions
     [Serializable]
     public class AccessDeniedException : MinioException
     {
-        public AccessDeniedException()
-        {
-        }
-
         public AccessDeniedException(string message) : base(message)
         {
         }

--- a/Minio/Exceptions/BucketNotFoundException.cs
+++ b/Minio/Exceptions/BucketNotFoundException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/ConnectionException.cs
+++ b/Minio/Exceptions/ConnectionException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/ConnectionException.cs
+++ b/Minio/Exceptions/ConnectionException.cs
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+using RestSharp;
+
 namespace Minio.Exceptions
 {
     public class ConnectionException : MinioException
     {
-        public ConnectionException(string message) : base(message)
+        public ConnectionException(string message, IRestResponse response) : base(message, response)
         {
         }
     }

--- a/Minio/Exceptions/ErrorResponseException.cs
+++ b/Minio/Exceptions/ErrorResponseException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/ErrorResponseException.cs
+++ b/Minio/Exceptions/ErrorResponseException.cs
@@ -20,24 +20,10 @@ namespace Minio.Exceptions
 {
     public class ErrorResponseException : MinioException
     {
-        private readonly string ErrorCode;
-
-        public ErrorResponseException(IRestResponse response)
-            : base($"MinIO API responded with status code={response.StatusCode}, response={response.ErrorMessage}, content={response.Content}")
+        public ErrorResponseException(ErrorResponse errorResponse, IRestResponse serverResponse) :
+            base(serverResponse)
         {
-            this.response = response;
+            Response = errorResponse;
         }
-
-        public ErrorResponseException()
-        {
-        }
-
-        public ErrorResponseException(string message, string errorcode) : base($"MinIO API responded with message={message}")
-        {
-            this.message = message;
-            this.ErrorCode = errorcode;
-        }
-
-        public override string ToString() => $"{this.message}: {base.ToString()}";
     }
 }

--- a/Minio/Exceptions/InternalClientException.cs
+++ b/Minio/Exceptions/InternalClientException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/InternalClientException.cs
+++ b/Minio/Exceptions/InternalClientException.cs
@@ -14,11 +14,13 @@
  * limitations under the License.
  */
 
+using RestSharp;
+
 namespace Minio.Exceptions
 {
     public class InternalClientException : MinioException
     {
-        public InternalClientException(string message) : base(message)
+        public InternalClientException(string message, IRestResponse response) : base(message, response)
         {
         }
     }

--- a/Minio/Exceptions/MinioException.cs
+++ b/Minio/Exceptions/MinioException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/SelectObjectContentException.cs
+++ b/Minio/Exceptions/SelectObjectContentException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/Exceptions/SelectObjectContentException.cs
+++ b/Minio/Exceptions/SelectObjectContentException.cs
@@ -19,15 +19,10 @@ using System;
 namespace Minio.Exceptions
 {
     [Serializable]
-    public class BucketNotFoundException : MinioException
+    public class SelectObjectContentException : MinioException
     {
-        private readonly string bucketName;
-
-        public BucketNotFoundException(string bucketName, string message) : base(message)
+        public SelectObjectContentException(string message) : base(message)
         {
-            this.bucketName = bucketName;
         }
-
-        public override string ToString() => $"{this.bucketName}: {base.ToString()}";
     }
 }

--- a/Minio/Exceptions/UnexpectedMinioException.cs
+++ b/Minio/Exceptions/UnexpectedMinioException.cs
@@ -19,15 +19,10 @@ using System;
 namespace Minio.Exceptions
 {
     [Serializable]
-    public class BucketNotFoundException : MinioException
+    public class UnexpectedMinioException : MinioException
     {
-        private readonly string bucketName;
-
-        public BucketNotFoundException(string bucketName, string message) : base(message)
+        public UnexpectedMinioException(string message) : base(message)
         {
-            this.bucketName = bucketName;
         }
-
-        public override string ToString() => $"{this.bucketName}: {base.ToString()}";
     }
 }

--- a/Minio/Exceptions/UnexpectedMinioException.cs
+++ b/Minio/Exceptions/UnexpectedMinioException.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -558,12 +558,6 @@ namespace Minio
                     XmlError = response.Content
                 };
             }
-            if (response.StatusCode.Equals(HttpStatusCode.NotFound)
-                && response.Request.Method.Equals(Method.GET) && errResponse.Code == "NoSuchBucket")
-            {
-                throw new BucketNotFoundException(errResponse.BucketName, "Not found.");
-
-            }
 
             if (response.StatusCode.Equals(HttpStatusCode.NotFound)
                 && response.Request.Method.Equals(Method.GET)

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -1,5 +1,6 @@
 ﻿/*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017, 2018, 2019, 2020 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Rename MinioException properties: message => ServerMessage; response => ServerResponse.
* Split ParseError method into simpler and shorter methods
* Throw exceptions for invalid object name and connectivity errors.
* Add NegativeTest for newly added exceptions
* Pass IRestResponse to connectivity-related and unexpected-error exceptions. 
* Add SelectObjectContentException and UnexpectedMinioException exceptions. Code now use specific exceptions and do not throw base MinioException anymore.
