### PR TITLE
Fix a null exception throw if bytes variable is empty

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -648,7 +648,7 @@ public partial class MinioClient : IObjectOperations
             var bytesRead = bytes == null ? 0 : bytes.Length;
             if (bytesRead != (int)args.ObjectSize)
                 throw new UnexpectedShortReadException(
-                    $"Data read {bytes.Length} is shorter than the size {args.ObjectSize} of input buffer.");
+                    $"Data read {bytesRead} is shorter than the size {args.ObjectSize} of input buffer.");
             args = args.WithRequestBody(bytes)
                 .WithStreamData(null)
                 .WithObjectSize(bytesRead);


### PR DESCRIPTION
When passing a void stream the bytes variable assumes a null value.
After this check
`if (bytesRead != (int)args.ObjectSize)` 
the relative exception 
```
throw new UnexpectedShortReadException(
                    $"Data read {bytes.Length} is shorter than the size {args.ObjectSize} of input buffer.");
```
throw another exception (NullReference) because `bytes` variable is null.