### PR TITLE
Fixes strong name signature failure for MinIO 4.0.3 NuGet pkg

### DIFF
--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #643

There were 2 package references to the `Newtonsoft.Json" Version="13.0.1"` in our dotnet code base, 1- for MinIO project, and 2nd for Functional tests project.
When an MVC Web Application template is created in Visual Studio, a version conflict happens since Web Application depends on an older version of the same package, `Newtonsoft.Json" Version="12.0.2"`. This can happen and it is expected. So, Visual Studio detects it and shows a message about it during MinIO 4.0.3 installation when dependencies are listed and the required package reference changes are done only for MinIO package and not for the internal project. That was causing the strong name signature verification failure. 
The fix is simply removing the extraneous package reference from the internal project.



