### PR TITLE
Runs all MakeBucketAsync tests regardless of the platform

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -263,10 +263,8 @@ namespace Minio.Functional.Tests
             }
         }
 
-        internal async static Task MakeBucket_Test2(MinioClient minio, bool aws = false)
+        internal async static Task MakeBucket_Test2(MinioClient minio)
         {
-            if (!aws)
-                return;
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(length: 10) + ".withperiod";
             MakeBucketArgs mbArgs = new MakeBucketArgs()
@@ -300,10 +298,8 @@ namespace Minio.Functional.Tests
             }
         }
 
-        internal async static Task MakeBucket_Test3(MinioClient minio, bool aws = false)
+        internal async static Task MakeBucket_Test3(MinioClient minio)
         {
-            if (!aws)
-                return;
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(length: 60);
             MakeBucketArgs mbArgs = new MakeBucketArgs()
@@ -337,10 +333,8 @@ namespace Minio.Functional.Tests
             }
         }
 
-        internal async static Task MakeBucket_Test4(MinioClient minio, bool aws = false)
+        internal async static Task MakeBucket_Test4(MinioClient minio)
         {
-            if (!aws)
-                return;
             DateTime startTime = DateTime.Now;
             string bucketName = GetRandomName(length: 20) + ".withperiod";
             MakeBucketArgs mbArgs = new MakeBucketArgs()

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -30,7 +30,6 @@ namespace Minio.Functional.Tests
             string enableHttps = "0";
             string kmsEnabled = "0";
 
-            bool useAWS = Environment.GetEnvironmentVariable("AWS_ENDPOINT") != null;
             if (Environment.GetEnvironmentVariable("SERVER_ENDPOINT") != null)
             {
                 endPoint = Environment.GetEnvironmentVariable("SERVER_ENDPOINT");
@@ -92,16 +91,12 @@ namespace Minio.Functional.Tests
                 // Check if bucket exists
                 FunctionalTest.BucketExists_Test(minioClient).Wait();
 
-                // Create a new bucket
+                // Create a new bucket and test valid bucket names
                 FunctionalTest.MakeBucket_Test1(minioClient).Wait();
+                FunctionalTest.MakeBucket_Test2(minioClient).Wait();
+                FunctionalTest.MakeBucket_Test3(minioClient).Wait();
+                FunctionalTest.MakeBucket_Test4(minioClient).Wait();
                 FunctionalTest.MakeBucket_Test5(minioClient).Wait();
-
-                if (useAWS)
-                {
-                    FunctionalTest.MakeBucket_Test2(minioClient, useAWS).Wait();
-                    FunctionalTest.MakeBucket_Test3(minioClient, useAWS).Wait();
-                    FunctionalTest.MakeBucket_Test4(minioClient, useAWS).Wait();
-                }
 
                 // Test removal of bucket
                 FunctionalTest.RemoveBucket_Test1(minioClient).Wait();


### PR DESCRIPTION
Some `MakeBucketAsync` test cases were running only if the platform is AWS by checking if the environment variable, `"AWS_ENDPOINT"`, is `null` or not.
However, there is no good reason to have this distinction at this point. All existing test cases apply to both platforms.
So, this PR makes all `MakeBucketAsync` test cases run against both AWS and MinIO servers.