### PR TITLE
Adds Func<Stream, Task> to replace Action<Stream> for GetObjectAsync()

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -4834,11 +4834,6 @@ public class FunctionalTest
                     TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
             }
         }
-        catch (OperationCanceledException cex)
-        {
-            new MintLogger("GetObject_LargeFile_Test0", getObjectSignature, "Tests whether GetObject as stream works",
-                TestStatus.NA, DateTime.Now - startTime, cex.Message, cex.ToString(), args: args).Log();
-        }
         catch (Exception ex)
         {
             new MintLogger("GetObject_LargeFile_Test0", getObjectSignature, "Tests whether GetObject as stream works",

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -17,14 +17,12 @@
 
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
@@ -271,6 +269,23 @@ public class FunctionalTest
         for (var i = 0; i < length; i++) result.Append(characters[rnd.Next(characters.Length)]);
 
         return "minio-dotnet-example-" + result;
+    }
+
+    internal static void generateRandomFile(string fileName)
+    {
+        using (var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true))
+        {
+            var fileSize = 3L * 1024 * 1024 * 1024;
+            var segments = fileSize / 10000;
+            var last_seg = fileSize % 10000;
+            var br = new BinaryWriter(fs);
+
+            for (long i = 0; i < segments; i++)
+                br.Write(new byte[10000]);
+
+            br.Write(new byte[last_seg]);
+            br.Close();
+        }
     }
 
     // Return true if running in Mint mode
@@ -4023,36 +4038,6 @@ public class FunctionalTest
         }
     }
 
-    public static void objPrint(object obj)
-    {
-        foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(obj))
-        {
-            var name = descriptor.Name;
-            var value = descriptor.GetValue(obj);
-            Console.WriteLine("{0}={1}", name, value);
-        }
-    }
-
-    public static void Print(object obj)
-    {
-        foreach (var prop in obj.GetType()
-                     .GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
-        {
-            var value = prop.GetValue(obj, new object[] { });
-            Console.WriteLine("{0} = {1}", prop.Name, value);
-        }
-
-        Console.WriteLine("DONE!\n\n");
-    }
-
-    public static void printDict(Dictionary<string, string> d)
-    {
-        if (d != null)
-            foreach (var kv in d)
-                Console.WriteLine("     {0} = {1}", kv.Key, kv.Value);
-        Console.WriteLine("DONE!\n\n");
-    }
-
     internal static async Task CopyObject_Test8(MinioClient minio)
     {
         var startTime = DateTime.Now;
@@ -4785,6 +4770,88 @@ public class FunctionalTest
                 if (File.Exists(tempSource)) File.Delete(tempSource);
                 await TearDown(minio, bucketName);
             }
+        }
+    }
+
+    internal static async Task GetObject_AsyncCallback_Test1(MinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        string contentType = null;
+        var fileName = GetRandomName(10);
+        var destFileName = GetRandomName(10);
+        var args = new Dictionary<string, string>
+        {
+            { "bucketName", bucketName },
+            { "objectName", objectName },
+            { "contentType", contentType }
+        };
+
+        try
+        {
+            // Create a large local file
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) generateRandomFile(fileName);
+            else Bash("truncate -s 2G " + fileName);
+
+            // Create the bucket
+            await Setup_Test(minio, bucketName);
+
+            using (var filestream = new FileStream(File.OpenHandle(fileName), FileAccess.Read))
+            {
+                // Upload the large file, "fileName", into the bucket
+                var size = filestream.Length;
+                long file_read_size = 0;
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length)
+                    .WithContentType(contentType);
+
+                await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+
+                var callbackAsync = async delegate(Stream stream, CancellationToken cancellationToken)
+                {
+                    using (var dest = new FileStream(destFileName, FileMode.Create, FileAccess.Write))
+                    {
+                        await stream.CopyToAsync(dest);
+                    }
+                };
+
+                var getObjectArgs = new GetObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithCallbackStream(async (stream, cancellationToken) => await callbackAsync(stream, default));
+
+                await minio.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
+                var writtenInfo = new FileInfo(destFileName);
+                file_read_size = writtenInfo.Length;
+                Assert.AreEqual(size, file_read_size);
+
+                new MintLogger("GetObject_LargeFile_Test0", getObjectSignature,
+                    "Tests whether GetObject as stream works",
+                    TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+            }
+        }
+        catch (OperationCanceledException cex)
+        {
+            new MintLogger("GetObject_LargeFile_Test0", getObjectSignature, "Tests whether GetObject as stream works",
+                TestStatus.NA, DateTime.Now - startTime, cex.Message, cex.ToString(), args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetObject_LargeFile_Test0", getObjectSignature, "Tests whether GetObject as stream works",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            if (File.Exists(fileName))
+                File.Delete(fileName);
+            if (File.Exists(destFileName))
+                File.Delete(destFileName);
+            await TearDown(minio, bucketName);
         }
     }
 

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -141,6 +141,8 @@ internal class Program
         // and length parameters. Tests will be reported as GetObject_Test3,
         // GetObject_Test4 and GetObject_Test5.
         FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient).Wait();
+        // Test async callback function to download an object
+        FunctionalTest.GetObject_AsyncCallback_Test1(minioClient).Wait();
 
         // Test File GetObject and PutObject functions
         FunctionalTest.FGetObject_Test1(minioClient).Wait();


### PR DESCRIPTION
Fixes #420 

Adds Func<Stream, Task> to replace Action<Stream> to run GetObjectAsync with async callback.

This also fixes the disposed object exception
```
Unhandled exception. System.ObjectDisposedException: Cannot access a disposed object.
Object name: 'SslStream'.
   at System.Net.Security.SslStream.<ThrowIfExceptional>g__ThrowExceptional|138_0(ExceptionDispatchInfo e)
   at System.Net.Security.SslStream.ReadAsync(Memory`1 buffer, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnection.FillAsync(Boolean async)
   at System.Net.Http.HttpConnection.CopyToContentLengthAsync(Stream destination, Boolean async, UInt64 length, Int32 bufferSize, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnection.ContentLengthReadStream.CompleteCopyToAsync(Task copyTask, CancellationToken cancellationToken)
   at Minio.MinioClient.<>c__DisplayClass111_0.<<getObjectFileAsync>b__0>d.MoveNext() in /home/ersan/work/src/github.com/minio/minio-dotnet/Minio/Helper/OperationsHelper.cs:line 112
--- End of stack trace from previous location ---
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.QueueUserWorkItemCallbackDefaultContext.Execute()
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
   at System.Threading.Thread.StartCallback()
```