### PR TITLE
removed double-encoding of url query parameters

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -232,10 +232,10 @@ namespace Minio
             var request = await this.CreateRequest(Method.GET,
                                                      bucketName)
                                         .ConfigureAwait(false);
-            request.AddQueryParameter("delimiter",Uri.EscapeDataString(delimiter));
-            request.AddQueryParameter("prefix", Uri.EscapeDataString(prefix));
+            request.AddQueryParameter("delimiter",delimiter);
+            request.AddQueryParameter("prefix",prefix);
             request.AddQueryParameter("max-keys", "1000");
-            request.AddQueryParameter("marker",Uri.EscapeDataString(marker));
+            request.AddQueryParameter("marker",marker);
             request.AddQueryParameter("encoding-type","url");
   
             var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -576,10 +576,10 @@ namespace Minio
 
             var request = await this.CreateRequest(Method.GET, bucketName).ConfigureAwait(false);
             request.AddQueryParameter("uploads","");
-            request.AddQueryParameter("prefix" , Uri.EscapeDataString(prefix));
-            request.AddQueryParameter("delimiter" ,Uri.EscapeDataString(delimiter));
-            request.AddQueryParameter("key-marker" , Uri.EscapeDataString(keyMarker));
-            request.AddQueryParameter("upload-id-marker" ,Uri.EscapeDataString(uploadIdMarker));
+            request.AddQueryParameter("prefix",prefix);
+            request.AddQueryParameter("delimiter",delimiter);
+            request.AddQueryParameter("key-marker",keyMarker);
+            request.AddQueryParameter("upload-id-marker",uploadIdMarker);
             request.AddQueryParameter("max-uploads","1000");
             var response = await this.ExecuteTaskAsync(this.NoErrorHandlers, request, cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
This PR removes the encoding of URL query parameters as already done by RestSharp.