### PR TITLE
Updated API.md intro to reflect current API usage

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -5,20 +5,22 @@
 ## MinIO
 
 ```cs
-var minioClient = new MinioClient("play.min.io",
-                                       "Q3AM3UQ867SPQQA43P2F",
-                                       "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-                                 ).WithSSL();
+MinioClient minioClient = new MinioClient()
+                                    .WithEndpoint("play.min.io")
+                                    .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+                                    .WithSSL()
+                                    .Build();
 ```
 
 ## AWS S3
 
 
 ```cs
-var s3Client = new MinioClient("s3.amazonaws.com",
-                                   "YOUR-ACCESSKEYID",
-                                   "YOUR-SECRETACCESSKEY"
-                               ).WithSSL();
+MinioClient minioClient = new MinioClient()
+                                    .WithEndpoint("s3.amazonaws.com")
+                                    .WithCredentials("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY")
+                                    .WithSSL()
+                                    .Build();
 ```
 
 | Bucket operations |  Object operations | Presigned operations  | Bucket Policy Operations
@@ -169,8 +171,7 @@ MinioClient minioClient = new MinioClient("play.min.io");
 // 2. public MinioClient(String endpoint, String accessKey, String secretKey)
 MinioClient minioClient = new MinioClient("play.min.io",
                                           accessKey:"Q3AM3UQ867SPQQA43P2F",
-                                          secretKey:"zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG"
-                                          ).WithSSL();
+                                          secretKey:"zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
 
 // 3. Initializing minio client with proxy
 IWebProxy proxy = new WebProxy("192.168.0.1", 8000);
@@ -204,7 +205,7 @@ MinioClient s3Client = new MinioClient("s3.amazonaws.com").WithSSL();
 // 2. public MinioClient(String endpoint, String accessKey, String secretKey)
 MinioClient s3Client = new MinioClient("s3.amazonaws.com",
                                        accessKey:"YOUR-ACCESSKEYID",
-                                       secretKey:"YOUR-SECRETACCESSKEY").WithSSL();
+                                       secretKey:"YOUR-SECRETACCESSKEY");
 // 3. Using Builder with public MinioClient(), Endpoint, Credentials & Secure connection
 MinioClient minioClient = new MinioClient()
                                     .WithEndpoint("s3.amazonaws.com")


### PR DESCRIPTION
While having a total brainfart moment (I apparently forgot that scrolling exists), I was going insane trying to figure out why the Minio client was not able to communicate over SSL. I was madly following the debugger and not understanding why the client still had http even though it *clearly* used .WithSSL()

An hour of stepping through the source code (obviously! Dump that nuget package and just link against the source!), and I eventually found the [Obsolete] tag on the constructor used in this example. 

I, of course, did a Git blame to find out how long it had been there. 2 years.

About time someone fixes this. It's a copy paste of the example just a little bit further down. 

I also removed the .WithSSL() calls on the "obsolete" constructor. That won't work. (this.HTTPClient is never created unless MinioClient() constructor is run, and just silently fails, and doesn't use SSL)

Just to save someone else from pulling their hair out too.