### PR TITLE
Reuse HttpClient and fix the wrong TLS and Proxy settings during MinioClient creation

### DIFF
--- a/.github/workflows/minio-dotnet-linux.yml
+++ b/.github/workflows/minio-dotnet-linux.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Execute Functional Tests
         env:
           MINT_MODE: full
-          SERVER_ENDPOINT: 127.0.0.1:9000
+          SERVER_ENDPOINT: localhost:9000
           ACCESS_KEY: minio
           SECRET_KEY: minio123
           ENABLE_HTTPS: 1
@@ -57,10 +57,12 @@ jobs:
           MINIO_SECRET_KEY: minio123
           MINIO_KMS_SECRET_KEY: my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw=
         run: |
-            wget --quiet -O /tmp/minio https://dl.min.io/server/minio/release/linux-amd64/minio
-            chmod +x /tmp/minio
-            mkdir -p /tmp/minio-config/certs/
-            cp Minio.Functional.Tests/certs/* /tmp/minio-config/certs/
-            /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &
-            dotnet build  Minio.Functional.Tests --configuration Release
-            dotnet Minio.Functional.Tests/bin/Release/net6.0/Minio.Functional.Tests.dll
+          wget --quiet -O /tmp/minio https://dl.min.io/server/minio/release/linux-amd64/minio
+          chmod +x /tmp/minio
+          mkdir -p /tmp/minio-config/certs/
+          cp Minio.Functional.Tests/certs/* /tmp/minio-config/certs/
+          sudo cp /tmp/minio-config/certs/public.crt /etc/ssl/certs/
+          sudo cp /tmp/minio-config/certs/private.key /etc/ssl/private/
+          /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &
+          dotnet build  Minio.Functional.Tests --configuration Release
+          dotnet Minio.Functional.Tests/bin/Release/net6.0/Minio.Functional.Tests.dll

--- a/Docs/API.md
+++ b/Docs/API.md
@@ -138,7 +138,7 @@ MinioClient minioClient = new MinioClient()
 
 ```cs
 // 1. Using Builder with public MinioClient(), Endpoint, Credentials, Secure connection & proxy
-MinioClient s3Client = new MinioClient("s3.amazonaws.com");
+MinioClient s3Client = new MinioClient()
 									 .WithEndpoint("s3.amazonaws.com")
 									 .WithCredentials("YOUR-AWS-ACCESSKEYID", "YOUR-AWS-SECRETACCESSKEY")
 									 .WithSSL()

--- a/Docs/API.md
+++ b/Docs/API.md
@@ -137,16 +137,14 @@ MinioClient minioClient = new MinioClient()
 ### AWS S3
 
 ```cs
-// 1. public MinioClient(String endpoint, String accessKey, String secretKey)
-MinioClient s3Client = new MinioClient("s3.amazonaws.com",
-									   accessKey:"YOUR-ACCESSKEYID",
-									   secretKey:"YOUR-SECRETACCESSKEY");
-// 2. Using Builder with public MinioClient(), Endpoint, Credentials & Secure connection
-MinioClient minioClient = new MinioClient()
-									.WithEndpoint("s3.amazonaws.com")
-									.WithCredentials("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY")
-									.WithSSL()
-									.Build()
+// 1. Using Builder with public MinioClient(), Endpoint, Credentials, Secure connection & proxy
+MinioClient s3Client = new MinioClient("s3.amazonaws.com");
+									 .WithEndpoint("s3.amazonaws.com")
+									 .WithCredentials("YOUR-AWS-ACCESSKEYID", "YOUR-AWS-SECRETACCESSKEY")
+									 .WithSSL()
+									 .WithProxy(proxy)
+									 .Build();
+
 ```
 
 ## 2. Bucket operations

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -424,7 +424,7 @@ public class FunctionalTest
             bucketList = list.Buckets;
             bucketList = bucketList.Where(x => x.Name.StartsWith(bucketName)).ToList();
             Assert.AreEqual(noOfBuckets, bucketList.Count());
-            bucketList.Sort(delegate(Bucket x, Bucket y)
+            bucketList.Sort(delegate (Bucket x, Bucket y)
             {
                 if (x.Name == y.Name) return 0;
                 if (x.Name == null) return -1;

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,8 +332,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExists passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -351,7 +351,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -373,11 +373,11 @@ public class FunctionalTest
         var found = false;
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
-            found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
+            found = await minio.BucketExistsAsync(beArgs);
             Assert.IsFalse(found);
             new MintLogger(nameof(RemoveBucket_Test1), removeBucketSignature, "Tests whether RemoveBucket passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -391,7 +391,7 @@ public class FunctionalTest
         finally
         {
             if (found)
-                await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+                await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -420,7 +420,7 @@ public class FunctionalTest
 
         try
         {
-            var list = await minio.ListBucketsAsync().ConfigureAwait(false);
+            var list = await minio.ListBucketsAsync();
             bucketList = list.Buckets;
             bucketList = bucketList.Where(x => x.Name.StartsWith(bucketName)).ToList();
             Assert.AreEqual(noOfBuckets, bucketList.Count());
@@ -453,7 +453,7 @@ public class FunctionalTest
             {
                 var rbArgs = new RemoveBucketArgs()
                     .WithBucket(bucket.Name);
-                await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+                await minio.RemoveBucketAsync(rbArgs);
             }
         }
     }
@@ -465,8 +465,8 @@ public class FunctionalTest
         if (await minio.BucketExistsAsync(beArgs)) return;
         var mbArgs = new MakeBucketArgs()
             .WithBucket(bucketName);
-        await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-        var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+        await minio.MakeBucketAsync(mbArgs);
+        var found = await minio.BucketExistsAsync(beArgs);
         Assert.IsTrue(found);
     }
 
@@ -477,8 +477,8 @@ public class FunctionalTest
             .WithObjectLock();
         var beArgs = new BucketExistsArgs()
             .WithBucket(bucketName);
-        await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-        var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+        await minio.MakeBucketAsync(mbArgs);
+        var found = await minio.BucketExistsAsync(beArgs);
         Assert.IsTrue(found);
     }
 
@@ -486,7 +486,7 @@ public class FunctionalTest
     {
         var beArgs = new BucketExistsArgs()
             .WithBucket(bucketName);
-        var bktExists = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+        var bktExists = await minio.BucketExistsAsync(beArgs);
         if (!bktExists)
             return;
         var taskList = new List<Task>();
@@ -503,7 +503,7 @@ public class FunctionalTest
                 .WithBucket(bucketName));
             if (versioningConfig != null && (versioningConfig.Status.Contains("Enabled") ||
                                              versioningConfig.Status.Contains("Suspended"))) getVersions = true;
-            lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs).ConfigureAwait(false);
+            lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs);
         }
         catch (MissingObjectLockConfigurationException)
         {
@@ -545,7 +545,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(item.Item1)
                     .WithVersionId(item.Item2);
-                var retentionConfig = await minio.GetObjectRetentionAsync(objectRetentionArgs).ConfigureAwait(false);
+                var retentionConfig = await minio.GetObjectRetentionAsync(objectRetentionArgs);
                 var bypassGovMode = retentionConfig.Mode == RetentionMode.GOVERNANCE ? true : false;
                 var removeObjectArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
@@ -582,7 +582,7 @@ public class FunctionalTest
         await Task.WhenAll(tasks);
         var rbArgs = new RemoveBucketArgs()
             .WithBucket(bucketName);
-        await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+        await minio.RemoveBucketAsync(rbArgs);
     }
 
     internal static string XmlStrToJsonStr(string xml)
@@ -629,7 +629,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -650,8 +650,8 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithServerSideEncryption(ssec);
-                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
-                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                await minio.StatObjectAsync(statObjectArgs);
+                await minio.GetObjectAsync(getObjectArgs);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test1", putObjectSignature,
@@ -713,7 +713,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithContentType(contentType)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -734,8 +734,8 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithServerSideEncryption(ssec);
-                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
-                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                await minio.StatObjectAsync(statObjectArgs);
+                await minio.GetObjectAsync(getObjectArgs);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test2", putObjectSignature,
@@ -795,7 +795,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(sses3)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -814,8 +814,8 @@ public class FunctionalTest
                 var statObjectArgs = new StatObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
-                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                await minio.StatObjectAsync(statObjectArgs);
+                await minio.GetObjectAsync(getObjectArgs);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test3", putObjectSignature,
@@ -862,7 +862,7 @@ public class FunctionalTest
                 .WithObjectSize(size)
                 .WithContentType(contentType)
                 .WithHeaders(metaData);
-            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            await minio.PutObjectAsync(putObjectArgs);
             File.Delete(tempFileName);
         }
     }
@@ -914,7 +914,7 @@ public class FunctionalTest
             var rmArgs = new RemoveObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
+            await minio.RemoveObjectAsync(rmArgs);
         }
 
         return statObject;
@@ -975,7 +975,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFileName(fileName);
-            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            await minio.PutObjectAsync(putObjectArgs);
             new MintLogger("FPutObject_Test1", putObjectSignature,
                 "Tests whether FPutObject for multipart upload passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();
@@ -1013,7 +1013,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFileName(fileName);
-            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            await minio.PutObjectAsync(putObjectArgs);
             new MintLogger("FPutObject_Test2", putObjectSignature, "Tests whether FPutObject for small upload passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -1056,7 +1056,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             new MintLogger("RemoveObject_Test1", removeObjectSignature1,
@@ -1159,7 +1159,7 @@ public class FunctionalTest
                     var removeObjectsArgs = new RemoveObjectsArgs()
                         .WithBucket(bucketName)
                         .WithObjectsVersions(objVersions);
-                    var rmObservable = await minio.RemoveObjectsAsync(removeObjectsArgs).ConfigureAwait(false);
+                    var rmObservable = await minio.RemoveObjectsAsync(removeObjectsArgs);
                     var deList = new List<DeleteError>();
                     var rmSub = rmObservable.Subscribe(
                         err => { deList.Add(err); },
@@ -1195,7 +1195,7 @@ public class FunctionalTest
 
         using (var fs = new FileStream(filePath, FileMode.CreateNew))
         {
-            await response.Content.CopyToAsync(fs).ConfigureAwait(false);
+            await response.Content.CopyToAsync(fs);
         }
     }
 
@@ -1245,7 +1245,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithPolicy(formPolicy);
 
-            var policyTuple = await minio.PresignedPostPolicyAsync(polArgs).ConfigureAwait(false);
+            var policyTuple = await minio.PresignedPostPolicyAsync(polArgs);
             var uri = policyTuple.Item1.AbsoluteUri;
 
             var curlCommand = "curl --insecure";
@@ -1323,7 +1323,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName);
 
-                await minio.RemoveIncompleteUploadAsync(rmArgs).ConfigureAwait(false);
+                await minio.RemoveIncompleteUploadAsync(rmArgs);
 
                 var listArgs = new ListIncompleteUploadsArgs()
                     .WithBucket(bucketName);
@@ -1531,7 +1531,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(stream)
                     .WithObjectSize(stream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var inputSerialization = new SelectObjectInputSerialization
@@ -1560,7 +1560,7 @@ public class FunctionalTest
                 .WithInputSerialization(inputSerialization)
                 .WithOutputSerialization(outputSerialization);
             var resp = await minio.SelectObjectContentAsync(selArgs).ConfigureAwait(false);
-            var output = await new StreamReader(resp.Payload).ReadToEndAsync().ConfigureAwait(false);
+            var output = await new StreamReader(resp.Payload).ReadToEndAsync();
             var csvStringNoWS = Regex.Replace(csvString.ToString(), @"\s+", "");
             var outputNoWS = Regex.Replace(output, @"\s+", "");
             // Compute MD5 for a better result.
@@ -1622,7 +1622,7 @@ public class FunctionalTest
         {
             var encryptionArgs = new SetBucketEncryptionArgs()
                 .WithBucket(bucketName);
-            await minio.SetBucketEncryptionAsync(encryptionArgs).ConfigureAwait(false);
+            await minio.SetBucketEncryptionAsync(encryptionArgs);
             new MintLogger(nameof(BucketEncryptionsAsync_Test1), setBucketEncryptionSignature,
                     "Tests whether SetBucketEncryptionAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1761,7 +1761,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithLegalHold(true);
-            await minio.SetObjectLegalHoldAsync(legalHoldArgs).ConfigureAwait(false);
+            await minio.SetObjectLegalHoldAsync(legalHoldArgs);
             new MintLogger(nameof(LegalHoldStatusAsync_Test1), setObjectLegalHoldSignature,
                     "Tests whether SetObjectLegalHoldAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1787,13 +1787,13 @@ public class FunctionalTest
             var getLegalHoldArgs = new GetObjectLegalHoldArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var enabled = await minio.GetObjectLegalHoldAsync(getLegalHoldArgs).ConfigureAwait(false);
+            var enabled = await minio.GetObjectLegalHoldAsync(getLegalHoldArgs);
             Assert.IsTrue(enabled);
             var rmArgs = new RemoveObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
 
-            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
+            await minio.RemoveObjectAsync(rmArgs);
             new MintLogger(nameof(LegalHoldStatusAsync_Test1), getObjectLegalHoldSignature,
                     "Tests whether GetObjectLegalHoldAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1853,7 +1853,7 @@ public class FunctionalTest
             var tagsArgs = new SetBucketTagsArgs()
                 .WithBucket(bucketName)
                 .WithTagging(Tagging.GetBucketTags(tags));
-            await minio.SetBucketTagsAsync(tagsArgs).ConfigureAwait(false);
+            await minio.SetBucketTagsAsync(tagsArgs);
             new MintLogger(nameof(BucketTagsAsync_Test1), setBucketTagsSignature,
                 "Tests whether SetBucketTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -1876,7 +1876,7 @@ public class FunctionalTest
         {
             var tagsArgs = new GetBucketTagsArgs()
                 .WithBucket(bucketName);
-            var tagObj = await minio.GetBucketTagsAsync(tagsArgs).ConfigureAwait(false);
+            var tagObj = await minio.GetBucketTagsAsync(tagsArgs);
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.GetTags());
             var tagsRes = tagObj.GetTags();
@@ -1904,10 +1904,10 @@ public class FunctionalTest
         {
             var tagsArgs = new RemoveBucketTagsArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketTagsAsync(tagsArgs).ConfigureAwait(false);
+            await minio.RemoveBucketTagsAsync(tagsArgs);
             var getTagsArgs = new GetBucketTagsArgs()
                 .WithBucket(bucketName);
-            var tagObj = await minio.GetBucketTagsAsync(getTagsArgs).ConfigureAwait(false);
+            var tagObj = await minio.GetBucketTagsAsync(getTagsArgs);
         }
         catch (NotImplementedException ex)
         {
@@ -1988,7 +1988,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithTagging(Tagging.GetObjectTags(tags));
-            await minio.SetObjectTagsAsync(tagsArgs).ConfigureAwait(false);
+            await minio.SetObjectTagsAsync(tagsArgs);
             new MintLogger(nameof(ObjectTagsAsync_Test1), setObjectTagsSignature,
                 "Tests whether SetObjectTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -2014,7 +2014,7 @@ public class FunctionalTest
             var tagsArgs = new GetObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var tagObj = await minio.GetObjectTagsAsync(tagsArgs).ConfigureAwait(false);
+            var tagObj = await minio.GetObjectTagsAsync(tagsArgs);
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.GetTags());
             var tagsRes = tagObj.GetTags();
@@ -2049,11 +2049,11 @@ public class FunctionalTest
             var tagsArgs = new RemoveObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.RemoveObjectTagsAsync(tagsArgs).ConfigureAwait(false);
+            await minio.RemoveObjectTagsAsync(tagsArgs);
             var getTagsArgs = new GetObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var tagObj = await minio.GetObjectTagsAsync(getTagsArgs).ConfigureAwait(false);
+            var tagObj = await minio.GetObjectTagsAsync(getTagsArgs);
             Assert.IsNotNull(tagObj);
             var tagsRes = tagObj.GetTags();
             Assert.IsNull(tagsRes);
@@ -2102,7 +2102,7 @@ public class FunctionalTest
                 var setVersioningArgs = new SetVersioningArgs()
                     .WithBucket(bucketName)
                     .WithVersioningEnabled();
-                await minio.SetVersioningAsync(setVersioningArgs).ConfigureAwait(false);
+                await minio.SetVersioningAsync(setVersioningArgs);
 
                 // Twice, for 2 versions.
                 using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
@@ -2152,7 +2152,7 @@ public class FunctionalTest
                 // Get Versioning Test
                 var getVersioningArgs = new GetVersioningArgs()
                     .WithBucket(bucketName);
-                var versioningConfig = await minio.GetVersioningAsync(getVersioningArgs).ConfigureAwait(false);
+                var versioningConfig = await minio.GetVersioningAsync(getVersioningArgs);
                 Assert.IsNotNull(versioningConfig);
                 Assert.IsNotNull(versioningConfig.Status);
                 Assert.IsTrue(versioningConfig.Status.ToLower().Equals("enabled"));
@@ -2166,7 +2166,7 @@ public class FunctionalTest
                 var setVersioningArgs = new SetVersioningArgs()
                     .WithBucket(bucketName)
                     .WithVersioningSuspended();
-                await minio.SetVersioningAsync(setVersioningArgs).ConfigureAwait(false);
+                await minio.SetVersioningAsync(setVersioningArgs);
 
                 var objectCount = 1;
                 var objectIndex = 0;
@@ -2280,7 +2280,7 @@ public class FunctionalTest
                 .WithLockConfiguration(
                     new ObjectLockConfiguration(RetentionMode.GOVERNANCE, 33)
                 );
-            await minio.SetObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
+            await minio.SetObjectLockConfigurationAsync(objectLockArgs);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();
@@ -2305,7 +2305,7 @@ public class FunctionalTest
         {
             var objectLockArgs = new GetObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            var config = await minio.GetObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
+            var config = await minio.GetObjectLockConfigurationAsync(objectLockArgs);
             Assert.IsNotNull(config);
             Assert.IsTrue(config.ObjectLockEnabled.Contains(ObjectLockConfiguration.LockEnabled));
             Assert.IsNotNull(config.Rule);
@@ -2345,10 +2345,10 @@ public class FunctionalTest
 
             var objectLockArgs = new RemoveObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
+            await minio.RemoveObjectLockConfigurationAsync(objectLockArgs);
             var getObjectLockArgs = new GetObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            var config = await minio.GetObjectLockConfigurationAsync(getObjectLockArgs).ConfigureAwait(false);
+            var config = await minio.GetObjectLockConfigurationAsync(getObjectLockArgs);
             Assert.IsNotNull(config);
             Assert.IsNull(config.Rule);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), deleteObjectLockConfigurationSignature,
@@ -2432,7 +2432,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithRetentionMode(RetentionMode.GOVERNANCE)
                 .WithRetentionUntilDate(untilDate);
-            await minio.SetObjectRetentionAsync(setRetentionArgs).ConfigureAwait(false);
+            await minio.SetObjectRetentionAsync(setRetentionArgs);
             new MintLogger(nameof(ObjectRetentionAsync_Test1), setObjectRetentionSignature,
                     "Tests whether SetObjectRetentionAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -2458,7 +2458,7 @@ public class FunctionalTest
             var getRetentionArgs = new GetObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var config = await minio.GetObjectRetentionAsync(getRetentionArgs).ConfigureAwait(false);
+            var config = await minio.GetObjectRetentionAsync(getRetentionArgs);
             var plusDays = 10.0;
             Assert.IsNotNull(config);
             Assert.AreEqual(config.Mode, RetentionMode.GOVERNANCE);
@@ -2489,11 +2489,11 @@ public class FunctionalTest
             var clearRetentionArgs = new ClearObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.ClearObjectRetentionAsync(clearRetentionArgs).ConfigureAwait(false);
+            await minio.ClearObjectRetentionAsync(clearRetentionArgs);
             var getRetentionArgs = new GetObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var config = await minio.GetObjectRetentionAsync(getRetentionArgs).ConfigureAwait(false);
+            var config = await minio.GetObjectRetentionAsync(getRetentionArgs);
         }
         catch (NotImplementedException ex)
         {
@@ -2526,7 +2526,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName);
 
-            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
+            await minio.RemoveObjectAsync(rmArgs);
             await TearDown(minio, bucketName);
         }
         catch (Exception ex)
@@ -2560,8 +2560,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test1), makeBucketSignature, "Tests whether MakeBucket passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2574,7 +2574,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -2599,8 +2599,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test2), makeBucketSignature, testType, TestStatus.PASS,
                 DateTime.Now - startTime, args: args).Log();
@@ -2613,7 +2613,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -2637,8 +2637,8 @@ public class FunctionalTest
         };
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test3), makeBucketSignature, "Tests whether MakeBucket with region passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2651,7 +2651,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -2675,8 +2675,8 @@ public class FunctionalTest
         };
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test4), makeBucketSignature,
                 "Tests whether MakeBucket with region and bucketname with . passes", TestStatus.PASS,
@@ -2691,7 +2691,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -2742,8 +2742,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
-            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            await minio.MakeBucketAsync(mbArgs);
+            var found = await minio.BucketExistsAsync(beArgs);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test1), makeBucketSignature, "Tests whether MakeBucket with Lock passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2756,7 +2756,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            await minio.RemoveBucketAsync(rbArgs);
         }
     }
 
@@ -2979,11 +2979,11 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(size)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
                 var rmArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
+                await minio.RemoveObjectAsync(rmArgs);
             }
 
             new MintLogger(nameof(PutObject_Test7), putObjectSignature,
@@ -3032,11 +3032,11 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(size)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
                 var rmArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
+                await minio.RemoveObjectAsync(rmArgs);
             }
 
             new MintLogger(nameof(PutObject_Test8), putObjectSignature,
@@ -3090,7 +3090,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
                 // .WithHeaders(null);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3101,13 +3101,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             File.Delete(outFileName);
             var rmArgs1 = new RemoveObjectArgs()
                 .WithBucket(bucketName)
@@ -3161,7 +3161,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithHeaders(null);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
         }
         catch (Exception ex)
@@ -3187,7 +3187,7 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
         }
         catch (MinioException ex)
         {
@@ -3249,13 +3249,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
 
             var conditions = new CopyConditions();
             conditions.SetMatchETag(stats.ETag);
@@ -3268,16 +3268,16 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var dstats = await minio.StatObjectAsync(statObjectArgs);
             Assert.IsNotNull(dstats);
             Assert.IsTrue(dstats.ObjectName.Contains(destObjectName));
             new MintLogger("CopyObject_Test3", copyObjectSignature, "Tests whether CopyObject with Etag match passes",
@@ -3326,7 +3326,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var conditions = new CopyConditions();
@@ -3339,17 +3339,17 @@ public class FunctionalTest
                 .WithCopyObjectSource(copySourceObjectArgs)
                 .WithBucket(destBucketName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.ObjectName.Contains(objectName));
             new MintLogger("CopyObject_Test4", copyObjectSignature,
@@ -3400,7 +3400,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var conditions = new CopyConditions();
@@ -3415,11 +3415,11 @@ public class FunctionalTest
                 .WithCopyObjectSource(copySourceObjectArgs)
                 .WithBucket(destBucketName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.ObjectName.Contains(objectName));
             Assert.AreEqual(6291455 - 1024 + 1, stats.Size);
@@ -3477,13 +3477,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
 
             var conditions = new CopyConditions();
             conditions.SetModified(new DateTime(2017, 8, 18));
@@ -3497,16 +3497,16 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var dstats = await minio.StatObjectAsync(statObjectArgs);
             Assert.IsNotNull(dstats);
             Assert.IsTrue(dstats.ObjectName.Contains(destObjectName));
             new MintLogger("CopyObject_Test6", copyObjectSignature,
@@ -3556,13 +3556,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
 
             var conditions = new CopyConditions();
             var modifiedDate = DateTime.Now;
@@ -3579,7 +3579,7 @@ public class FunctionalTest
                     .WithCopyObjectSource(copySourceObjectArgs)
                     .WithBucket(destBucketName)
                     .WithObject(destObjectName);
-                await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+                await minio.CopyObjectAsync(copyObjectArgs);
             }
             catch (Exception ex)
             {
@@ -3665,13 +3665,13 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithHeaders(new Dictionary<string, string> { { "Orig", "orig-val with  spaces" } });
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
 
             Assert.IsTrue(stats.MetaData["Orig"] != null);
 
@@ -3696,12 +3696,12 @@ public class FunctionalTest
                 .WithObject(destObjectName)
                 .WithHeaders(customMetadata);
 
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var dstats = await minio.StatObjectAsync(statObjectArgs);
             Assert.IsTrue(dstats.MetaData["Content-Type"] != null);
             Assert.IsTrue(dstats.MetaData["Mynewkey"] != null);
             Assert.IsTrue(dstats.MetaData["Content-Type"].Contains("application/css"));
@@ -3752,7 +3752,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
                 var putTags = new Dictionary<string, string>
                 {
                     { "key1", "PutObjectTags" }
@@ -3761,7 +3761,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithTagging(Tagging.GetObjectTags(putTags));
-                await minio.SetObjectTagsAsync(setObjectTagsArgs).ConfigureAwait(false);
+                await minio.SetObjectTagsAsync(setObjectTagsArgs);
             }
 
             var copyTags = new Dictionary<string, string>
@@ -3778,12 +3778,12 @@ public class FunctionalTest
                 .WithObject(destObjectName)
                 .WithTagging(Tagging.GetObjectTags(copyTags))
                 .WithReplaceTagsDirective(true);
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             var getObjectTagsArgs = new GetObjectTagsArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var tags = await minio.GetObjectTagsAsync(getObjectTagsArgs).ConfigureAwait(false);
+            var tags = await minio.GetObjectTagsAsync(getObjectTagsArgs);
             Assert.IsNotNull(tags);
             var copiedTags = tags.GetTags();
             Assert.IsNotNull(tags);
@@ -3851,7 +3851,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3863,13 +3863,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(ssecDst);
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(ssecDst)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             new MintLogger("EncryptedCopyObject_Test1", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -3932,7 +3932,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3944,13 +3944,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(null);
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             new MintLogger("EncryptedCopyObject_Test2", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4013,7 +4013,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -4025,12 +4025,12 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(sses3);
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             new MintLogger("EncryptedCopyObject_Test3", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4083,7 +4083,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(sses3);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -4095,13 +4095,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(sses3);
-            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
+            await minio.CopyObjectAsync(copyObjectArgs);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             new MintLogger("EncryptedCopyObject_Test4", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4152,7 +4152,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -4168,7 +4168,7 @@ public class FunctionalTest
                         Assert.AreEqual(file_write_size, file_read_size);
                         File.Delete(tempFileName);
                     });
-                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                await minio.GetObjectAsync(getObjectArgs);
             }
 
             Thread.Sleep(1000);
@@ -4213,7 +4213,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
         }
         catch (Exception ex)
@@ -4231,7 +4231,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithFile(fileName);
 
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             Assert.IsTrue(File.Exists(fileName));
             new MintLogger("GetObject_Test2", getObjectSignature, "Tests whether GetObject with a file name works",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -4329,7 +4329,7 @@ public class FunctionalTest
                         .WithStreamData(filestream)
                         .WithObjectSize(objectSize)
                         .WithContentType(contentType);
-                    await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                    await minio.PutObjectAsync(putObjectArgs);
 
                     var getObjectArgs = new GetObjectArgs()
                         .WithBucket(bucketName)
@@ -4350,7 +4350,7 @@ public class FunctionalTest
                             Assert.AreEqual(actualContent, expectedContent);
                         });
 
-                    await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                    await minio.GetObjectAsync(getObjectArgs);
                 }
 
                 new MintLogger(testName, getObjectSignature, "Tests whether GetObject returns all the data",
@@ -4393,14 +4393,14 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+            await minio.GetObjectAsync(getObjectArgs);
             new MintLogger("FGetObject_Test1", getObjectSignature, "Tests whether FGetObject passes for small upload",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -4819,19 +4819,19 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
 
             var preArgs = new PresignedGetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(expiresInt);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
 
             await DownloadObjectAsync(minio, presigned_url, downloadFile).ConfigureAwait(false);
             var writtenInfo = new FileInfo(downloadFile);
@@ -4880,18 +4880,18 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             var preArgs = new PresignedGetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(0);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
             throw new InvalidOperationException(
                 "PresignedGetObjectAsync expected to throw an InvalidExpiryRangeException.");
         }
@@ -4951,13 +4951,13 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             var reqParams = new Dictionary<string, string>
             {
                 ["response-content-type"] = "application/json",
@@ -4969,7 +4969,7 @@ public class FunctionalTest
                 .WithExpiry(1000)
                 .WithHeaders(reqParams)
                 .WithRequestDate(reqDate);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
 
             var response = await minio.WrapperGetAsync(presigned_url).ConfigureAwait(false);
             if (string.IsNullOrEmpty(Convert.ToString(response.Content)) ||
@@ -4984,7 +4984,7 @@ public class FunctionalTest
 
             using (var fs = new FileStream(downloadFile, FileMode.CreateNew))
             {
-                await response.Content.CopyToAsync(fs).ConfigureAwait(false);
+                await response.Content.CopyToAsync(fs);
             }
 
             var writtenInfo = new FileInfo(downloadFile);
@@ -5037,13 +5037,13 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(1000);
-            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs);
             await UploadObjectAsync(minio, presigned_url, fileName);
             // Get stats for object from server
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             // Compare with file used for upload
             var writtenInfo = new FileInfo(fileName);
             var file_written_size = writtenInfo.Length;
@@ -5090,18 +5090,18 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var stats = await minio.StatObjectAsync(statObjectArgs);
             var presignedPutObjectArgs = new PresignedPutObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(0);
-            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs);
             new MintLogger("PresignedPutObject_Test2", presignedPutObjectSignature,
                 "Tests whether PresignedPutObject url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -5350,7 +5350,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var policyJson =
@@ -5359,7 +5359,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithPolicy(policyJson);
 
-            await minio.SetPolicyAsync(setPolicyArgs).ConfigureAwait(false);
+            await minio.SetPolicyAsync(setPolicyArgs);
             new MintLogger("SetBucketPolicy_Test1", setBucketPolicySignature, "Tests whether SetBucketPolicy passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -5406,7 +5406,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+                await minio.PutObjectAsync(putObjectArgs);
             }
 
             var setPolicyArgs = new SetPolicyArgs()
@@ -5416,9 +5416,9 @@ public class FunctionalTest
                 .WithBucket(bucketName);
             var rmPolicyArgs = new RemovePolicyArgs()
                 .WithBucket(bucketName);
-            await minio.SetPolicyAsync(setPolicyArgs).ConfigureAwait(false);
-            var policy = await minio.GetPolicyAsync(getPolicyArgs).ConfigureAwait(false);
-            await minio.RemovePolicyAsync(rmPolicyArgs).ConfigureAwait(false);
+            await minio.SetPolicyAsync(setPolicyArgs);
+            var policy = await minio.GetPolicyAsync(getPolicyArgs);
+            await minio.RemovePolicyAsync(rmPolicyArgs);
             new MintLogger("GetBucketPolicy_Test1", getBucketPolicySignature, "Tests whether GetBucketPolicy passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -5481,7 +5481,7 @@ public class FunctionalTest
             var lfcArgs = new SetBucketLifecycleArgs()
                 .WithBucket(bucketName)
                 .WithLifecycleConfiguration(lfc);
-            await minio.SetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            await minio.SetBucketLifecycleAsync(lfcArgs);
             new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".1", setBucketLifecycleSignature,
                     "Tests whether SetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -5506,7 +5506,7 @@ public class FunctionalTest
         {
             var lfcArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs);
             Assert.IsNotNull(lfcObj);
             Assert.IsNotNull(lfcObj.Rules);
             Assert.IsTrue(lfcObj.Rules.Count > 0);
@@ -5537,10 +5537,10 @@ public class FunctionalTest
         {
             var lfcArgs = new RemoveBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            await minio.RemoveBucketLifecycleAsync(lfcArgs);
             var getLifecycleArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs).ConfigureAwait(false);
+            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs);
         }
         catch (NotImplementedException ex)
         {
@@ -5606,7 +5606,7 @@ public class FunctionalTest
             var lfcArgs = new SetBucketLifecycleArgs()
                 .WithBucket(bucketName)
                 .WithLifecycleConfiguration(lfc);
-            await minio.SetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            await minio.SetBucketLifecycleAsync(lfcArgs);
             new MintLogger(nameof(BucketLifecycleAsync_Test2) + ".1", setBucketLifecycleSignature,
                     "Tests whether SetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -5631,7 +5631,7 @@ public class FunctionalTest
         {
             var lfcArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs);
             Assert.IsNotNull(lfcObj);
             Assert.IsNotNull(lfcObj.Rules);
             Assert.IsTrue(lfcObj.Rules.Count > 0);
@@ -5660,10 +5660,10 @@ public class FunctionalTest
         {
             var lfcArgs = new RemoveBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
+            await minio.RemoveBucketLifecycleAsync(lfcArgs);
             var getLifecycleArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs).ConfigureAwait(false);
+            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs);
         }
         catch (NotImplementedException ex)
         {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,8 +332,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExists passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -351,7 +351,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -373,11 +373,11 @@ public class FunctionalTest
         var found = false;
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
-            await minio.RemoveBucketAsync(rbArgs);
-            found = await minio.BucketExistsAsync(beArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsFalse(found);
             new MintLogger(nameof(RemoveBucket_Test1), removeBucketSignature, "Tests whether RemoveBucket passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -391,7 +391,7 @@ public class FunctionalTest
         finally
         {
             if (found)
-                await minio.RemoveBucketAsync(rbArgs);
+                await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -420,7 +420,7 @@ public class FunctionalTest
 
         try
         {
-            var list = await minio.ListBucketsAsync();
+            var list = await minio.ListBucketsAsync().ConfigureAwait(false);
             bucketList = list.Buckets;
             bucketList = bucketList.Where(x => x.Name.StartsWith(bucketName)).ToList();
             Assert.AreEqual(noOfBuckets, bucketList.Count());
@@ -453,7 +453,7 @@ public class FunctionalTest
             {
                 var rbArgs = new RemoveBucketArgs()
                     .WithBucket(bucket.Name);
-                await minio.RemoveBucketAsync(rbArgs);
+                await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
             }
         }
     }
@@ -465,8 +465,8 @@ public class FunctionalTest
         if (await minio.BucketExistsAsync(beArgs)) return;
         var mbArgs = new MakeBucketArgs()
             .WithBucket(bucketName);
-        await minio.MakeBucketAsync(mbArgs);
-        var found = await minio.BucketExistsAsync(beArgs);
+        await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+        var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
         Assert.IsTrue(found);
     }
 
@@ -477,8 +477,8 @@ public class FunctionalTest
             .WithObjectLock();
         var beArgs = new BucketExistsArgs()
             .WithBucket(bucketName);
-        await minio.MakeBucketAsync(mbArgs);
-        var found = await minio.BucketExistsAsync(beArgs);
+        await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+        var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
         Assert.IsTrue(found);
     }
 
@@ -486,7 +486,7 @@ public class FunctionalTest
     {
         var beArgs = new BucketExistsArgs()
             .WithBucket(bucketName);
-        var bktExists = await minio.BucketExistsAsync(beArgs);
+        var bktExists = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
         if (!bktExists)
             return;
         var taskList = new List<Task>();
@@ -503,7 +503,7 @@ public class FunctionalTest
                 .WithBucket(bucketName));
             if (versioningConfig != null && (versioningConfig.Status.Contains("Enabled") ||
                                              versioningConfig.Status.Contains("Suspended"))) getVersions = true;
-            lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs);
+            lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs).ConfigureAwait(false);
         }
         catch (MissingObjectLockConfigurationException)
         {
@@ -545,7 +545,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(item.Item1)
                     .WithVersionId(item.Item2);
-                var retentionConfig = await minio.GetObjectRetentionAsync(objectRetentionArgs);
+                var retentionConfig = await minio.GetObjectRetentionAsync(objectRetentionArgs).ConfigureAwait(false);
                 var bypassGovMode = retentionConfig.Mode == RetentionMode.GOVERNANCE ? true : false;
                 var removeObjectArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
@@ -582,7 +582,7 @@ public class FunctionalTest
         await Task.WhenAll(tasks);
         var rbArgs = new RemoveBucketArgs()
             .WithBucket(bucketName);
-        await minio.RemoveBucketAsync(rbArgs);
+        await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
     }
 
     internal static string XmlStrToJsonStr(string xml)
@@ -629,7 +629,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -650,8 +650,8 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithServerSideEncryption(ssec);
-                await minio.StatObjectAsync(statObjectArgs);
-                await minio.GetObjectAsync(getObjectArgs);
+                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test1", putObjectSignature,
@@ -713,7 +713,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithContentType(contentType)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -734,8 +734,8 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithServerSideEncryption(ssec);
-                await minio.StatObjectAsync(statObjectArgs);
-                await minio.GetObjectAsync(getObjectArgs);
+                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test2", putObjectSignature,
@@ -795,7 +795,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(sses3)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -814,8 +814,8 @@ public class FunctionalTest
                 var statObjectArgs = new StatObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.StatObjectAsync(statObjectArgs);
-                await minio.GetObjectAsync(getObjectArgs);
+                await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             }
 
             new MintLogger("PutGetStatEncryptedObject_Test3", putObjectSignature,
@@ -862,7 +862,7 @@ public class FunctionalTest
                 .WithObjectSize(size)
                 .WithContentType(contentType)
                 .WithHeaders(metaData);
-            await minio.PutObjectAsync(putObjectArgs);
+            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             File.Delete(tempFileName);
         }
     }
@@ -914,7 +914,7 @@ public class FunctionalTest
             var rmArgs = new RemoveObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.RemoveObjectAsync(rmArgs);
+            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
         }
 
         return statObject;
@@ -975,7 +975,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFileName(fileName);
-            await minio.PutObjectAsync(putObjectArgs);
+            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             new MintLogger("FPutObject_Test1", putObjectSignature,
                 "Tests whether FPutObject for multipart upload passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();
@@ -1013,7 +1013,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFileName(fileName);
-            await minio.PutObjectAsync(putObjectArgs);
+            await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             new MintLogger("FPutObject_Test2", putObjectSignature, "Tests whether FPutObject for small upload passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -1056,7 +1056,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             new MintLogger("RemoveObject_Test1", removeObjectSignature1,
@@ -1159,7 +1159,7 @@ public class FunctionalTest
                     var removeObjectsArgs = new RemoveObjectsArgs()
                         .WithBucket(bucketName)
                         .WithObjectsVersions(objVersions);
-                    var rmObservable = await minio.RemoveObjectsAsync(removeObjectsArgs);
+                    var rmObservable = await minio.RemoveObjectsAsync(removeObjectsArgs).ConfigureAwait(false);
                     var deList = new List<DeleteError>();
                     var rmSub = rmObservable.Subscribe(
                         err => { deList.Add(err); },
@@ -1187,37 +1187,23 @@ public class FunctionalTest
         }
     }
 
-    internal static async Task DownloadObjectAsync(string url, string filePath)
+    internal static async Task DownloadObjectAsync(MinioClient minio, string url, string filePath)
     {
-        var clientHandler = new HttpClientHandler();
-        clientHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) =>
-        {
-            return true;
-        };
-        var client = new HttpClient(clientHandler);
-
-        var response = await client.GetAsync(url);
+        var response = await minio.WrapperGetAsync(url).ConfigureAwait(false);
         if (string.IsNullOrEmpty(Convert.ToString(response.Content)) || !HttpStatusCode.OK.Equals(response.StatusCode))
             throw new ArgumentNullException("Unable to download via presigned URL");
 
         using (var fs = new FileStream(filePath, FileMode.CreateNew))
         {
-            await response.Content.CopyToAsync(fs);
+            await response.Content.CopyToAsync(fs).ConfigureAwait(false);
         }
     }
 
-    internal static async Task UploadObjectAsync(string url, string filePath)
+    internal static async Task UploadObjectAsync(MinioClient minio, string url, string filePath)
     {
-        var clientHandler = new HttpClientHandler();
-        clientHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) =>
-        {
-            return true;
-        };
-        var client = new HttpClient(clientHandler);
-
         using (var strm = new StreamContent(new FileStream(filePath, FileMode.Open, FileAccess.Read)))
         {
-            await client.PutAsync(url, strm);
+            await minio.WrapperPutAsync(url, strm).ConfigureAwait(false);
         }
     }
 
@@ -1259,7 +1245,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithPolicy(formPolicy);
 
-            var policyTuple = await minio.PresignedPostPolicyAsync(polArgs);
+            var policyTuple = await minio.PresignedPostPolicyAsync(polArgs).ConfigureAwait(false);
             var uri = policyTuple.Item1.AbsoluteUri;
 
             var curlCommand = "curl --insecure";
@@ -1337,7 +1323,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName);
 
-                await minio.RemoveIncompleteUploadAsync(rmArgs);
+                await minio.RemoveIncompleteUploadAsync(rmArgs).ConfigureAwait(false);
 
                 var listArgs = new ListIncompleteUploadsArgs()
                     .WithBucket(bucketName);
@@ -1545,7 +1531,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(stream)
                     .WithObjectSize(stream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var inputSerialization = new SelectObjectInputSerialization
@@ -1574,7 +1560,7 @@ public class FunctionalTest
                 .WithInputSerialization(inputSerialization)
                 .WithOutputSerialization(outputSerialization);
             var resp = await minio.SelectObjectContentAsync(selArgs).ConfigureAwait(false);
-            var output = await new StreamReader(resp.Payload).ReadToEndAsync();
+            var output = await new StreamReader(resp.Payload).ReadToEndAsync().ConfigureAwait(false);
             var csvStringNoWS = Regex.Replace(csvString.ToString(), @"\s+", "");
             var outputNoWS = Regex.Replace(output, @"\s+", "");
             // Compute MD5 for a better result.
@@ -1636,7 +1622,7 @@ public class FunctionalTest
         {
             var encryptionArgs = new SetBucketEncryptionArgs()
                 .WithBucket(bucketName);
-            await minio.SetBucketEncryptionAsync(encryptionArgs);
+            await minio.SetBucketEncryptionAsync(encryptionArgs).ConfigureAwait(false);
             new MintLogger(nameof(BucketEncryptionsAsync_Test1), setBucketEncryptionSignature,
                     "Tests whether SetBucketEncryptionAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1775,7 +1761,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithLegalHold(true);
-            await minio.SetObjectLegalHoldAsync(legalHoldArgs);
+            await minio.SetObjectLegalHoldAsync(legalHoldArgs).ConfigureAwait(false);
             new MintLogger(nameof(LegalHoldStatusAsync_Test1), setObjectLegalHoldSignature,
                     "Tests whether SetObjectLegalHoldAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1801,13 +1787,13 @@ public class FunctionalTest
             var getLegalHoldArgs = new GetObjectLegalHoldArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var enabled = await minio.GetObjectLegalHoldAsync(getLegalHoldArgs);
+            var enabled = await minio.GetObjectLegalHoldAsync(getLegalHoldArgs).ConfigureAwait(false);
             Assert.IsTrue(enabled);
             var rmArgs = new RemoveObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
 
-            await minio.RemoveObjectAsync(rmArgs);
+            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
             new MintLogger(nameof(LegalHoldStatusAsync_Test1), getObjectLegalHoldSignature,
                     "Tests whether GetObjectLegalHoldAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -1867,7 +1853,7 @@ public class FunctionalTest
             var tagsArgs = new SetBucketTagsArgs()
                 .WithBucket(bucketName)
                 .WithTagging(Tagging.GetBucketTags(tags));
-            await minio.SetBucketTagsAsync(tagsArgs);
+            await minio.SetBucketTagsAsync(tagsArgs).ConfigureAwait(false);
             new MintLogger(nameof(BucketTagsAsync_Test1), setBucketTagsSignature,
                 "Tests whether SetBucketTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -1890,7 +1876,7 @@ public class FunctionalTest
         {
             var tagsArgs = new GetBucketTagsArgs()
                 .WithBucket(bucketName);
-            var tagObj = await minio.GetBucketTagsAsync(tagsArgs);
+            var tagObj = await minio.GetBucketTagsAsync(tagsArgs).ConfigureAwait(false);
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.GetTags());
             var tagsRes = tagObj.GetTags();
@@ -1918,10 +1904,10 @@ public class FunctionalTest
         {
             var tagsArgs = new RemoveBucketTagsArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketTagsAsync(tagsArgs);
+            await minio.RemoveBucketTagsAsync(tagsArgs).ConfigureAwait(false);
             var getTagsArgs = new GetBucketTagsArgs()
                 .WithBucket(bucketName);
-            var tagObj = await minio.GetBucketTagsAsync(getTagsArgs);
+            var tagObj = await minio.GetBucketTagsAsync(getTagsArgs).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -2002,7 +1988,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithTagging(Tagging.GetObjectTags(tags));
-            await minio.SetObjectTagsAsync(tagsArgs);
+            await minio.SetObjectTagsAsync(tagsArgs).ConfigureAwait(false);
             new MintLogger(nameof(ObjectTagsAsync_Test1), setObjectTagsSignature,
                 "Tests whether SetObjectTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -2028,7 +2014,7 @@ public class FunctionalTest
             var tagsArgs = new GetObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var tagObj = await minio.GetObjectTagsAsync(tagsArgs);
+            var tagObj = await minio.GetObjectTagsAsync(tagsArgs).ConfigureAwait(false);
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.GetTags());
             var tagsRes = tagObj.GetTags();
@@ -2063,11 +2049,11 @@ public class FunctionalTest
             var tagsArgs = new RemoveObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.RemoveObjectTagsAsync(tagsArgs);
+            await minio.RemoveObjectTagsAsync(tagsArgs).ConfigureAwait(false);
             var getTagsArgs = new GetObjectTagsArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var tagObj = await minio.GetObjectTagsAsync(getTagsArgs);
+            var tagObj = await minio.GetObjectTagsAsync(getTagsArgs).ConfigureAwait(false);
             Assert.IsNotNull(tagObj);
             var tagsRes = tagObj.GetTags();
             Assert.IsNull(tagsRes);
@@ -2116,7 +2102,7 @@ public class FunctionalTest
                 var setVersioningArgs = new SetVersioningArgs()
                     .WithBucket(bucketName)
                     .WithVersioningEnabled();
-                await minio.SetVersioningAsync(setVersioningArgs);
+                await minio.SetVersioningAsync(setVersioningArgs).ConfigureAwait(false);
 
                 // Twice, for 2 versions.
                 using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
@@ -2166,7 +2152,7 @@ public class FunctionalTest
                 // Get Versioning Test
                 var getVersioningArgs = new GetVersioningArgs()
                     .WithBucket(bucketName);
-                var versioningConfig = await minio.GetVersioningAsync(getVersioningArgs);
+                var versioningConfig = await minio.GetVersioningAsync(getVersioningArgs).ConfigureAwait(false);
                 Assert.IsNotNull(versioningConfig);
                 Assert.IsNotNull(versioningConfig.Status);
                 Assert.IsTrue(versioningConfig.Status.ToLower().Equals("enabled"));
@@ -2180,7 +2166,7 @@ public class FunctionalTest
                 var setVersioningArgs = new SetVersioningArgs()
                     .WithBucket(bucketName)
                     .WithVersioningSuspended();
-                await minio.SetVersioningAsync(setVersioningArgs);
+                await minio.SetVersioningAsync(setVersioningArgs).ConfigureAwait(false);
 
                 var objectCount = 1;
                 var objectIndex = 0;
@@ -2294,7 +2280,7 @@ public class FunctionalTest
                 .WithLockConfiguration(
                     new ObjectLockConfiguration(RetentionMode.GOVERNANCE, 33)
                 );
-            await minio.SetObjectLockConfigurationAsync(objectLockArgs);
+            await minio.SetObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();
@@ -2319,7 +2305,7 @@ public class FunctionalTest
         {
             var objectLockArgs = new GetObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            var config = await minio.GetObjectLockConfigurationAsync(objectLockArgs);
+            var config = await minio.GetObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
             Assert.IsNotNull(config);
             Assert.IsTrue(config.ObjectLockEnabled.Contains(ObjectLockConfiguration.LockEnabled));
             Assert.IsNotNull(config.Rule);
@@ -2359,10 +2345,10 @@ public class FunctionalTest
 
             var objectLockArgs = new RemoveObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveObjectLockConfigurationAsync(objectLockArgs);
+            await minio.RemoveObjectLockConfigurationAsync(objectLockArgs).ConfigureAwait(false);
             var getObjectLockArgs = new GetObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
-            var config = await minio.GetObjectLockConfigurationAsync(getObjectLockArgs);
+            var config = await minio.GetObjectLockConfigurationAsync(getObjectLockArgs).ConfigureAwait(false);
             Assert.IsNotNull(config);
             Assert.IsNull(config.Rule);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), deleteObjectLockConfigurationSignature,
@@ -2446,7 +2432,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithRetentionMode(RetentionMode.GOVERNANCE)
                 .WithRetentionUntilDate(untilDate);
-            await minio.SetObjectRetentionAsync(setRetentionArgs);
+            await minio.SetObjectRetentionAsync(setRetentionArgs).ConfigureAwait(false);
             new MintLogger(nameof(ObjectRetentionAsync_Test1), setObjectRetentionSignature,
                     "Tests whether SetObjectRetentionAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -2472,7 +2458,7 @@ public class FunctionalTest
             var getRetentionArgs = new GetObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var config = await minio.GetObjectRetentionAsync(getRetentionArgs);
+            var config = await minio.GetObjectRetentionAsync(getRetentionArgs).ConfigureAwait(false);
             var plusDays = 10.0;
             Assert.IsNotNull(config);
             Assert.AreEqual(config.Mode, RetentionMode.GOVERNANCE);
@@ -2503,11 +2489,11 @@ public class FunctionalTest
             var clearRetentionArgs = new ClearObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            await minio.ClearObjectRetentionAsync(clearRetentionArgs);
+            await minio.ClearObjectRetentionAsync(clearRetentionArgs).ConfigureAwait(false);
             var getRetentionArgs = new GetObjectRetentionArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var config = await minio.GetObjectRetentionAsync(getRetentionArgs);
+            var config = await minio.GetObjectRetentionAsync(getRetentionArgs).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -2540,7 +2526,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName);
 
-            await minio.RemoveObjectAsync(rmArgs);
+            await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
             await TearDown(minio, bucketName);
         }
         catch (Exception ex)
@@ -2574,8 +2560,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test1), makeBucketSignature, "Tests whether MakeBucket passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2588,7 +2574,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -2613,8 +2599,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test2), makeBucketSignature, testType, TestStatus.PASS,
                 DateTime.Now - startTime, args: args).Log();
@@ -2627,7 +2613,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -2651,8 +2637,8 @@ public class FunctionalTest
         };
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test3), makeBucketSignature, "Tests whether MakeBucket with region passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2665,7 +2651,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -2689,8 +2675,8 @@ public class FunctionalTest
         };
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test4), makeBucketSignature,
                 "Tests whether MakeBucket with region and bucketname with . passes", TestStatus.PASS,
@@ -2705,7 +2691,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -2756,8 +2742,8 @@ public class FunctionalTest
 
         try
         {
-            await minio.MakeBucketAsync(mbArgs);
-            var found = await minio.BucketExistsAsync(beArgs);
+            await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
+            var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsTrue(found);
             new MintLogger(nameof(MakeBucket_Test1), makeBucketSignature, "Tests whether MakeBucket with Lock passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2770,7 +2756,7 @@ public class FunctionalTest
         }
         finally
         {
-            await minio.RemoveBucketAsync(rbArgs);
+            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
         }
     }
 
@@ -2993,11 +2979,11 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(size)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
                 var rmArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.RemoveObjectAsync(rmArgs);
+                await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
             }
 
             new MintLogger(nameof(PutObject_Test7), putObjectSignature,
@@ -3046,11 +3032,11 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(size)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
                 var rmArgs = new RemoveObjectArgs()
                     .WithBucket(bucketName)
                     .WithObject(objectName);
-                await minio.RemoveObjectAsync(rmArgs);
+                await minio.RemoveObjectAsync(rmArgs).ConfigureAwait(false);
             }
 
             new MintLogger(nameof(PutObject_Test8), putObjectSignature,
@@ -3104,7 +3090,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
                 // .WithHeaders(null);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3115,13 +3101,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             File.Delete(outFileName);
             var rmArgs1 = new RemoveObjectArgs()
                 .WithBucket(bucketName)
@@ -3175,7 +3161,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithHeaders(null);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -3201,7 +3187,7 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
         }
         catch (MinioException ex)
         {
@@ -3263,13 +3249,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
 
             var conditions = new CopyConditions();
             conditions.SetMatchETag(stats.ETag);
@@ -3282,16 +3268,16 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs);
+            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             Assert.IsNotNull(dstats);
             Assert.IsTrue(dstats.ObjectName.Contains(destObjectName));
             new MintLogger("CopyObject_Test3", copyObjectSignature, "Tests whether CopyObject with Etag match passes",
@@ -3340,7 +3326,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var conditions = new CopyConditions();
@@ -3353,17 +3339,17 @@ public class FunctionalTest
                 .WithCopyObjectSource(copySourceObjectArgs)
                 .WithBucket(destBucketName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.ObjectName.Contains(objectName));
             new MintLogger("CopyObject_Test4", copyObjectSignature,
@@ -3414,7 +3400,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var conditions = new CopyConditions();
@@ -3429,11 +3415,11 @@ public class FunctionalTest
                 .WithCopyObjectSource(copySourceObjectArgs)
                 .WithBucket(destBucketName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             Assert.IsNotNull(stats);
             Assert.IsTrue(stats.ObjectName.Contains(objectName));
             Assert.AreEqual(6291455 - 1024 + 1, stats.Size);
@@ -3491,13 +3477,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
 
             var conditions = new CopyConditions();
             conditions.SetModified(new DateTime(2017, 8, 18));
@@ -3511,16 +3497,16 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs);
+            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             Assert.IsNotNull(dstats);
             Assert.IsTrue(dstats.ObjectName.Contains(destObjectName));
             new MintLogger("CopyObject_Test6", copyObjectSignature,
@@ -3570,13 +3556,13 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
 
             var conditions = new CopyConditions();
             var modifiedDate = DateTime.Now;
@@ -3593,7 +3579,7 @@ public class FunctionalTest
                     .WithCopyObjectSource(copySourceObjectArgs)
                     .WithBucket(destBucketName)
                     .WithObject(destObjectName);
-                await minio.CopyObjectAsync(copyObjectArgs);
+                await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             }
             catch (Exception ex)
             {
@@ -3679,13 +3665,13 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithHeaders(new Dictionary<string, string> { { "Orig", "orig-val with  spaces" } });
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
 
             Assert.IsTrue(stats.MetaData["Orig"] != null);
 
@@ -3710,12 +3696,12 @@ public class FunctionalTest
                 .WithObject(destObjectName)
                 .WithHeaders(customMetadata);
 
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             statObjectArgs = new StatObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var dstats = await minio.StatObjectAsync(statObjectArgs);
+            var dstats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             Assert.IsTrue(dstats.MetaData["Content-Type"] != null);
             Assert.IsTrue(dstats.MetaData["Mynewkey"] != null);
             Assert.IsTrue(dstats.MetaData["Content-Type"].Contains("application/css"));
@@ -3766,7 +3752,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
                 var putTags = new Dictionary<string, string>
                 {
                     { "key1", "PutObjectTags" }
@@ -3775,7 +3761,7 @@ public class FunctionalTest
                     .WithBucket(bucketName)
                     .WithObject(objectName)
                     .WithTagging(Tagging.GetObjectTags(putTags));
-                await minio.SetObjectTagsAsync(setObjectTagsArgs);
+                await minio.SetObjectTagsAsync(setObjectTagsArgs).ConfigureAwait(false);
             }
 
             var copyTags = new Dictionary<string, string>
@@ -3792,12 +3778,12 @@ public class FunctionalTest
                 .WithObject(destObjectName)
                 .WithTagging(Tagging.GetObjectTags(copyTags))
                 .WithReplaceTagsDirective(true);
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             var getObjectTagsArgs = new GetObjectTagsArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName);
-            var tags = await minio.GetObjectTagsAsync(getObjectTagsArgs);
+            var tags = await minio.GetObjectTagsAsync(getObjectTagsArgs).ConfigureAwait(false);
             Assert.IsNotNull(tags);
             var copiedTags = tags.GetTags();
             Assert.IsNotNull(tags);
@@ -3865,7 +3851,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3877,13 +3863,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(ssecDst);
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(ssecDst)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             new MintLogger("EncryptedCopyObject_Test1", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -3946,7 +3932,7 @@ public class FunctionalTest
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -3958,13 +3944,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(null);
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             new MintLogger("EncryptedCopyObject_Test2", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4027,7 +4013,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(ssec);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -4039,12 +4025,12 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(sses3);
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             new MintLogger("EncryptedCopyObject_Test3", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4097,7 +4083,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithServerSideEncryption(sses3);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var copySourceObjectArgs = new CopySourceObjectArgs()
@@ -4109,13 +4095,13 @@ public class FunctionalTest
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithServerSideEncryption(sses3);
-            await minio.CopyObjectAsync(copyObjectArgs);
+            await minio.CopyObjectAsync(copyObjectArgs).ConfigureAwait(false);
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(destBucketName)
                 .WithObject(destObjectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             new MintLogger("EncryptedCopyObject_Test4", copyObjectSignature,
                     "Tests whether encrypted CopyObject passes", TestStatus.PASS, DateTime.Now - startTime, args: args)
                 .Log();
@@ -4166,7 +4152,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length)
                     .WithContentType(contentType);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
 
                 var getObjectArgs = new GetObjectArgs()
                     .WithBucket(bucketName)
@@ -4182,7 +4168,7 @@ public class FunctionalTest
                         Assert.AreEqual(file_write_size, file_read_size);
                         File.Delete(tempFileName);
                     });
-                await minio.GetObjectAsync(getObjectArgs);
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             }
 
             Thread.Sleep(1000);
@@ -4227,7 +4213,7 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
         }
         catch (Exception ex)
@@ -4245,7 +4231,7 @@ public class FunctionalTest
                 .WithObject(objectName)
                 .WithFile(fileName);
 
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             Assert.IsTrue(File.Exists(fileName));
             new MintLogger("GetObject_Test2", getObjectSignature, "Tests whether GetObject with a file name works",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -4343,7 +4329,7 @@ public class FunctionalTest
                         .WithStreamData(filestream)
                         .WithObjectSize(objectSize)
                         .WithContentType(contentType);
-                    await minio.PutObjectAsync(putObjectArgs);
+                    await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
 
                     var getObjectArgs = new GetObjectArgs()
                         .WithBucket(bucketName)
@@ -4364,7 +4350,7 @@ public class FunctionalTest
                             Assert.AreEqual(actualContent, expectedContent);
                         });
 
-                    await minio.GetObjectAsync(getObjectArgs);
+                    await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
                 }
 
                 new MintLogger(testName, getObjectSignature, "Tests whether GetObject returns all the data",
@@ -4407,14 +4393,14 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var getObjectArgs = new GetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithFile(outFileName);
-            await minio.GetObjectAsync(getObjectArgs);
+            await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
             new MintLogger("FGetObject_Test1", getObjectSignature, "Tests whether FGetObject passes for small upload",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -4833,21 +4819,21 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
 
             var preArgs = new PresignedGetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(expiresInt);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
 
-            await DownloadObjectAsync(presigned_url, downloadFile);
+            await DownloadObjectAsync(minio, presigned_url, downloadFile).ConfigureAwait(false);
             var writtenInfo = new FileInfo(downloadFile);
             var file_read_size = writtenInfo.Length;
             // Compare the size of the file downloaded using the generated
@@ -4894,18 +4880,18 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             var preArgs = new PresignedGetObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(0);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
             throw new InvalidOperationException(
                 "PresignedGetObjectAsync expected to throw an InvalidExpiryRangeException.");
         }
@@ -4965,13 +4951,13 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             var reqParams = new Dictionary<string, string>
             {
                 ["response-content-type"] = "application/json",
@@ -4983,16 +4969,9 @@ public class FunctionalTest
                 .WithExpiry(1000)
                 .WithHeaders(reqParams)
                 .WithRequestDate(reqDate);
-            var presigned_url = await minio.PresignedGetObjectAsync(preArgs);
+            var presigned_url = await minio.PresignedGetObjectAsync(preArgs).ConfigureAwait(false);
 
-            var clientHandler = new HttpClientHandler();
-            clientHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) =>
-            {
-                return true;
-            };
-            var client = new HttpClient(clientHandler);
-
-            var response = await client.GetAsync(presigned_url);
+            var response = await minio.WrapperGetAsync(presigned_url).ConfigureAwait(false);
             if (string.IsNullOrEmpty(Convert.ToString(response.Content)) ||
                 !HttpStatusCode.OK.Equals(response.StatusCode))
                 throw new ArgumentNullException("Unable to download via presigned URL");
@@ -5005,7 +4984,7 @@ public class FunctionalTest
 
             using (var fs = new FileStream(downloadFile, FileMode.CreateNew))
             {
-                await response.Content.CopyToAsync(fs);
+                await response.Content.CopyToAsync(fs).ConfigureAwait(false);
             }
 
             var writtenInfo = new FileInfo(downloadFile);
@@ -5058,13 +5037,13 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(1000);
-            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs);
-            await UploadObjectAsync(presigned_url, fileName);
+            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            await UploadObjectAsync(minio, presigned_url, fileName);
             // Get stats for object from server
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             // Compare with file used for upload
             var writtenInfo = new FileInfo(fileName);
             var file_written_size = writtenInfo.Length;
@@ -5111,18 +5090,18 @@ public class FunctionalTest
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
 
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var statObjectArgs = new StatObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName);
-            var stats = await minio.StatObjectAsync(statObjectArgs);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
             var presignedPutObjectArgs = new PresignedPutObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
                 .WithExpiry(0);
-            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs);
+            var presigned_url = await minio.PresignedPutObjectAsync(presignedPutObjectArgs).ConfigureAwait(false);
             new MintLogger("PresignedPutObject_Test2", presignedPutObjectSignature,
                 "Tests whether PresignedPutObject url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -5371,7 +5350,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var policyJson =
@@ -5380,7 +5359,7 @@ public class FunctionalTest
                 .WithBucket(bucketName)
                 .WithPolicy(policyJson);
 
-            await minio.SetPolicyAsync(setPolicyArgs);
+            await minio.SetPolicyAsync(setPolicyArgs).ConfigureAwait(false);
             new MintLogger("SetBucketPolicy_Test1", setBucketPolicySignature, "Tests whether SetBucketPolicy passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -5427,7 +5406,7 @@ public class FunctionalTest
                     .WithObject(objectName)
                     .WithStreamData(filestream)
                     .WithObjectSize(filestream.Length);
-                await minio.PutObjectAsync(putObjectArgs);
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
             }
 
             var setPolicyArgs = new SetPolicyArgs()
@@ -5437,9 +5416,9 @@ public class FunctionalTest
                 .WithBucket(bucketName);
             var rmPolicyArgs = new RemovePolicyArgs()
                 .WithBucket(bucketName);
-            await minio.SetPolicyAsync(setPolicyArgs);
-            var policy = await minio.GetPolicyAsync(getPolicyArgs);
-            await minio.RemovePolicyAsync(rmPolicyArgs);
+            await minio.SetPolicyAsync(setPolicyArgs).ConfigureAwait(false);
+            var policy = await minio.GetPolicyAsync(getPolicyArgs).ConfigureAwait(false);
+            await minio.RemovePolicyAsync(rmPolicyArgs).ConfigureAwait(false);
             new MintLogger("GetBucketPolicy_Test1", getBucketPolicySignature, "Tests whether GetBucketPolicy passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
@@ -5502,7 +5481,7 @@ public class FunctionalTest
             var lfcArgs = new SetBucketLifecycleArgs()
                 .WithBucket(bucketName)
                 .WithLifecycleConfiguration(lfc);
-            await minio.SetBucketLifecycleAsync(lfcArgs);
+            await minio.SetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".1", setBucketLifecycleSignature,
                     "Tests whether SetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -5527,7 +5506,7 @@ public class FunctionalTest
         {
             var lfcArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs);
+            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             Assert.IsNotNull(lfcObj);
             Assert.IsNotNull(lfcObj.Rules);
             Assert.IsTrue(lfcObj.Rules.Count > 0);
@@ -5558,10 +5537,10 @@ public class FunctionalTest
         {
             var lfcArgs = new RemoveBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketLifecycleAsync(lfcArgs);
+            await minio.RemoveBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             var getLifecycleArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs);
+            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -5627,7 +5606,7 @@ public class FunctionalTest
             var lfcArgs = new SetBucketLifecycleArgs()
                 .WithBucket(bucketName)
                 .WithLifecycleConfiguration(lfc);
-            await minio.SetBucketLifecycleAsync(lfcArgs);
+            await minio.SetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             new MintLogger(nameof(BucketLifecycleAsync_Test2) + ".1", setBucketLifecycleSignature,
                     "Tests whether SetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)
@@ -5652,7 +5631,7 @@ public class FunctionalTest
         {
             var lfcArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs);
+            var lfcObj = await minio.GetBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             Assert.IsNotNull(lfcObj);
             Assert.IsNotNull(lfcObj.Rules);
             Assert.IsTrue(lfcObj.Rules.Count > 0);
@@ -5681,10 +5660,10 @@ public class FunctionalTest
         {
             var lfcArgs = new RemoveBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            await minio.RemoveBucketLifecycleAsync(lfcArgs);
+            await minio.RemoveBucketLifecycleAsync(lfcArgs).ConfigureAwait(false);
             var getLifecycleArgs = new GetBucketLifecycleArgs()
                 .WithBucket(bucketName);
-            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs);
+            var lfcObj = await minio.GetBucketLifecycleAsync(getLifecycleArgs).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -424,7 +424,7 @@ public class FunctionalTest
             bucketList = list.Buckets;
             bucketList = bucketList.Where(x => x.Name.StartsWith(bucketName)).ToList();
             Assert.AreEqual(noOfBuckets, bucketList.Count());
-            bucketList.Sort(delegate (Bucket x, Bucket y)
+            bucketList.Sort(delegate(Bucket x, Bucket y)
             {
                 if (x.Name == y.Name) return 0;
                 if (x.Name == null) return -1;

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Net;
-using System.Net.Http;
 
 namespace Minio.Functional.Tests;
 
@@ -51,25 +50,17 @@ internal class Program
 
         MinioClient minioClient = null;
 
-        var clientHandler = new HttpClientHandler();
-        clientHandler.ServerCertificateCustomValidationCallback =
-            (sender, cert, chain, sslPolicyErrors) => { return true; };
-        clientHandler.UseProxy = false;
-        var httpClient = new HttpClient(clientHandler);
-
         if (enableHttps == "1")
             // WithSSL() enables SSL support in MinIO client
             minioClient = new MinioClient()
                 .WithSSL()
                 .WithCredentials(accessKey, secretKey)
                 .WithEndpoint(endPoint)
-                .WithHttpClient(httpClient)
                 .Build();
         else
             minioClient = new MinioClient()
                 .WithCredentials(accessKey, secretKey)
                 .WithEndpoint(endPoint)
-                .WithHttpClient(httpClient)
                 .Build();
 
         // Assign parameters before starting the test

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -66,9 +66,10 @@ internal class Program
                 .WithHttpClient(httpClient)
                 .Build();
         else
-            minioClient = new MinioClient(httpClient)
+            minioClient = new MinioClient()
                 .WithCredentials(accessKey, secretKey)
                 .WithEndpoint(endPoint)
+                .WithHttpClient(httpClient)
                 .Build();
 
         // Assign parameters before starting the test

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -68,7 +68,7 @@ internal class Program
                 .WithHttpClient(httpClient)
                 .Build();
         else
-            minioClient = new MinioClient()
+            minioClient = new MinioClient(httpClient)
                 .WithCredentials(accessKey, secretKey)
                 .WithEndpoint(endPoint)
                 .Build();

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -52,10 +52,8 @@ internal class Program
         MinioClient minioClient = null;
 
         var clientHandler = new HttpClientHandler();
-        clientHandler.ServerCertificateCustomValidationCallback = (sender, cert, chain, sslPolicyErrors) =>
-        {
-            return true;
-        };
+        clientHandler.ServerCertificateCustomValidationCallback =
+            (sender, cert, chain, sslPolicyErrors) => { return true; };
         clientHandler.UseProxy = false;
         var httpClient = new HttpClient(clientHandler);
 

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1772,10 +1772,7 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         if (PartNumber < 0)
             throw new ArgumentOutOfRangeException(nameof(PartNumber), PartNumber,
                 "Invalid Part number value. Cannot be less than 0");
-        // Check if only one of filename or stream are initialized
-        if (!string.IsNullOrWhiteSpace(FileName) && ObjectStreamData != null)
-            throw new ArgumentException("Only one of " + nameof(FileName) + " or " + nameof(ObjectStreamData) +
-                                        " should be set.");
+
         if (!string.IsNullOrWhiteSpace(FileName)) utils.ValidateFile(FileName);
         // Check object size when using stream data
         if (ObjectStreamData != null && ObjectSize == 0)

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1772,7 +1772,10 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         if (PartNumber < 0)
             throw new ArgumentOutOfRangeException(nameof(PartNumber), PartNumber,
                 "Invalid Part number value. Cannot be less than 0");
-
+        // Check if only one of filename or stream are initialized
+        if (!string.IsNullOrWhiteSpace(FileName) && ObjectStreamData != null)
+            throw new ArgumentException("Only one of " + nameof(FileName) + " or " + nameof(ObjectStreamData) +
+                                        " should be set.");
         if (!string.IsNullOrWhiteSpace(FileName)) utils.ValidateFile(FileName);
         // Check object size when using stream data
         if (ObjectStreamData != null && ObjectSize == 0)

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -87,13 +87,18 @@ public partial class MinioClient
         Region = "";
         SessionToken = "";
         Provider = null;
-        HTTPClient = new HttpClient();
+        var clientHandler = new HttpClientHandler();
+        clientHandler.ServerCertificateCustomValidationCallback =
+            (sender, cert, chain, sslPolicyErrors) => { return true; };
+        clientHandler.UseProxy = false;
+        HTTPClient = new HttpClient(clientHandler);
     }
 
     /// <summary>
     ///     Creates and returns an MinIO Client with custom HTTP Client
     /// </summary>
     /// <returns>Client with no arguments to be used with other builder methods</returns>
+    [Obsolete("Use MinioClient() and Builder method .WithHttpClient(httpClient)")]
     public MinioClient(HttpClient httpClient)
     {
         Region = "";
@@ -532,6 +537,7 @@ public partial class MinioClient
             if (requestMessageBuilder.FunctionResponseWriter != null)
                 requestMessageBuilder.ProcessFunctionResponseWriter(requestMessageBuilder.FunctionResponseWriter,
                     responseResult.ContentStream);
+
         }
         catch (OperationCanceledException)
         {

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -87,11 +87,7 @@ public partial class MinioClient
         Region = "";
         SessionToken = "";
         Provider = null;
-        var clientHandler = new HttpClientHandler();
-        clientHandler.ServerCertificateCustomValidationCallback =
-            (sender, cert, chain, sslPolicyErrors) => { return true; };
-        clientHandler.UseProxy = false;
-        HTTPClient = new HttpClient(clientHandler);
+        HTTPClient = new HttpClient();
     }
 
     /// <summary>

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -181,6 +181,23 @@ public partial class MinioClient
     private string FullUserAgent => $"{SystemUserAgent} {CustomUserAgent}";
 
     /// <summary>
+    ///     Runs httpClient's GetAsync method
+    /// </summary>
+    public async Task<HttpResponseMessage> WrapperGetAsync(string url)
+    {
+        var response = await HTTPClient.GetAsync(url).ConfigureAwait(false);
+        return response;
+    }
+
+    /// <summary>
+    ///     Runs httpClient's PutObjectAsync method
+    /// </summary>
+    public async Task WrapperPutAsync(string url, StreamContent strm)
+    {
+        await Task.Run(async () => await HTTPClient.PutAsync(url, strm).ConfigureAwait(false)).ConfigureAwait(false);
+    }
+
+    /// <summary>
     ///     Resolve region of the bucket.
     /// </summary>
     /// <param name="bucketName"></param>
@@ -537,7 +554,6 @@ public partial class MinioClient
             if (requestMessageBuilder.FunctionResponseWriter != null)
                 requestMessageBuilder.ProcessFunctionResponseWriter(requestMessageBuilder.FunctionResponseWriter,
                     responseResult.ContentStream);
-
         }
         catch (OperationCanceledException)
         {


### PR DESCRIPTION
Socket/Memory leak issue was addressed before, but there was a case where we were not using HttpHandler when MinioClient is created with no args.
Also adds a functional test for socket/memory leak issue.