### PR TITLE
Fix for object size validation

### DIFF
--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1909,9 +1909,9 @@ namespace Minio
         internal override void Validate()
         {
             base.Validate();
-            if (this.RequestBody == null && this.ObjectStreamData == null && string.IsNullOrWhiteSpace(this.FileName))
+            if (string.IsNullOrWhiteSpace(FileName) && ObjectStreamData == null)
             {
-                throw new ArgumentNullException("Invalid input. " + nameof(RequestBody) + ", " + nameof(FileName) + " and " + nameof(ObjectStreamData) + " cannot be empty.");
+                throw new ArgumentException("One of " + nameof(FileName) + " or " + nameof(ObjectStreamData) + " must be set.");
             }
             if (this.PartNumber < 0)
             {

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1909,6 +1909,7 @@ namespace Minio
         internal override void Validate()
         {
             base.Validate();
+            // Check atleast one of filename or stream are initialized
             if (string.IsNullOrWhiteSpace(FileName) && ObjectStreamData == null)
             {
                 throw new ArgumentException("One of " + nameof(FileName) + " or " + nameof(ObjectStreamData) + " must be set.");
@@ -1921,11 +1922,6 @@ namespace Minio
             if (!string.IsNullOrWhiteSpace(this.FileName) && this.ObjectStreamData != null)
             {
                 throw new ArgumentException("Only one of " + nameof(FileName) + " or " + nameof(ObjectStreamData) + " should be set.");
-            }
-            // Check atleast one of filename or stream are initialized
-            if (string.IsNullOrWhiteSpace(this.FileName) && this.ObjectStreamData == null)
-            {
-                throw new ArgumentException("One of " + nameof(FileName) + " or " + nameof(ObjectStreamData) + " must be set.");
             }
             if (!string.IsNullOrWhiteSpace(this.FileName))
             {

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1931,6 +1931,11 @@ namespace Minio
             {
                 utils.ValidateFile(this.FileName);
             }
+            // Check object size when using stream data
+            if (ObjectStreamData != null && ObjectSize == 0)
+            {
+                throw new ArgumentException($"{nameof(ObjectSize)} must be set");
+            }
             this.Populate();
         }
 


### PR DESCRIPTION
If you missed the WithObjectSize argument for PutArgs, you will get empty file in the bucket
This PR fixes a validation for uploading file via stream data