### PR TITLE
Mint - Avoid invalid JSON output

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3784,12 +3784,8 @@ namespace Minio.Functional.Tests
                 IObservable<MinioNotificationRaw> events = minio.ListenBucketNotificationsAsync(listenArgs);
                 subscription = events.Subscribe(
                     ev => {
-                        Console.WriteLine($"ListenBucketNotificationsAsync received: " + ev.json);
                         received.Add(ev);
-                    },
-                    ex => Console.WriteLine("OnError: {0}", ex.Message),
-                    () => Console.WriteLine($"ListenBucketNotificationsAsync finished")
-                );
+                    });
                 await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null, rsg.GenerateStreamFromSeed(1 * KB));
 
                 // wait for notifications
@@ -3834,8 +3830,6 @@ namespace Minio.Functional.Tests
                         Assert.IsTrue(objectName.Contains(System.Web.HttpUtility.UrlDecode(notification.Records[0].s3.objectMeta.key)));
                         Assert.IsTrue(contentType.Contains(notification.Records[0].s3.objectMeta.contentType));
                         break;
-                    } else {
-                        Console.WriteLine($"ListenBucketNotificationsAsync: waiting for notification (t={attempt})");
                     }
                 }
 

--- a/Minio/DataModel/Select/SelectObjectOptions.cs
+++ b/Minio/DataModel/Select/SelectObjectOptions.cs
@@ -79,7 +79,6 @@ namespace Minio.DataModel
                     xw.Close();
                 }
             }
-            Console.WriteLine(str);
             return str;
         }
     }

--- a/Minio/DataModel/Select/SelectResponseStream.cs
+++ b/Minio/DataModel/Select/SelectResponseStream.cs
@@ -197,7 +197,6 @@ namespace Minio.DataModel
                     }
                     if (value.Equals("Stats"))
                     {
-                        Console.WriteLine("payload|"+Encoding.UTF7.GetString(payload));
                         StatsMessage stats = new StatsMessage();
                         using (var stream = new MemoryStream(payload))
                         stats = (StatsMessage)new XmlSerializer(typeof(StatsMessage)).Deserialize(stream);


### PR DESCRIPTION
## Description
The console outputs have been removed and the exception handling for versioning and locking has been extended. 

## Motivation and Context
Testing with Mint Suite generates a log.json file. We want to process the file, but MinIO .NET generates invalid JSON in case of errors.
 
## How to test this PR?
Runing the tests against a `minio server data{1...4}` should now return a valid JSON without error stacktraces.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] Fixes a regression (If yes, please add `commit-id` or `PR #` here)
- [ ] Documentation updated
- [ ] Unit tests added/updated