### PR TITLE
Fix for issue during setting .WithLifecycleConfiguration (#656)

### DIFF
--- a/Minio/DataModel/ILM/LifecycleRule.cs
+++ b/Minio/DataModel/ILM/LifecycleRule.cs
@@ -33,8 +33,11 @@ public class LifecycleRule
     public static readonly string LIFECYCLE_RULE_STATUS_ENABLED = "Enabled";
     public static readonly string LIFECYCLE_RULE_STATUS_DISABLED = "Disabled";
 
+    private RuleFilter _ruleFilter;
+
     public LifecycleRule()
     {
+        _ruleFilter = new RuleFilter();
     }
 
     public LifecycleRule(AbortIncompleteMultipartUpload abortIncompleteMultipartUpload, string id,
@@ -67,7 +70,22 @@ public class LifecycleRule
     public Transition TransitionObject { get; set; }
 
     [XmlElement("Filter", IsNullable = true)]
-    public RuleFilter Filter { get; set; }
+    public RuleFilter Filter
+    {
+        get { return _ruleFilter; }
+        set
+        {
+            // The filter must not be missing, even if it is empty.
+            if (value == null)
+            {
+                _ruleFilter = new RuleFilter();
+            }
+            else
+            {
+                _ruleFilter = value;
+            }
+        }
+    }
 
     [XmlElement("NoncurrentVersionExpiration", IsNullable = true)]
     public NoncurrentVersionExpiration NoncurrentVersionExpirationObject { get; set; }
@@ -75,5 +93,6 @@ public class LifecycleRule
     [XmlElement("NoncurrentVersionTransition", IsNullable = true)]
     public NoncurrentVersionTransition NoncurrentVersionTransitionObject { get; set; }
 
-    [XmlElement("Status")] public string Status { get; set; }
+    [XmlElement("Status")]
+    public string Status { get; set; }
 }

--- a/Minio/DataModel/ILM/LifecycleRule.cs
+++ b/Minio/DataModel/ILM/LifecycleRule.cs
@@ -72,18 +72,14 @@ public class LifecycleRule
     [XmlElement("Filter", IsNullable = true)]
     public RuleFilter Filter
     {
-        get { return _ruleFilter; }
+        get => _ruleFilter;
         set
         {
             // The filter must not be missing, even if it is empty.
             if (value == null)
-            {
                 _ruleFilter = new RuleFilter();
-            }
             else
-            {
                 _ruleFilter = value;
-            }
         }
     }
 
@@ -93,6 +89,5 @@ public class LifecycleRule
     [XmlElement("NoncurrentVersionTransition", IsNullable = true)]
     public NoncurrentVersionTransition NoncurrentVersionTransitionObject { get; set; }
 
-    [XmlElement("Status")]
-    public string Status { get; set; }
+    [XmlElement("Status")] public string Status { get; set; }
 }

--- a/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
+++ b/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System;
 using System.Xml.Serialization;
 
 /*

--- a/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
+++ b/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
@@ -33,13 +33,18 @@ public class NoncurrentVersionExpiration
     public NoncurrentVersionExpiration()
     {
         NoncurrentDays = null;
+        NewerNoncurrentVersions = null;
     }
 
-    public NoncurrentVersionExpiration(uint nonCurrentDays)
+    public NoncurrentVersionExpiration(uint nonCurrentDays, uint? newerNoncurrentVersions = null)
     {
         NoncurrentDays = nonCurrentDays;
+        NewerNoncurrentVersions = newerNoncurrentVersions;
     }
 
     [XmlElement(ElementName = "NoncurrentDays", IsNullable = true)]
     public uint? NoncurrentDays { get; set; }
+
+    [XmlElement(ElementName = "NewerNoncurrentVersions", IsNullable = true)]
+    public uint? NewerNoncurrentVersions { get; set; }
 }

--- a/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
+++ b/Minio/DataModel/ILM/NoncurrentVersionExpiration.cs
@@ -25,6 +25,8 @@ using System.Xml.Serialization;
 
 namespace Minio.DataModel.ILM;
 
+[Serializable]
+[XmlRoot(ElementName = "NoncurrentVersionExpiration")]
 public class NoncurrentVersionExpiration
 {
     public NoncurrentVersionExpiration()
@@ -38,5 +40,5 @@ public class NoncurrentVersionExpiration
     }
 
     [XmlElement(ElementName = "NoncurrentDays", IsNullable = true)]
-    internal uint? NoncurrentDays { get; set; }
+    public uint? NoncurrentDays { get; set; }
 }

--- a/Minio/DataModel/ILM/NoncurrentVersionTransition.cs
+++ b/Minio/DataModel/ILM/NoncurrentVersionTransition.cs
@@ -44,5 +44,5 @@ public class NoncurrentVersionTransition : NoncurrentVersionExpiration
     }
 
     [XmlElement(ElementName = "StorageClass", IsNullable = true)]
-    internal string StorageClass { get; set; }
+    public string StorageClass { get; set; }
 }


### PR DESCRIPTION
Fixes issue [Error during setting .WithLifecycleConfiguration #656](https://github.com/minio/minio-dotnet/issues/656).

The XML node NoncurrentVersionExpiration was empty because internal properties are not serialized.