### PR TITLE
Fix xml sent in DeleteObjects API

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -723,12 +723,9 @@ namespace Minio
                                        new XElement("Key", obj.Key)));
             }
 
-            var deleteObjectsRequest = new XElement("DeleteObject", objects,
+            var deleteObjectsRequest = new XElement("Delete", objects,
                                         new XElement("Quiet", true));
 
-            var bodyString = deleteObjectsRequest.ToString();
-
-            var body = System.Text.Encoding.UTF8.GetBytes(bodyString);
             request.AddXmlBody(deleteObjectsRequest);
             request.XmlSerializer = new RestSharp.Serializers.DotNetXmlSerializer();
             request.RequestFormat = DataFormat.Xml;


### PR DESCRIPTION
As suggested by @sergei66666 DeleteObjects API in the SDK was sending the wrong XML.

Fixes #436