### PR TITLE
Adds missing bucket replication config exception

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -2371,7 +2371,7 @@ __Parameters__
 |        |  ``InvalidObjectNameException`` : upon invalid object name |
 |        |  ``BucketNotFoundException`` : upon bucket with name not found   |
 |        |  ``ObjectNotFoundException`` : upon object with name not found |
-|        |  ``MissingObjectLockConfiguration`` : upon bucket created with object lock not enabled |
+|        |  ``MissingObjectLockConfigurationException`` : upon bucket created with object lock not enabled |
 |        |  ``MalFormedXMLException`` : upon configuration XML in http request validation failure |
 
 
@@ -2421,7 +2421,7 @@ __Parameters__
 |        |  ``InvalidObjectNameException`` : upon invalid object name |
 |        |  ``BucketNotFoundException`` : upon bucket with name not found  |
 |        |  ``ObjectNotFoundException`` : upon object with name not found |
-|        |  ``MissingObjectLockConfiguration`` : upon bucket created with object lock not enabled |
+|        |  ``MissingObjectLockConfigurationException`` : upon bucket created with object lock not enabled |
 |        |  ``MalFormedXMLException`` : upon configuration XML in http request validation failure |
 
 
@@ -2622,7 +2622,7 @@ __Parameters__
 |        |  ``InvalidObjectNameException`` : upon invalid object name |
 |        |  ``BucketNotFoundException`` : upon bucket with name not found |
 |        |  ``ObjectNotFoundException`` : upon object with name not found |
-|        |  ``MissingObjectLockConfiguration`` : upon bucket created with object lock not enabled |
+|        |  ``MissingObjectLockConfigurationException`` : upon bucket created with object lock not enabled |
 |        |  ``MalFormedXMLException`` : upon configuration XML in http request validation failure |
 
 
@@ -2674,7 +2674,7 @@ __Parameters__
 |        |  ``InvalidObjectNameException`` : upon invalid object name |
 |        |  ``BucketNotFoundException`` : upon bucket with name not found  |
 |        |  ``ObjectNotFoundException`` : upon object with name not found |
-|        |  ``MissingObjectLockConfiguration`` : upon bucket created with object lock not enabled |
+|        |  ``MissingObjectLockConfigurationException`` : upon bucket created with object lock not enabled |
 |        |  ``MalFormedXMLException`` : upon configuration XML in http request validation failure |
 
 
@@ -2723,7 +2723,7 @@ __Parameters__
 |        |  ``InvalidObjectNameException`` : upon invalid object name |
 |        |  ``BucketNotFoundException`` : upon bucket with name not found   |
 |        |  ``ObjectNotFoundException`` : upon object with name not found |
-|        |  ``MissingObjectLockConfiguration`` : upon bucket created with object lock not enabled |
+|        |  ``MissingObjectLockConfigurationException`` : upon bucket created with object lock not enabled |
 |        |  ``MalFormedXMLException`` : upon configuration XML in http request validation failure |
 
 

--- a/Minio.Examples/Cases/GetBucketReplication.cs
+++ b/Minio.Examples/Cases/GetBucketReplication.cs
@@ -15,6 +15,7 @@
  */
 using System;
 using System.Threading.Tasks;
+using Minio.Exceptions;
 
 namespace Minio.Examples.Cases
 {
@@ -41,8 +42,11 @@ namespace Minio.Examples.Cases
                     Console.WriteLine();
                     return;
                 }
-                Console.WriteLine($"Bucket Replication Configuration not set for bucket {bucketName}.");
                 Console.WriteLine();
+            }
+            catch (MissingBucketReplicationConfiguration)
+            {
+                Console.WriteLine($"[Bucket] Exception: Replication Configuration not set for bucket {bucketName}.");
             }
             catch (Exception e)
             {

--- a/Minio.Examples/Cases/GetBucketReplication.cs
+++ b/Minio.Examples/Cases/GetBucketReplication.cs
@@ -44,7 +44,7 @@ namespace Minio.Examples.Cases
                 }
                 Console.WriteLine();
             }
-            catch (MissingBucketReplicationConfiguration)
+            catch (MissingBucketReplicationConfigurationException)
             {
                 Console.WriteLine($"[Bucket] Exception: Replication Configuration not set for bucket {bucketName}.");
             }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -547,7 +547,7 @@ namespace Minio.Functional.Tests
             {
                 lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs);
             }
-            catch (MissingObjectLockConfiguration)
+            catch (MissingObjectLockConfigurationException)
             {
                 // This exception is expected for those buckets created without a lock.
             }

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -559,7 +559,7 @@ namespace Minio
         /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task SetObjectLockConfigurationAsync(SetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -580,7 +580,7 @@ namespace Minio
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         public async Task<ObjectLockConfiguration> GetObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))
         {
             args.Validate();
@@ -600,7 +600,7 @@ namespace Minio
         /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task RemoveObjectLockConfigurationAsync(RemoveObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -677,7 +677,7 @@ namespace Minio
         /// <returns>Replication configuration object</returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task<ReplicationConfiguration> GetBucketReplicationAsync(GetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -698,7 +698,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception> 
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task SetBucketReplicationAsync(SetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -717,7 +717,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception> 
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task RemoveBucketReplicationAsync(RemoveBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -677,6 +677,7 @@ namespace Minio
         /// <returns>Replication configuration object</returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task<ReplicationConfiguration> GetBucketReplicationAsync(GetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -697,6 +698,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception> 
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task SetBucketReplicationAsync(SetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -715,6 +717,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception> 
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         public async Task RemoveBucketReplicationAsync(RemoveBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken))

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -430,6 +430,7 @@ namespace Minio
         /// <returns>Replication configuration object</returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task<ReplicationConfiguration> GetBucketReplicationAsync(GetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -442,6 +443,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task SetBucketReplicationAsync(SetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -454,6 +456,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task RemoveBucketReplicationAsync(RemoveBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -219,7 +219,7 @@ namespace Minio
         /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task SetObjectLockConfigurationAsync(SetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -234,7 +234,7 @@ namespace Minio
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         Task<ObjectLockConfiguration> GetObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken));
 
 
@@ -247,7 +247,7 @@ namespace Minio
         /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task RemoveObjectLockConfigurationAsync(RemoveObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -430,7 +430,7 @@ namespace Minio
         /// <returns>Replication configuration object</returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task<ReplicationConfiguration> GetBucketReplicationAsync(GetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -443,7 +443,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task SetBucketReplicationAsync(SetBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -456,7 +456,7 @@ namespace Minio
         /// <returns></returns>
         /// <exception cref="AuthorizationException">When access or secret key provided is invalid</exception>
         /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-        /// <exception cref="MissingBucketReplicationConfiguration">When bucket replication configuration is not set</exception>
+        /// <exception cref="MissingBucketReplicationConfigurationException">When bucket replication configuration is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         Task RemoveBucketReplicationAsync(RemoveBucketReplicationArgs args, CancellationToken cancellationToken = default(CancellationToken));

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -41,7 +41,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task<bool> GetObjectLegalHoldAsync(GetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -57,7 +57,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task SetObjectLegalHoldAsync(SetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -73,7 +73,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task SetObjectRetentionAsync(SetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken));
@@ -90,7 +90,7 @@ namespace Minio
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         Task<ObjectRetentionConfiguration> GetObjectRetentionAsync(GetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         Task ClearObjectRetentionAsync(ClearObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken));

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -313,7 +313,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task<bool> GetObjectLegalHoldAsync(GetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -337,7 +337,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task SetObjectLegalHoldAsync(SetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -481,7 +481,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task SetObjectRetentionAsync(SetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))
@@ -504,7 +504,7 @@ namespace Minio
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         public async Task<ObjectRetentionConfiguration> GetObjectRetentionAsync(GetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))
         {
             args.Validate();
@@ -526,7 +526,7 @@ namespace Minio
         /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
         /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
         /// <exception cref="ObjectNotFoundException">When object is not found</exception>
-        /// <exception cref="MissingObjectLockConfiguration">When object lock configuration on bucket is not set</exception>
+        /// <exception cref="MissingObjectLockConfigurationException">When object lock configuration on bucket is not set</exception>
         /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
         /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
         public async Task ClearObjectRetentionAsync(ClearObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))

--- a/Minio/Exceptions/MissingBucketReplicationConfiguration.cs
+++ b/Minio/Exceptions/MissingBucketReplicationConfiguration.cs
@@ -1,0 +1,30 @@
+/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Minio.Exceptions
+{
+    public class MissingBucketReplicationConfiguration : MinioException
+    {
+        private readonly string bucketName;
+
+        public MissingBucketReplicationConfiguration(string bucketName, string message) : base(message)
+        {
+            this.bucketName = bucketName;
+        }
+
+        public override string ToString() => $"{this.bucketName}: {base.ToString()}";
+    }
+}

--- a/Minio/Exceptions/MissingBucketReplicationConfigurationException.cs
+++ b/Minio/Exceptions/MissingBucketReplicationConfigurationException.cs
@@ -16,11 +16,11 @@
 
 namespace Minio.Exceptions
 {
-    public class MissingBucketReplicationConfiguration : MinioException
+    public class MissingBucketReplicationConfigurationException : MinioException
     {
         private readonly string bucketName;
 
-        public MissingBucketReplicationConfiguration(string bucketName, string message) : base(message)
+        public MissingBucketReplicationConfigurationException(string bucketName, string message) : base(message)
         {
             this.bucketName = bucketName;
         }

--- a/Minio/Exceptions/MissingObjectLockConfigurationException.cs
+++ b/Minio/Exceptions/MissingObjectLockConfigurationException.cs
@@ -16,11 +16,11 @@
 
 namespace Minio.Exceptions
 {
-    public class MissingObjectLockConfiguration : MinioException
+    public class MissingObjectLockConfigurationException : MinioException
     {
         private readonly string bucketName;
 
-        public MissingObjectLockConfiguration(string bucketName, string message) : base(message)
+        public MissingObjectLockConfigurationException(string bucketName, string message) : base(message)
         {
             this.bucketName = bucketName;
         }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -766,20 +766,20 @@ namespace Minio
                 Parameter legalHold = new Parameter("legal-hold", "", ParameterType.QueryString);
                 if (response.Request.Parameters.Contains(legalHold))
                 {
-                    throw new MissingObjectLockConfiguration(errResponse.BucketName, errResponse.Message);
+                    throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
                 }
             }
 
             if (response.StatusCode.Equals(HttpStatusCode.NotFound)
                 && errResponse.Code.Equals("ObjectLockConfigurationNotFoundError"))
             {
-                throw new MissingObjectLockConfiguration(errResponse.BucketName, errResponse.Message);
+                throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
             }
 
             if (response.StatusCode.Equals(HttpStatusCode.NotFound)
                 && errResponse.Code.Equals("ReplicationConfigurationNotFoundError"))
             {
-                throw new MissingBucketReplicationConfiguration(errResponse.BucketName, errResponse.Message);
+                throw new MissingBucketReplicationConfigurationException(errResponse.BucketName, errResponse.Message);
             }
 
             throw new UnexpectedMinioException(errResponse.Message)

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -776,6 +776,12 @@ namespace Minio
                 throw new MissingObjectLockConfiguration(errResponse.BucketName, errResponse.Message);
             }
 
+            if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+                && errResponse.Code.Equals("ReplicationConfigurationNotFoundError"))
+            {
+                throw new MissingBucketReplicationConfiguration(errResponse.BucketName, errResponse.Message);
+            }
+
             throw new UnexpectedMinioException(errResponse.Message)
             {
                 Response = errResponse,


### PR DESCRIPTION
Creates a custom exception when the configuration file is missing and the `GetBucketReplication` or `RemoveBucketReplication` API runs. 