### PR TITLE
fix: Functional Tests with Encryption/HTTPS

### DIFF
--- a/Minio.Examples/Cases/FGetObject.cs
+++ b/Minio.Examples/Cases/FGetObject.cs
@@ -34,7 +34,12 @@ namespace Minio.Examples.Cases
             {
                 Console.WriteLine("Running example for API: GetObjectAsync");
                 File.Delete(fileName);
-                await minio.GetObjectAsync(bucketName, objectName, fileName, sse: sse);
+                GetObjectArgs args = new GetObjectArgs()
+                                                .WithBucket(bucketName)
+                                                .WithObject(objectName)
+                                                .WithFile(fileName)
+                                                .WithServerSideEncryption(sse);
+                await minio.GetObjectAsync(args).ConfigureAwait(false);
                 Console.WriteLine($"Downloaded the file {fileName} from bucket {bucketName}");
                 Console.WriteLine();
             }

--- a/Minio.Examples/Cases/GetPartialObject.cs
+++ b/Minio.Examples/Cases/GetPartialObject.cs
@@ -40,19 +40,23 @@ namespace Minio.Examples.Cases
                 await minio.StatObjectAsync(statObjectArgs);
 
                 // Get object content starting at byte position 1024 and length of 4096
-                await minio.GetObjectAsync(bucketName, objectName, 1024L, 4096L,
-                (stream) =>
-                {
-                    var fileStream = File.Create(fileName);
-                    stream.CopyTo(fileStream);
-                    fileStream.Dispose();
-                    var writtenInfo = new FileInfo(fileName);
-                    long file_read_size = writtenInfo.Length;
-                    // Uncomment to print the file on output console
-                    // stream.CopyTo(Console.OpenStandardOutput());
-                    Console.WriteLine($"Successfully downloaded object with requested offset and length {writtenInfo.Length} into file");
-                    stream.Dispose();
-                });
+                GetObjectArgs getObjectArgs = new GetObjectArgs()
+                                                        .WithBucket(bucketName)
+                                                        .WithObject(objectName)
+                                                        .WithOffsetAndLength(1024L, 4096L)
+                                                        .WithCallbackStream((stream) =>
+                                                                            {
+                                                                                var fileStream = File.Create(fileName);
+                                                                                stream.CopyTo(fileStream);
+                                                                                fileStream.Dispose();
+                                                                                var writtenInfo = new FileInfo(fileName);
+                                                                                long file_read_size = writtenInfo.Length;
+                                                                                // Uncomment to print the file on output console
+                                                                                // stream.CopyTo(Console.OpenStandardOutput());
+                                                                                Console.WriteLine($"Successfully downloaded object with requested offset and length {writtenInfo.Length} into file");
+                                                                                stream.Dispose();
+                                                                            });
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
                 Console.WriteLine();
             }
             catch (Exception e)

--- a/Minio.Examples/Cases/RetryPolicyObject.cs
+++ b/Minio.Examples/Cases/RetryPolicyObject.cs
@@ -94,7 +94,11 @@ namespace Minio.Examples.Cases
 
                 try
                 {
-                    await minio.GetObjectAsync("bad-bucket", "bad-file", s => { });
+                    GetObjectArgs getObjectArgs = new GetObjectArgs()
+                                                            .WithBucket("bad-bucket")
+                                                            .WithObject("bad-file")
+                                                            .WithCallbackStream(s => { });
+                    await minio.GetObjectAsync(getObjectArgs);
                 }
                 catch (BucketNotFoundException ex)
                 {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1476,7 +1476,7 @@ namespace Minio.Functional.Tests
                 await minio.RemoveObjectAsync(rmArgs);
                 RemoveObjectArgs rmArgsDest = new RemoveObjectArgs()
                                                     .WithBucket(destBucketName)
-                                                    .WithObject(destObjectName);
+                                                    .WithObject(objectName);
                 await minio.RemoveObjectAsync(rmArgsDest);
                 await TearDown(minio, bucketName);
                 await TearDown(minio, destBucketName);
@@ -2168,7 +2168,7 @@ namespace Minio.Functional.Tests
                     GetObjectArgs getObjectArgs = new GetObjectArgs()
                                                             .WithBucket(bucketName)
                                                             .WithObject(objectName)
-                                                            .WithLengthAndOffset(1024L, file_write_size)
+                                                            .WithOffsetAndLength(1024L, file_write_size)
                                                             .WithCallbackStream((stream) =>
                                                                                 {
                                                                                     var fileStream = File.Create(tempFileName);

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -89,8 +89,12 @@ namespace Minio.Tests
                 }
                 Assert.AreEqual(ex.Response.Code, "InvalidObjectName");
 
+                GetObjectArgs getObjectArgs = new GetObjectArgs()
+                                                        .WithBucket(bucketName)
+                                                        .WithObject(badName)
+                                                        .WithCallbackStream(s =>{});
                 ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
-                    () => minio.GetObjectAsync(bucketName, badName, s => { }));
+                    () => minio.GetObjectAsync(getObjectArgs));
                 Assert.AreEqual(ex.Response.Code, "InvalidObjectName");
             }
             finally

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -82,8 +82,12 @@ namespace Minio.Tests
                     throw exception;
                 });
 
+            GetObjectArgs getObjectArgs = new GetObjectArgs()
+                                                    .WithBucket(Guid.NewGuid().ToString())
+                                                    .WithObject("aa")
+                                                    .WithCallbackStream(s => { });
             await Assert.ThrowsExceptionAsync<BucketNotFoundException>(
-                () => client.GetObjectAsync(Guid.NewGuid().ToString(), "aa", s => { }));
+                () => client.GetObjectAsync(getObjectArgs));
             Assert.AreEqual(invokeCount, retryCount);
         }
     }

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -111,11 +111,19 @@ namespace Minio
         /// <summary>
         /// Get an object. The object will be streamed to the callback given by the user.
         /// </summary>
+        /// <param name="args">GetObjectArgs Arguments Object encapsulates information like - bucket name, object name, server-side encryption object, action stream, length, offset</param>
+        /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+        Task GetObjectAsync(GetObjectArgs args, CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Get an object. The object will be streamed to the callback given by the user.
+        /// </summary>
         /// <param name="bucketName">Bucket to retrieve object from</param>
         /// <param name="objectName">Name of object to retrieve</param>
         /// <param name="callback">A stream will be passed to the callback</param>
         /// <param name="sse">Optional Server-side encryption option. Defaults to null.</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+        [Obsolete("Use GetObjectAsync method with GetObjectArgs object. Refer GetObject, GetObjectVersion & GetObjectQuery example code.")]
         Task GetObjectAsync(string bucketName, string objectName, Action<Stream> callback, ServerSideEncryption sse = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -128,6 +136,7 @@ namespace Minio
         /// <param name="cb">A stream will be passed to the callback</param>
         /// <param name="sse">Optional Server-side encryption option. Defaults to null.</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+        [Obsolete("Use GetObjectAsync method with GetObjectArgs object. Refer GetObject, GetObjectVersion & GetObjectQuery example code.")]
         Task GetObjectAsync(string bucketName, string objectName, long offset, long length, Action<Stream> cb, ServerSideEncryption sse = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -192,6 +201,7 @@ namespace Minio
         /// <param name="recursive">Set to true to recursively list all incomplete uploads</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <returns>A lazily populated list of incomplete uploads</returns>
+        [Obsolete("Use ListIncompleteUploads method with ListIncompleteUploadsArgs object. Refer ListIncompleteUploads example code.")]
         IObservable<Upload> ListIncompleteUploads(string bucketName, string prefix = "", bool recursive = false, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -200,6 +210,7 @@ namespace Minio
         /// <param name="bucketName">Bucket to remove incomplete uploads from</param>
         /// <param name="objectName">Key to remove incomplete uploads from</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+        [Obsolete("Use RemoveIncompleteUploadAsync method with RemoveIncompleteUploadArgs object. Refer RemoveIncompleteUpload example code.")]
         Task RemoveIncompleteUploadAsync(string bucketName, string objectName, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -238,6 +249,7 @@ namespace Minio
         /// <param name="sse">Optional Server-side encryption option. Defaults to null.</param>
         /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
         /// <returns></returns>
+        [Obsolete("Use GetObjectAsync method with GetObjectArgs object. Refer GetObject, GetObjectVersion & GetObjectQuery example code.")]
         Task GetObjectAsync(string bucketName, string objectName, string filePath, ServerSideEncryption sse = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -249,6 +261,7 @@ namespace Minio
         /// <param name="expiresInt">Expiration time in seconds.</param>
         /// <param name="reqParams">Optional override response headers</param>
         /// <param name="reqDate">Optional request date and time in UTC</param>
+        [Obsolete("Use PresignedGetObjectAsync method with PresignedGetObjectArgs object.")]
         Task<string> PresignedGetObjectAsync(string bucketName, string objectName, int expiresInt, Dictionary<string, string> reqParams = null, DateTime? reqDate = null);
 
         /// <summary>


### PR DESCRIPTION
1. Added Obsolete warnings to some function calls in ObjectOperations.cs.
2. Handle the ripple effect of warnings.
3. Added 'Range' to header map in StatObject.
4. Changed to function name: WithOffsetAndLength
5. Changed name of class ObjectQueryArgs to ObjectConditionalQueryArgs.
6. Handled failure related to CompleteMultipartUpload.
7. Minor fixes, code refactoring related to ServerSide encryption for CopyObject.