### PR TITLE
Adds missing HeadObject and GetObject support changes

### DIFF
--- a/Minio/DataModel/ObjectArgs.cs
+++ b/Minio/DataModel/ObjectArgs.cs
@@ -19,6 +19,8 @@ namespace Minio;
 public abstract class ObjectArgs<T> : BucketArgs<T>
     where T : ObjectArgs<T>
 {
+    protected const string S3ZipExtractKey = "X-Minio-Extract";
+
     internal string ObjectName { get; set; }
     internal byte[] RequestBody { get; set; }
 

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -228,7 +228,11 @@ public class StatObjectArgs : ObjectConditionalQueryArgs<StatObjectArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+        if (!string.IsNullOrEmpty(VersionId))
+            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+        if (Headers.ContainsKey(S3ZipExtractKey))
+            requestMessageBuilder.AddQueryParameter(S3ZipExtractKey, Headers[S3ZipExtractKey]);
+
         return requestMessageBuilder;
     }
 
@@ -257,7 +261,7 @@ public class StatObjectArgs : ObjectConditionalQueryArgs<StatObjectArgs>
 
     private void Populate()
     {
-        Headers = new Dictionary<string, string>();
+        Headers = Headers ?? new Dictionary<string, string>();
         if (SSE != null && SSE.GetType().Equals(EncryptionType.SSE_C)) SSE.Marshal(Headers);
         if (OffsetLengthSet)
         {
@@ -530,7 +534,7 @@ public class GetObjectArgs : ObjectConditionalQueryArgs<GetObjectArgs>
 
     private void Populate()
     {
-        Headers = new Dictionary<string, string>();
+        Headers = Headers ?? new Dictionary<string, string>();
         if (SSE != null && SSE.GetType().Equals(EncryptionType.SSE_C)) SSE.Marshal(Headers);
 
         if (OffsetLengthSet)
@@ -548,6 +552,8 @@ public class GetObjectArgs : ObjectConditionalQueryArgs<GetObjectArgs>
     {
         if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
         requestMessageBuilder.ResponseWriter = CallBack;
+        if (Headers.ContainsKey(S3ZipExtractKey))
+            requestMessageBuilder.AddQueryParameter(S3ZipExtractKey, Headers[S3ZipExtractKey]);
 
         return requestMessageBuilder;
     }

--- a/Minio/Helper/OperationsHelper.cs
+++ b/Minio/Helper/OperationsHelper.cs
@@ -37,6 +37,7 @@ public partial class MinioClient : IObjectOperations
     {
         // StatObject is called to both verify the existence of the object and return it with GetObject.
         // NOTE: This avoids writing the error body to the action stream passed (Do not remove).
+
         var statArgs = new StatObjectArgs()
             .WithBucket(args.BucketName)
             .WithObject(args.ObjectName)
@@ -45,7 +46,8 @@ public partial class MinioClient : IObjectOperations
             .WithNotMatchETag(args.NotMatchETag)
             .WithModifiedSince(args.ModifiedSince)
             .WithUnModifiedSince(args.UnModifiedSince)
-            .WithServerSideEncryption(args.SSE);
+            .WithServerSideEncryption(args.SSE)
+            .WithHeaders(args.Headers);
         if (args.OffsetLengthSet) statArgs.WithOffsetAndLength(args.ObjectOffset, args.ObjectLength);
         var objStat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
         args.Validate();
@@ -294,7 +296,7 @@ public class OperationsUtil
     private static readonly List<string> SupportedHeaders = new()
     {
         "cache-control", "content-encoding", "content-type",
-        "x-amz-acl", "content-disposition"
+        "x-amz-acl", "content-disposition", "x-minio-extract"
     };
 
     private static readonly List<string> SSEHeaders = new()


### PR DESCRIPTION
Adds additional changes required to support s3zip file extraction when get object (`GetObjectAsync()` api) or check object metadata (`StatObjectAsync()` api) is in action.