### PR TITLE
Fixes WithProxy(#658) and HttpClient(#675) issues

### DIFF
--- a/Minio.Tests/OperationsTest.cs
+++ b/Minio.Tests/OperationsTest.cs
@@ -47,7 +47,8 @@ public class OperationsTest
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .Build();
 
         var bucket = "bucket";
         var objectName = "object-name";
@@ -95,7 +96,8 @@ public class OperationsTest
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .Build();
 
         var bucket = "bucket";
         var objectName = "object-name";

--- a/Minio.Tests/ReuseTcpConnectionTest.cs
+++ b/Minio.Tests/ReuseTcpConnectionTest.cs
@@ -15,7 +15,8 @@ public class ReuseTcpConnectionTest
         MinioClient = new MinioClient()
             .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG");
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .Build();
     }
 
     private MinioClient MinioClient { get; }

--- a/Minio/DataModel/MinioClientBuilder.cs
+++ b/Minio/DataModel/MinioClientBuilder.cs
@@ -17,6 +17,7 @@
 
 using System;
 using System.Net;
+using System.Net.Http;
 using Minio.Credentials;
 using Minio.Exceptions;
 
@@ -98,6 +99,7 @@ public partial class MinioClient : IMinioClient
         else
             Endpoint = host;
 
+        HTTPClient ??= Proxy is null ? new HttpClient() : new HttpClient(new HttpClientHandler { Proxy = Proxy });
         HTTPClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", FullUserAgent);
         return this;
     }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -87,7 +87,6 @@ public partial class MinioClient
         Region = "";
         SessionToken = "";
         Provider = null;
-        HTTPClient = new HttpClient();
     }
 
     /// <summary>
@@ -417,8 +416,11 @@ public partial class MinioClient
     }
 
     /// <summary>
-    ///     Uses webproxy for all requests if this method is invoked on client object
+    ///     Uses webproxy for all requests if this method is invoked on client object.
     /// </summary>
+    /// <remarks>
+    ///     This setting will be ignored when injecting an external <see cref="HttpClient"/> instance with <see cref="MinioClient(HttpClient)"/> <see cref="WithHttpClient(HttpClient)"/>.
+    /// </remarks>
     /// <returns></returns>
     public MinioClient WithProxy(IWebProxy proxy)
     {

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -153,6 +153,8 @@ public partial class MinioClient
 
     internal HttpClient HTTPClient { get; private set; }
 
+    private bool disposeHttpClient = true;
+
     private static string SystemUserAgent
     {
         get
@@ -419,7 +421,7 @@ public partial class MinioClient
     ///     Uses webproxy for all requests if this method is invoked on client object.
     /// </summary>
     /// <remarks>
-    ///     This setting will be ignored when injecting an external <see cref="HttpClient"/> instance with <see cref="MinioClient(HttpClient)"/> <see cref="WithHttpClient(HttpClient)"/>.
+    ///     This setting will be ignored when injecting an external <see cref="HttpClient"/> instance with <see cref="MinioClient(HttpClient)"/> <see cref="WithHttpClient(HttpClient, bool)"/>.
     /// </remarks>
     /// <returns></returns>
     public MinioClient WithProxy(IWebProxy proxy)
@@ -454,10 +456,12 @@ public partial class MinioClient
     ///     Allows end user to define the Http server and pass it as a parameter
     /// </summary>
     /// <param name="httpClient"> Instance of HttpClient</param>
+    /// <param name="disposeHttpClient"> Dispose the HttpClient when leaving</param>
     /// <returns></returns>
-    public MinioClient WithHttpClient(HttpClient httpClient)
+    public MinioClient WithHttpClient(HttpClient httpClient, bool disposeHttpClient = false)
     {
         if (httpClient != null) HTTPClient = httpClient;
+        this.disposeHttpClient = disposeHttpClient;
         return this;
     }
 
@@ -850,7 +854,7 @@ public partial class MinioClient
 
     public void Dispose()
     {
-        HTTPClient?.Dispose();
+        if (disposeHttpClient) HTTPClient?.Dispose();
     }
 }
 

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -59,6 +59,8 @@ public partial class MinioClient
 
     private string CustomUserAgent = string.Empty;
 
+    private bool disposeHttpClient = true;
+
     private IRequestLogger logger;
 
     internal ClientProvider Provider;
@@ -152,8 +154,6 @@ public partial class MinioClient
     internal bool Secure { get; private set; }
 
     internal HttpClient HTTPClient { get; private set; }
-
-    private bool disposeHttpClient = true;
 
     private static string SystemUserAgent
     {
@@ -421,7 +421,8 @@ public partial class MinioClient
     ///     Uses webproxy for all requests if this method is invoked on client object.
     /// </summary>
     /// <remarks>
-    ///     This setting will be ignored when injecting an external <see cref="HttpClient"/> instance with <see cref="MinioClient(HttpClient)"/> <see cref="WithHttpClient(HttpClient, bool)"/>.
+    ///     This setting will be ignored when injecting an external <see cref="HttpClient" /> instance with
+    ///     <see cref="MinioClient(HttpClient)" /> <see cref="WithHttpClient(HttpClient, bool)" />.
     /// </remarks>
     /// <returns></returns>
     public MinioClient WithProxy(IWebProxy proxy)


### PR DESCRIPTION
Fixes 2 issues:
1. #658 
    * To avoid unnecessary socket allocation, create `HttpClient` when delayed until `Build()`.
    * The injected `HttpClient` cannot change the `Proxy`, add a hint for the ignored `WithProxy(IWebProxy)`.
2. #675 
    * ~`HttpClient` is the basic dependency of `MinioClient`, `MinioClient (HttpClient)` is still necessary to implement dependency injection.~
    * Generally, the life cycle of the injected `HttpClient` is managed by IoC or other implementations, and there may even be other operations externally, so add an identifier to control the `Dispose()` behavior.