### PR TITLE
Update "Target framework" to netcoreapp2.1

### DIFF
--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>


### PR DESCRIPTION
Update target framework
 

Updating the target framework from netstandard2.0;net46 to netcoreapp2.1 (as it is with the other projects):
 

https://github.com/minio/minio-dotnet/blob/master/Minio.Functional.Tests/Minio.Functional.Tests.csproj#L3

https://github.com/minio/minio-dotnet/blob/master/Minio.Tests/Minio.Tests.csproj#L3

https://github.com/minio/minio-dotnet/blob/master/Minio.Examples/Minio.Examples.csproj#L3

https://github.com/minio/minio-dotnet/blob/master/FileUploader/FileUploader.csproj#L3
 

Otherwise it will not build on macOS.