### PR TITLE
Fixes multi-space issue in header request parameters

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -4904,7 +4904,7 @@ public class FunctionalTest
             { "expiresInt", expiresInt.ToString() },
             {
                 "reqParams",
-                "response-content-type:application/json,response-content-disposition:attachment;filename=MyDocument.json;"
+                "response-content-type:application/json,response-content-disposition:attachment;filename=  MyDoc u m  e   nt.json ;"
             },
             { "reqDate", reqDate.ToString() }
         };
@@ -4929,7 +4929,7 @@ public class FunctionalTest
             var reqParams = new Dictionary<string, string>
             {
                 ["response-content-type"] = "application/json",
-                ["response-content-disposition"] = "attachment;filename=MyDocument.json;"
+                ["response-content-disposition"] = "attachment;filename=  MyDoc u m  e   nt.json ;"
             };
             var preArgs = new PresignedGetObjectArgs()
                 .WithBucket(bucketName)

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -175,7 +175,6 @@ internal class Program
         FunctionalTest.PresignedGetObject_Test3(minioClient).Wait();
         FunctionalTest.PresignedPutObject_Test1(minioClient).Wait();
         FunctionalTest.PresignedPutObject_Test2(minioClient).Wait();
-        FunctionalTest.PresignedGetObject_Test1(minioClient).Wait();
         // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
 
         // Test incomplete uploads

--- a/Minio/DataModel/BucketArgs.cs
+++ b/Minio/DataModel/BucketArgs.cs
@@ -44,7 +44,7 @@ public abstract class BucketArgs<T> : Args
         {
             if (Headers.ContainsKey(key))
                 Headers.Remove(key);
-            Headers[key] = headers[key];
+            Headers[key] = headers[key].Replace('"', '\"');
         }
 
         return (T)this;

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -347,7 +347,7 @@ internal class V4Authenticator
         canonicalStringList.AddLast(path);
         var queryParams = uri.Query.TrimStart('?').Split('&').ToList();
         queryParams.AddRange(headersToSign.Select(cv =>
-            $"{utils.UrlEncode(cv.Key)}={utils.UrlEncode(s3utils.TrimAll(cv.Value))}"));
+            $"{utils.UrlEncode(cv.Key)}={utils.UrlEncode(cv.Value.Trim())}"));
         queryParams.Sort(StringComparer.Ordinal);
         var query = string.Join("&", queryParams);
         canonicalStringList.AddLast(query);


### PR DESCRIPTION
Fixes #419 
After replacing RestSharp with HttpClient, the issue explained in #419 changed its behavior a little, but the cause of the issue, multiple spaces in request parameters, and the reproduction steps were still causing a problem. The error message now is
```
"System.ArgumentNullException: Value cannot be null. (Parameter 'Unable to download via presigned URL')"
```