### PR TITLE
Removes the tooltip "ObjectNotfoundException" that will never happen

### DIFF
--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -91,8 +91,8 @@ internal class Program
         // "Listening for bucket notification is specific only to `minio`
         // server endpoints".
         FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).Wait();
-        // FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient).Wait();
-        // FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient).Wait();
+        FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient).Wait();
+        FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient).Wait();
 
         // Check if bucket exists
         FunctionalTest.BucketExists_Test(minioClient).Wait();

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -91,8 +91,8 @@ internal class Program
         // "Listening for bucket notification is specific only to `minio`
         // server endpoints".
         FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).Wait();
-        FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient).Wait();
-        FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient).Wait();
+        // FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient).Wait();
+        // FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient).Wait();
 
         // Check if bucket exists
         FunctionalTest.BucketExists_Test(minioClient).Wait();

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -137,7 +137,6 @@ public interface IObjectOperations
     /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
     /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
     /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-    /// <exception cref="ObjectNotFoundException">When object is not found</exception>
     Task RemoveObjectAsync(RemoveObjectArgs args, CancellationToken cancellationToken = default);
 
     /// <summary>
@@ -154,7 +153,6 @@ public interface IObjectOperations
     /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
     /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
     /// <exception cref="NotImplementedException">When a functionality or extension is not implemented</exception>
-    /// <exception cref="ObjectNotFoundException">When object is not found</exception>
     Task<IObservable<DeleteError>> RemoveObjectsAsync(RemoveObjectsArgs args,
         CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
Fix for #685 