### PR TITLE
Adds support for bucket force-delete option

### DIFF
--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -116,6 +116,7 @@ internal class Program
 
         // Test removal of bucket
         FunctionalTest.RemoveBucket_Test1(minioClient).Wait();
+        FunctionalTest.RemoveBucket_Test2(minioClient).Wait();
 
         // Test ListBuckets function
         FunctionalTest.ListBuckets_Test(minioClient).Wait();

--- a/Minio/DataModel/BucketArgs.cs
+++ b/Minio/DataModel/BucketArgs.cs
@@ -21,6 +21,8 @@ namespace Minio;
 public abstract class BucketArgs<T> : Args
     where T : BucketArgs<T>
 {
+    protected const string BucketForceDeleteKey = "X-Minio-Force-Delete";
+
     public BucketArgs()
     {
         Headers = new Dictionary<string, string>();

--- a/Minio/DataModel/BucketOperationsArgs.cs
+++ b/Minio/DataModel/BucketOperationsArgs.cs
@@ -43,6 +43,13 @@ public class RemoveBucketArgs : BucketArgs<RemoveBucketArgs>
     {
         RequestMethod = HttpMethod.Delete;
     }
+
+    internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
+    {
+        if (Headers.ContainsKey(BucketForceDeleteKey))
+            requestMessageBuilder.AddHeaderParameter(BucketForceDeleteKey, Headers[BucketForceDeleteKey]);
+        return requestMessageBuilder;
+    }
 }
 
 public class MakeBucketArgs : BucketArgs<MakeBucketArgs>

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -244,7 +244,7 @@ public partial class MinioClient
     {
         ArgsCheck(args);
         var requestMessageBuilder =
-            await CreateRequest(args.RequestMethod, args.BucketName,
+            await CreateRequest(args.RequestMethod, args.BucketName, headerMap: args.Headers,
                 isBucketCreationRequest: args.IsBucketCreationRequest).ConfigureAwait(false);
         return args.BuildRequest(requestMessageBuilder);
     }


### PR DESCRIPTION
Adds support for the force delete header, "x-minio-force-delete" which makes `RemoveBucket` api remove a bucket when the bucket is not empty.

