### PR TITLE
Correct StatObjectAsync header retrieval

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -489,7 +489,7 @@ namespace Minio.Functional.Tests
                 Assert.IsTrue(statObject != null);
                 Assert.IsTrue(statObject.MetaData != null);
                 var statMeta = new Dictionary<string, string>(statObject.MetaData, StringComparer.OrdinalIgnoreCase);
-                Assert.IsTrue(statMeta.ContainsKey("X-Amz-Meta-Customheader"));
+                Assert.IsTrue(statMeta.ContainsKey("Customheader"));
                 Assert.IsTrue(statObject.MetaData.ContainsKey("Content-Type") && statObject.MetaData["Content-Type"].Equals("custom/contenttype"));
                 await TearDown(minio, bucketName);
                 new MintLogger(nameof(PutObject_Test4), putObjectSignature1, "Tests whether PutObject with different content-type passes", TestStatus.PASS, (DateTime.Now - startTime), args:args).Log();
@@ -1309,7 +1309,7 @@ namespace Minio.Functional.Tests
                 }
                 ObjectStat stats = await minio.StatObjectAsync(bucketName, objectName);
 
-                Assert.IsTrue(stats.MetaData["X-Amz-Meta-Orig"] != null) ;
+                Assert.IsTrue(stats.MetaData["Orig"] != null) ;
 
                 CopyConditions copyCond = new CopyConditions();
                 copyCond.SetReplaceMetadataDirective();
@@ -1323,7 +1323,7 @@ namespace Minio.Functional.Tests
                 await minio.CopyObjectAsync(bucketName, objectName, destBucketName, destObjectName, copyConditions:copyCond, metadata: metadata);
 
                 ObjectStat dstats = await minio.StatObjectAsync(destBucketName, destObjectName);
-                Assert.IsTrue(dstats.MetaData["X-Amz-Meta-Mynewkey"] != null);
+                Assert.IsTrue(dstats.MetaData["Mynewkey"] != null);
                 await minio.RemoveObjectAsync(bucketName, objectName);
                 await minio.RemoveObjectAsync(destBucketName, destObjectName);
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -23,9 +23,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Web;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Xml.Linq;
@@ -36,6 +36,9 @@ namespace Minio
     public partial class MinioClient : IObjectOperations
     {
         private readonly List<string> supportedHeaders = new List<string> { "cache-control", "content-encoding", "content-type", "x-amz-acl", "content-disposition" };
+
+        public static readonly Regex valueReplaceRegex = new Regex(@"^x-amz-meta-",
+            RegexOptions.IgnoreCase | RegexOptions.CultureInvariant | RegexOptions.Compiled);
 
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.
@@ -840,7 +843,7 @@ namespace Minio
                 }
                 else if (supportedHeaders.Contains(parameter.Name, StringComparer.OrdinalIgnoreCase) || parameter.Name.StartsWith("x-amz-meta-", StringComparison.OrdinalIgnoreCase))
                 {
-                    metaData[parameter.Name] = parameter.Value.ToString().ToLowerInvariant().Replace("x-amz-meta-", string.Empty);
+                    metaData[parameter.Name] = valueReplaceRegex.Replace(parameter.Value.ToString(), string.Empty);
                 }
             }
             return new ObjectStat(objectName, size, lastModified, etag, contentType, metaData);

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -843,7 +843,6 @@ namespace Minio
                 }
                 else if (parameter.Name.StartsWith("x-amz-meta-", StringComparison.OrdinalIgnoreCase))
                 {
-                    metaData[parameter.Name] = parameter.Value.ToString();
                     metaData[parameter.Name.Substring("x-amz-meta-".Length)] = parameter.Value.ToString();
                 }
             }


### PR DESCRIPTION
This fixes #408.

Pull request #356 applied a case change to retrieved header values in addition to removing `x-amz-meta-` from values.  The author @kannappanr confirmed that this was not the intention.  The intention was to remove `x-amz-meta-` from the header name, not the value.

This pull request applies the fix in a backward compatible way in that it stores both the original header name and the trimmed header name into the returned metadata.