### PR TITLE
Clean up unsupported sdks and add support for net6.0 sdk

### DIFF
--- a/.github/workflows/minio-dotnet-linux.yml
+++ b/.github/workflows/minio-dotnet-linux.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ["5.0.x"]
+        dotnet-version: ["5.0.x", "6.0.x"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/minio-dotnet-windows.yml
+++ b/.github/workflows/minio-dotnet-windows.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         configuration: [Release]
+        dotnet-version: ["5.0.x", "6.0.x"]
 
     runs-on: windows-latest
     env:
@@ -26,10 +27,10 @@ jobs:
           fetch-depth: 0
 
       # Install the .NET
-      - name: Setup .NET
+      - name: Setup .NET ${{ matrix.dotnet-version }}
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.402
+          dotnet-version: ${{ matrix.dotnet-version }}
 
       # Install dependencies
       - name: Install dependencies

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -9,17 +9,6 @@
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
-  <Choose>
-    <When Condition=" '$(Configuration)'!='Mint' ">
-      <ItemGroup>
-        <ProjectReference Include="..\Minio\Minio.csproj" />
-      </ItemGroup>
-    </When>
-    <When Condition=" '$(Configuration)'=='Mint' ">
-      <ItemGroup>
-        <PackageReference Include="Minio" Version="3.1.*" />
-      </ItemGroup>
-    </When>
-  </Choose>
 </Project>

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -10,9 +10,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-  </ItemGroup>
-  
-  <ItemGroup>
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -4,7 +4,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net46;net5.0;</TargetFrameworks>
+    <TargetFrameworks>net5.0; net6.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>
@@ -35,29 +35,10 @@
     <PackageReference Include="Crc32.NET" Version="1.2.0"/>
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All"/>
-    <PackageReference Include="System.Reactive.Linq" Version="4.0.1"/>
+    <PackageReference Include="System.Reactive.Linq" Version="5.0.0"/>
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>
     <PackageReference Include="System.Net.Primitives" Version="4.3.1"/>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>
     <PackageReference Include="System.ValueTuple" Version="4.4.0" />
   </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'" Label="Framework References">
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0"/>
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'" Label="Framework References">
-    <Reference Include="Microsoft.CSharp"/>
-    <Reference Include="System.Runtime">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Primitives">
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Http"/>
-    <Reference Include="System.Web"/>
-    <Reference Include="System.IO"/>
-    <Reference Include="System.Text.Encoding"/>
-    <Reference Include="System.Threading.Tasks"/>
-  </ItemGroup>
-
 </Project>  


### PR DESCRIPTION
Microsoft does not support some of the .NET SDKs, Minio SDK was supporting, netstandard2.0 and net4.6, This PR removes these SDKs from the project target frameworks and adds the following versions currently supported at this point:
net6.0, net5.0 (and net3.1, but we did not support this version before). 
net7.0 is available at this point, but it is in Preview stage.
This information is valid for all 3 platforms, Windows, Linux and macOS.
Reference: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#cadence
