### PR TITLE
Fixes random failures in bucket notification tests

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2601,7 +2601,7 @@ public class FunctionalTest
                 () => throw new Exception("STOPPED LISTENING FOR BUCKET NOTIFICATIONS\n"));
 
             // Sleep to give enough time for the subscriber to be ready
-            var sleepTime = 25; // Milliseconds
+            var sleepTime = 1000; // Milliseconds
             Thread.Sleep(sleepTime);
 
             var modelJson = "{\"test\": \"test\"}";
@@ -2708,7 +2708,7 @@ public class FunctionalTest
                 () => { });
 
             // Sleep to give enough time for the subscriber to be ready
-            var sleepTime = 25; // Milliseconds
+            var sleepTime = 1000; // Milliseconds
             Thread.Sleep(sleepTime);
 
             await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2620,7 +2620,7 @@ public class FunctionalTest
             var timeout = 3000; // Milliseconds
             var waitTime = 25; // Milliseconds
             var stTime = DateTime.UtcNow;
-            while (string.IsNullOrEmpty(rxEventsData.json))
+            while (string.IsNullOrEmpty(rxEventData.json))
             {
                 await Task.Delay(waitTime);
                 if ((DateTime.UtcNow - stTime).TotalMilliseconds >= timeout)


### PR DESCRIPTION
Fixes #691

Sometimes the event is created so fast even before the subscriber is ready to capture the event, hence random failures. So, adding delay and sleep in the right places in the tests resolved the issue for almost always, although theoretically there is always a very low but still a chance to see this problem.