### PR TITLE
Several fixes for endpoint and region settings

### DIFF
--- a/FileUploader/FileUpload.cs
+++ b/FileUploader/FileUpload.cs
@@ -27,7 +27,7 @@ namespace FileUploader
     /// </summary>
     public class FileUpload
     {
-        static void Main(string[] args)
+        static void Main()
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
                                                  | SecurityProtocolType.Tls11
@@ -35,18 +35,22 @@ namespace FileUploader
             var endpoint = "play.min.io";
             var accessKey = "Q3AM3UQ867SPQQA43P2F";
             var secretKey = "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG";
+
             try
             {
                 var minio = new MinioClient()
                                     .WithEndpoint(endpoint)
                                     .WithCredentials(accessKey, secretKey)
-                                    .WithSSL();
+                                    .WithSSL()
+                                    .Build();
                 Run(minio).Wait();
             }
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
             }
+            // Added for Windows folks. Without it, the window, tests
+            // run in, dissappears as soon as the test code completes.
             Console.ReadLine();
         }
 
@@ -62,6 +66,8 @@ namespace FileUploader
             var location = "us-east-1";
             // Upload the zip file
             var objectName = "my-golden-oldies.mp3";
+            // The following is a source file that needs to be created in
+            // your local filesystem.
             var filePath = "C:\\Users\\vagrant\\Downloads\\golden_oldies.mp3";
             var contentType = "application/zip";
 
@@ -81,7 +87,7 @@ namespace FileUploader
                                                         .WithBucket(bucketName)
                                                         .WithObject(objectName)
                                                         .WithFileName(filePath)
-                                                        .WithContentType(contentType);           
+                                                        .WithContentType(contentType);
                 await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
                 Console.WriteLine("Successfully uploaded " + objectName);
             }
@@ -89,6 +95,9 @@ namespace FileUploader
             {
                 Console.WriteLine(e);
             }
+            // Added for Windows folks. Without it, the window, tests
+            // run in, dissappears as soon as the test code completes.
+            Console.ReadLine();
         }
     }
 }

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>False</IsPackable>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -78,7 +78,7 @@ namespace Minio.Tests
                                             .WithObject(badName);
                 var ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
                     () => minio.StatObjectAsync(statObjArgs));
-                for(int i=0;
+                for (int i = 0;
                         i < tryCount &&
                             (ex.ServerResponse != null &&
                                 ex.ServerResponse.StatusCode.Equals(HttpStatusCode.ServiceUnavailable)); ++i)
@@ -92,7 +92,7 @@ namespace Minio.Tests
                 GetObjectArgs getObjectArgs = new GetObjectArgs()
                                                         .WithBucket(bucketName)
                                                         .WithObject(badName)
-                                                        .WithCallbackStream(s =>{});
+                                                        .WithCallbackStream(s => { });
                 ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
                     () => minio.GetObjectAsync(getObjectArgs));
                 Assert.AreEqual(ex.Response.Code, "InvalidObjectName");

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -108,7 +108,19 @@ namespace Minio
             {
                 this.restClient.Authenticator = new V4Authenticator(this.Secure, this.AccessKey, this.SecretKey, region: args.Location, sessionToken: this.SessionToken);
             }
-            var response = await this.ExecuteAsync(this.NoErrorHandlers, args.BuildRequest(request), cancellationToken);
+            try
+            {
+                await this.ExecuteAsync(this.NoErrorHandlers, args.BuildRequest(request), cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                var bucketAlreadyExistsMsg = "Your previous request to create " +
+                            "the named bucket succeeded and you already own it.";
+                if (ex.Message.Contains(bucketAlreadyExistsMsg))
+                {
+                    Console.WriteLine("Bucket has been already created and owned by you! Continuing...");
+                }
+            }
         }
 
 
@@ -267,10 +279,10 @@ namespace Minio
                               ListObjectVersionResponse listObjectsItemResponse = new ListObjectVersionResponse(args, objectList, obs);
                               if (objectList.Item2.Count == 0 && count == 0)
                               {
-                                string name = args.BucketName;
-                                if (!string.IsNullOrEmpty(args.Prefix))
-                                    name += "/" + args.Prefix;
-                                throw new EmptyBucketOperation("Bucket " + name + " is empty.");
+                                  string name = args.BucketName;
+                                  if (!string.IsNullOrEmpty(args.Prefix))
+                                      name += "/" + args.Prefix;
+                                  throw new EmptyBucketOperation("Bucket " + name + " is empty.");
                               }
                               obs = listObjectsItemResponse.ItemObservable;
                               marker = listObjectsItemResponse.NextKeyMarker;
@@ -282,10 +294,10 @@ namespace Minio
                               Tuple<ListBucketResult, List<Item>> objectList = await GetObjectListAsync(goArgs, cts.Token).ConfigureAwait(false);
                               if (objectList.Item2.Count == 0 && objectList.Item1.KeyCount.Equals("0") && count == 0)
                               {
-                                string name = args.BucketName;
-                                if (!string.IsNullOrEmpty(args.Prefix))
-                                    name += "/" + args.Prefix;
-                                throw new EmptyBucketOperation("Bucket " + name + " is empty.");
+                                  string name = args.BucketName;
+                                  if (!string.IsNullOrEmpty(args.Prefix))
+                                      name += "/" + args.Prefix;
+                                  throw new EmptyBucketOperation("Bucket " + name + " is empty.");
                               }
                               ListObjectsItemResponse listObjectsItemResponse = new ListObjectsItemResponse(args, objectList, obs);
                               marker = listObjectsItemResponse.NextMarker;

--- a/Minio/DataModel/MinioClientBuilder.cs
+++ b/Minio/DataModel/MinioClientBuilder.cs
@@ -39,7 +39,7 @@ namespace Minio
 
         private void SetBaseURL(Uri url)
         {
-            if ( url.IsDefaultPort )
+            if (url.IsDefaultPort)
             {
                 this.BaseUrl = url.Host;
             }
@@ -52,7 +52,7 @@ namespace Minio
         {
             if (String.IsNullOrEmpty(endpoint))
             {
-                throw new ArgumentException(String.Format("{0} is the value of the endpoint. It can't be null or empty.", endpoint),"endpoint");
+                throw new ArgumentException(String.Format("{0} is the value of the endpoint. It can't be null or empty.", endpoint), "endpoint");
             }
             if (endpoint.EndsWith("/"))
             {
@@ -60,15 +60,15 @@ namespace Minio
             }
             if (!endpoint.StartsWith("http") && !BuilderUtil.IsValidHostnameOrIPAddress(endpoint))
             {
-                throw new InvalidEndpointException(String.Format("{0} is invalid hostname.", endpoint),"endpoint");
+                throw new InvalidEndpointException(String.Format("{0} is invalid hostname.", endpoint), "endpoint");
             }
             string conn_url;
             if (endpoint.StartsWith("http"))
             {
-                throw new InvalidEndpointException(String.Format("{0} the value of the endpoint has the scheme (http/https) in it.", endpoint),"endpoint");
+                throw new InvalidEndpointException(String.Format("{0} the value of the endpoint has the scheme (http/https) in it.", endpoint), "endpoint");
             }
             string enable_https = Environment.GetEnvironmentVariable("ENABLE_HTTPS");
-            string scheme = (enable_https != null && enable_https.Equals("1"))? "https://":"http://";
+            string scheme = (enable_https != null && enable_https.Equals("1")) ? "https://" : "http://";
             conn_url = scheme + endpoint;
             string hostnameOfUri = string.Empty;
             Uri url = null;
@@ -81,9 +81,9 @@ namespace Minio
             {
                 throw;
             }
-            if ( !String.IsNullOrEmpty(hostnameOfUri) && !BuilderUtil.IsValidHostnameOrIPAddress(hostnameOfUri))
+            if (!String.IsNullOrEmpty(hostnameOfUri) && !BuilderUtil.IsValidHostnameOrIPAddress(hostnameOfUri))
             {
-                throw new InvalidEndpointException(String.Format("{0}, {1} is invalid hostname.", endpoint, hostnameOfUri),"endpoint");
+                throw new InvalidEndpointException(String.Format("{0}, {1} is invalid hostname.", endpoint, hostnameOfUri), "endpoint");
             }
 
             return url;
@@ -100,14 +100,14 @@ namespace Minio
         {
             if (port < 1 || port > 65535)
             {
-                throw new ArgumentException(String.Format("Port {0} is not a number between 1 and 65535",port), "port");
+                throw new ArgumentException(String.Format("Port {0} is not a number between 1 and 65535", port), "port");
             }
             return WithEndpoint(endpoint + ":" + port);
         }
 
         public MinioClient WithEndpoint(Uri url)
         {
-            if (url == null )
+            if (url == null)
             {
                 throw new ArgumentException(String.Format("URL is null. Can't create endpoint."));
             }
@@ -118,9 +118,18 @@ namespace Minio
         {
             if (String.IsNullOrEmpty(region))
             {
-                throw new ArgumentException(String.Format("{0} the region value can't be null or empty.", region),"region");
+                // Set region to its default value if empty or null
+                this.Region = "us-east-1";
+                return this;
             }
             this.Region = region;
+            return this;
+        }
+
+        public MinioClient WithRegion()
+        {
+            // Set region to its default value if empty or null
+            this.Region = "us-east-1";
             return this;
         }
 
@@ -158,9 +167,9 @@ namespace Minio
 
             var scheme = this.Secure ? utils.UrlEncode("https") : utils.UrlEncode("http");
 
-            if ( !this.BaseUrl.StartsWith("http") )
+            if (!this.BaseUrl.StartsWith("http"))
             {
-               this.Endpoint = string.Format("{0}://{1}", scheme, host);
+                this.Endpoint = string.Format("{0}://{1}", scheme, host);
             }
             else
             {

--- a/SimpleTest/Program.cs
+++ b/SimpleTest/Program.cs
@@ -65,7 +65,9 @@ namespace SimpleTest
             var bucketExistTask = minio.BucketExistsAsync(bktExistsArgs);
             Task.WaitAll(bucketExistTask);
             var found = bucketExistTask.Result;
-            Console.WriteLine("bucket was " + found);
+            Console.WriteLine("Bucket exists: " + found);
+            // Added for Windows folks. Without it, the window, tests
+            // run in, dissappears as soon as the test code completes.
             Console.ReadLine();
         }
 


### PR DESCRIPTION
After looking into FileUploader and SimpleTest projects, found out that the introduction of the new approach of collecting all arguments required to run an api and calling the api with the formed `args` is broken in MinioClient generation. This PR addresses the endpoint and missing region default value setting when not provided.
At this point, `region` argument should be `NOT Optional` as skipping it causes signature mismatch.
