### PR TITLE
Throw BucketNotFoundException for all http methods

### DIFF
--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -561,7 +561,6 @@ namespace Minio
             }
 
             if (response.StatusCode.Equals(HttpStatusCode.NotFound)
-                && response.Request.Method.Equals(Method.GET)
                 && errResponse.Code == "NoSuchBucket")
             {
                 throw new BucketNotFoundException(errResponse.BucketName, "Not found.");


### PR DESCRIPTION
If the error code returned is `NoSuchBucket` throw `BucketNotFoundException` error for all `http` methods

Fixes #431