### PR TITLE
3 tests/examples on downloading large/Gig size objects

### DIFF
--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Polly" Version="7.2.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    <PackageReference Include="System.Net.Primitives" Version="4.3.1" />
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -4817,7 +4817,8 @@ public class FunctionalTest
                                 while (tot != size)
                                 {
                                     IBytes = stream.Read(fileData, 0, fileData.Length);
-                                    Task.Run(async Task() => {await destinStream.WriteAsync(fileData, 0, IBytes);}).Wait();
+                                    Task.Run(async Task() => { await destinStream.WriteAsync(fileData, 0, IBytes); })
+                                        .Wait();
 
                                     tot = tot + IBytes;
                                 }

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -8,7 +8,6 @@
   <ItemGroup>
     <PackageReference Include="MSTest.TestFramework" Version="1.3.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -24,6 +24,9 @@ internal class Program
 {
     public static void Main(string[] args)
     {
+        ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12
+                                               | SecurityProtocolType.Tls13
+                                               | SecurityProtocolType.Tls11;
         string endPoint = null;
         string accessKey = null;
         string secretKey = null;
@@ -141,6 +144,10 @@ internal class Program
         // and length parameters. Tests will be reported as GetObject_Test3,
         // GetObject_Test4 and GetObject_Test5.
         FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient).Wait();
+        // 3 tests to download large files (3 GB) with using and minimal memory usage
+        FunctionalTest.GetObject_LargeFile_Test1(minioClient).Wait();
+        FunctionalTest.GetObjectGetObject_LargeFile_Test2(minioClient).Wait();
+        FunctionalTest.GetObjectGetObject_LargeFile_Test3(minioClient).Wait();
 
         // Test File GetObject and PutObject functions
         FunctionalTest.FGetObject_Test1(minioClient).Wait();

--- a/Minio/DataModel/MinioClientBuilder.cs
+++ b/Minio/DataModel/MinioClientBuilder.cs
@@ -1,4 +1,4 @@
-/*
+               /*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
  * (C) 2020 MinIO, Inc.
  *
@@ -19,12 +19,9 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-<<<<<<< Updated upstream
 using System.Threading;
 using System.Threading.Tasks;
-=======
 using Microsoft.Extensions.DependencyInjection;
->>>>>>> Stashed changes
 using Minio.Credentials;
 using Minio.DataModel;
 using Minio.DataModel.ILM;

--- a/Minio/DataModel/MinioClientBuilder.cs
+++ b/Minio/DataModel/MinioClientBuilder.cs
@@ -1,4 +1,4 @@
-               /*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
  * (C) 2020 MinIO, Inc.
  *

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1"/>
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0"/>     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="SourceLink.Embed.AllSourceFiles" Version="2.8.3" PrivateAssets="All"/>
     <PackageReference Include="AsyncFixer" Version="1.1.6" PrivateAssets="All"/>
-    <PackageReference Include="System.Net.Http" Version="4.3.4"/>
+    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
     <PackageReference Include="System.Net.Primitives" Version="4.3.1"/>
     <PackageReference Include="System.Reactive.Linq" Version="5.0.0"/>     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1"/>


### PR DESCRIPTION
Callback function of `GetObjectAsync` cannot be called as `async` due to a known .Net limitation/issue, hence these 3 new tests. They can be also considered as examples on how to download large (Gig) objects and all consume some memory.
