### PR TITLE
Modifies the target framework for Windows OS

### DIFF
--- a/.github/workflows/minio-dotnet-windows.yml
+++ b/.github/workflows/minio-dotnet-windows.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Build & Unit Test
         run: |
           dotnet build --configuration Release --no-restore
-          dotnet pack ./Minio/Minio.csproj --no-build --configuration Release -output ./artifacts
+          dotnet pack ./Minio/Minio.csproj --no-build --configuration Release --output ./artifacts
           dotnet test ./Minio.Tests/Minio.Tests.csproj
 
       # Execute all functional tests in the solution

--- a/FileUploader/FileUploader.csproj
+++ b/FileUploader/FileUploader.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FileUploader/FileUploader.csproj
+++ b/FileUploader/FileUploader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/FileUploader/FileUploader.csproj
+++ b/FileUploader/FileUploader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Polly" Version="7.2.0" />

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFramework Condition=" '$(OS)' == 'Unix'">netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,8 +3,8 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
-    <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0;net6.0</TargetFrameworks>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,7 +3,7 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' == 'Unix'">netstandard2.1</TargetFramework>
     <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,8 +3,8 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
     <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT'">netstandard2.1</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,8 +3,8 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>netstandard2.1;net6.0;</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">netstandard2.1;net4.8;net6.0;</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -3,8 +3,8 @@
     <LangVersion>latest</LangVersion>
     <AssemblyName>Minio</AssemblyName>
     <RootNamespace>Minio</RootNamespace>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' == 'Windows_NT'">netstandard2.0</TargetFramework>
     <DebugType>embedded</DebugType>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -403,10 +403,10 @@ internal class V4Authenticator
             switch (contentKind)
             {
                 case "application/x-www-form-urlencoded":
-                    {
-                        isFormData = true;
-                        cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
-                    }
+                {
+                    isFormData = true;
+                    cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
+                }
                     break;
             }
 
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split(new Char[] { '=' }).Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split(new[] { '=' }).Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -403,10 +403,10 @@ internal class V4Authenticator
             switch (contentKind)
             {
                 case "application/x-www-form-urlencoded":
-                {
-                    isFormData = true;
-                    cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
-                }
+                    {
+                        isFormData = true;
+                        cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
+                    }
                     break;
             }
 
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split('=').Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split(new Char[] { '=' }).Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split("=".ToCharArray()).Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split(new char[] { '=' }).Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split(new char[] { '=' }).Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split(new Char[] { '=' }).Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -20,8 +20,9 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
-using Minio.Helper;
 using Newtonsoft.Json;
+
+using Minio.Helper;
 
 namespace Minio;
 
@@ -385,49 +386,18 @@ internal class V4Authenticator
         // METHOD
         canonicalStringList.AddLast(requestBuilder.Method.ToString());
 
-        var queryParams = "";
+        var queryParamsDict = new Dictionary<string, string>();
         if (requestBuilder.QueryParameters != null)
-            queryParams = string.Join("&",
-                requestBuilder.QueryParameters.Select(kvp => $"{kvp.Key}={Uri.EscapeDataString(kvp.Value)}"));
-
-        var isFormData = false;
-        var c = requestBuilder.Request.Content;
-
-        if (string.IsNullOrEmpty(queryParams) && c != null &&
-            c.Headers != null && c.Headers.ContentType != null &&
-            c.Headers.ContentType.ToString() == "application/x-www-form-urlencoded")
+	{
+	    foreach (var kvp in requestBuilder.QueryParameters)
+	    {
+		queryParamsDict[kvp.Key] = Uri.EscapeDataString(kvp.Value);
+	    }
+	}
+	
+        var queryParams = "";
+        if (queryParamsDict.Count > 0)
         {
-            // Convert stream content to byte[]
-            var cntntByteData = new byte[] { };
-            var contentKind = requestBuilder.Request.Content.Headers.ContentType.ToString();
-            switch (contentKind)
-            {
-                case "application/x-www-form-urlencoded":
-                {
-                    isFormData = true;
-                    cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
-                }
-                    break;
-            }
-
-            // Convert byte[] to regular string
-            var cntntByteDataStr = new StringBuilder();
-            // UTF conversion - String from bytes
-            queryParams = Encoding.UTF8.GetString(cntntByteData, 0, cntntByteData.Length);
-        }
-
-        if (!string.IsNullOrEmpty(queryParams))
-        {
-            var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split(new[] { '=' }).Length == 2)
-                queryParamsDict.Add(queryParams.Trim('='), "");
-            else if (queryParams.Split('=').Length == 2)
-                queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);
-            else if (queryParams.Split('=').Length > 2)
-                queryParamsDict = queryParams.Split(new[] { '&' })
-                    .Select(part => part.Split('='))
-                    .ToDictionary(split => split[0], split => split[1]);
-
             var sb1 = new StringBuilder();
             var queryKeys = new List<string>(queryParamsDict.Keys);
             queryKeys.Sort(StringComparer.Ordinal);
@@ -439,6 +409,23 @@ internal class V4Authenticator
             }
 
             queryParams = sb1.ToString();
+        }
+
+        var isFormData = false;
+        if (requestBuilder.Request.Content != null && requestBuilder.Request.Content.Headers != null && requestBuilder.Request.Content.Headers.ContentType != null)
+            isFormData = requestBuilder.Request.Content.Headers.ContentType.ToString() == "application/x-www-form-urlencoded";
+
+        if (string.IsNullOrEmpty(queryParams) && isFormData)
+        {
+            // Convert stream content to byte[]
+	    var cntntByteData = new byte[] { };
+	    if (requestBuilder.Request.Content != null)
+	    {
+		cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
+	    }
+
+            // UTF conversion - String from bytes
+            queryParams = Encoding.UTF8.GetString(cntntByteData, 0, cntntByteData.Length);
         }
 
         if (!string.IsNullOrEmpty(queryParams) &&

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split(new Char[] { '=' }).Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -419,7 +419,7 @@ internal class V4Authenticator
         if (!string.IsNullOrEmpty(queryParams))
         {
             var queryParamsDict = new Dictionary<string, string>();
-            if (queryParams.EndsWith('=') && queryParams.Split('=').Length == 2)
+            if (queryParams.EndsWith('=') && queryParams.Split("=".ToCharArray()).Length == 2)
                 queryParamsDict.Add(queryParams.Trim('='), "");
             else if (queryParams.Split('=').Length == 2)
                 queryParamsDict.Add(queryParams.Split('=')[0], queryParams.Split('=')[1]);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -20,9 +20,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
-using Newtonsoft.Json;
-
 using Minio.Helper;
+using Newtonsoft.Json;
 
 namespace Minio;
 
@@ -388,13 +387,9 @@ internal class V4Authenticator
 
         var queryParamsDict = new Dictionary<string, string>();
         if (requestBuilder.QueryParameters != null)
-	{
-	    foreach (var kvp in requestBuilder.QueryParameters)
-	    {
-		queryParamsDict[kvp.Key] = Uri.EscapeDataString(kvp.Value);
-	    }
-	}
-	
+            foreach (var kvp in requestBuilder.QueryParameters)
+                queryParamsDict[kvp.Key] = Uri.EscapeDataString(kvp.Value);
+
         var queryParams = "";
         if (queryParamsDict.Count > 0)
         {
@@ -412,17 +407,17 @@ internal class V4Authenticator
         }
 
         var isFormData = false;
-        if (requestBuilder.Request.Content != null && requestBuilder.Request.Content.Headers != null && requestBuilder.Request.Content.Headers.ContentType != null)
-            isFormData = requestBuilder.Request.Content.Headers.ContentType.ToString() == "application/x-www-form-urlencoded";
+        if (requestBuilder.Request.Content != null && requestBuilder.Request.Content.Headers != null &&
+            requestBuilder.Request.Content.Headers.ContentType != null)
+            isFormData = requestBuilder.Request.Content.Headers.ContentType.ToString() ==
+                         "application/x-www-form-urlencoded";
 
         if (string.IsNullOrEmpty(queryParams) && isFormData)
         {
             // Convert stream content to byte[]
-	    var cntntByteData = new byte[] { };
-	    if (requestBuilder.Request.Content != null)
-	    {
-		cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
-	    }
+            var cntntByteData = new byte[] { };
+            if (requestBuilder.Request.Content != null)
+                cntntByteData = requestBuilder.Request.Content.ReadAsByteArrayAsync().Result;
 
             // UTF conversion - String from bytes
             queryParams = Encoding.UTF8.GetString(cntntByteData, 0, cntntByteData.Length);

--- a/SimpleTest/SimpleTest.csproj
+++ b/SimpleTest/SimpleTest.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SimpleTest/SimpleTest.csproj
+++ b/SimpleTest/SimpleTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/SimpleTest/SimpleTest.csproj
+++ b/SimpleTest/SimpleTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
The team decided to set the TFM to `"netstandard2.0"` as it covers all legacy .Net SDK versions.