### PR TITLE
Support netstandard 2.0 as package target

### DIFF
--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>net5.0;net6.0;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net5.0;net6.0;</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Crc32.NET" Version="1.2.0"/>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All"/>
     <PackageReference Include="System.Net.Http" Version="4.3.4"/>


### PR DESCRIPTION
Currently it is not possible to use Minio client with .NET Framework applications