### PR TITLE
using interface IReadOnlyDictionary instead of a dicrionary in TagSet and Tagging

### DIFF
--- a/Minio/DataModel/Tags/TagSet.cs
+++ b/Minio/DataModel/Tags/TagSet.cs
@@ -29,7 +29,7 @@ public class TagSet
         Tag = null;
     }
 
-    public TagSet(Dictionary<string, string> tags)
+    public TagSet(IReadOnlyDictionary<string, string> tags)
     {
         if (tags == null || tags.Count == 0) return;
         Tag = new List<Tag>();

--- a/Minio/DataModel/Tags/Tagging.cs
+++ b/Minio/DataModel/Tags/Tagging.cs
@@ -42,7 +42,7 @@ public class Tagging
         TaggingSet = null;
     }
 
-    public Tagging(Dictionary<string, string> tags, bool isObjects)
+    public Tagging(IReadOnlyDictionary<string, string> tags, bool isObjects)
     {
         if (tags == null)
         {


### PR DESCRIPTION
The dictionary is used only for enumeration, so the interface IReadOnlyDictionary is enough