### PR TITLE
Adds return values for PutObjectAsync api

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3226,6 +3226,7 @@ public static class FunctionalTest
         var bucketName = GetRandomName(15);
         var objectName = GetRandomObjectName(10);
         var contentType = "application/octet-stream";
+        var size = 1 * MB;
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -3236,8 +3237,10 @@ public static class FunctionalTest
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
-            await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
-                rsg.GenerateStreamFromSeed(1 * MB)).ConfigureAwait(false);
+            var resp = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
+                rsg.GenerateStreamFromSeed(size)).ConfigureAwait(false);
+            Assert.AreEqual(size, resp.Size);
+            Assert.AreEqual(objectName, objectName);
             new MintLogger(nameof(PutObject_Test1), putObjectSignature,
                 "Tests whether PutObject passes for small object", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -201,7 +201,7 @@ public interface IObjectOperations
     /// <exception cref="NotSupportedException">The file stream cannot be read from</exception>
     /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
     /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
-    Task PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default);
+    Task<PutObjectResponse> PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default);
 
     /// <summary>
     ///     Select an object's content. The object will be streamed to the callback given by the user.

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -821,7 +821,9 @@ public partial class MinioClient : IObjectOperations
     {
         //Skipping validate as we need the case where stream sends 0 bytes
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken).ConfigureAwait(false);
+        using var response =
+            await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
         return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
             args.ObjectSize, args.ObjectName);
     }
@@ -1058,9 +1060,10 @@ public partial class MinioClient : IObjectOperations
     {
         args?.Validate();
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using ResponseResult response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
-        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers, response.Content.Length,
+        using var response =
+            await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
+        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers, -1,
             args.ObjectName);
     }
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -555,7 +555,8 @@ public partial class MinioClient : IObjectOperations
     /// <exception cref="NotSupportedException">The file stream cannot be read from</exception>
     /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
     /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
-    public async Task PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default)
+    public async Task<PutObjectResponse> PutObjectAsync(PutObjectArgs args,
+        CancellationToken cancellationToken = default)
     {
         args?.Validate();
         args.SSE?.Marshal(args.Headers);
@@ -572,8 +573,8 @@ public partial class MinioClient : IObjectOperations
             args = args.WithRequestBody(bytes)
                 .WithStreamData(null)
                 .WithObjectSize(bytesRead);
-            await PutObjectSinglePartAsync(args, cancellationToken).ConfigureAwait(false);
-            return;
+            var putObjResponse = await PutObjectSinglePartAsync(args, cancellationToken).ConfigureAwait(false);
+            return putObjResponse;
         }
 
         // For all sizes greater than 5MiB do multipart.
@@ -622,7 +623,10 @@ public partial class MinioClient : IObjectOperations
             .WithObject(args.ObjectName)
             .WithUploadId(uploadId)
             .WithETags(etags);
-        await CompleteMultipartUploadAsync(completeMultipartUploadArgs, cancellationToken).ConfigureAwait(false);
+        var putObjectResponse = await CompleteMultipartUploadAsync(completeMultipartUploadArgs, cancellationToken)
+            .ConfigureAwait(false);
+        putObjectResponse.Size = args.ObjectSize;
+        return putObjectResponse;
     }
 
     /// <summary>
@@ -812,16 +816,14 @@ public partial class MinioClient : IObjectOperations
     /// <exception cref="NotSupportedException">The file stream cannot be read from</exception>
     /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
     /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
-    private async Task<string> PutObjectSinglePartAsync(PutObjectArgs args,
+    private async Task<PutObjectResponse> PutObjectSinglePartAsync(PutObjectArgs args,
         CancellationToken cancellationToken = default)
     {
         //Skipping validate as we need the case where stream sends 0 bytes
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using var response =
-            await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-        var putObjectResponse = new PutObjectResponse(response.StatusCode, response.Content, response.Headers);
-        return putObjectResponse.Etag;
+        using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken).ConfigureAwait(false);
+        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
+            args.ObjectSize, args.ObjectName);
     }
 
     /// <summary>
@@ -861,7 +863,10 @@ public partial class MinioClient : IObjectOperations
                 .WithRequestBody(dataToCopy)
                 .WithUploadId(args.UploadId)
                 .WithPartNumber(partNumber);
-            var etag = await PutObjectSinglePartAsync(putObjectArgs, cancellationToken).ConfigureAwait(false);
+            var putObjectResponse =
+                await PutObjectSinglePartAsync(putObjectArgs, cancellationToken).ConfigureAwait(false);
+            var etag = putObjectResponse.Etag;
+
             numPartsUploaded++;
             totalParts[partNumber - 1] = new Part
                 { PartNumber = partNumber, ETag = etag, Size = (long)expectedReadSize };
@@ -1048,14 +1053,15 @@ public partial class MinioClient : IObjectOperations
     /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
     /// <exception cref="ObjectNotFoundException">When object is not found</exception>
     /// <exception cref="AccessDeniedException">For encrypted copy operation, Access is denied if the key is wrong</exception>
-    private async Task CompleteMultipartUploadAsync(CompleteMultipartUploadArgs args,
+    private async Task<PutObjectResponse> CompleteMultipartUploadAsync(CompleteMultipartUploadArgs args,
         CancellationToken cancellationToken)
     {
         args?.Validate();
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using var response =
-            await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+        using ResponseResult response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers, response.Content.Length,
+            args.ObjectName);
     }
 
     /// <summary>

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -573,8 +573,7 @@ public partial class MinioClient : IObjectOperations
             args = args.WithRequestBody(bytes)
                 .WithStreamData(null)
                 .WithObjectSize(bytesRead);
-            var putObjResponse = await PutObjectSinglePartAsync(args, cancellationToken).ConfigureAwait(false);
-            return putObjResponse;
+            return await PutObjectSinglePartAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
         // For all sizes greater than 5MiB do multipart.

--- a/Minio/DataModel/MinioClientBuilder.cs
+++ b/Minio/DataModel/MinioClientBuilder.cs
@@ -77,7 +77,7 @@ public interface IMinioClient : IDisposable
     Task<(Uri, IDictionary<string, string>)> PresignedPostPolicyAsync(PostPolicy policy);
     Task<(Uri, IDictionary<string, string>)> PresignedPostPolicyAsync(PresignedPostPolicyArgs args);
     Task<string> PresignedPutObjectAsync(PresignedPutObjectArgs args);
-    Task PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default);
+    Task<PutObjectResponse> PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default);
 
     Task RemoveAllBucketNotificationsAsync(RemoveAllBucketNotificationsArgs args,
         CancellationToken cancellationToken = default);

--- a/Minio/DataModel/ObjectOperationsResponse.cs
+++ b/Minio/DataModel/ObjectOperationsResponse.cs
@@ -202,10 +202,6 @@ public class PutObjectResponse : GenericResponse
         IDictionary<string, string> responseHeaders, long size, string name)
         : base(statusCode, responseContent)
     {
-        if (responseHeaders.ContainsKey("Etag"))
-            if (!string.IsNullOrEmpty("Etag"))
-                Etag = responseHeaders["ETag"];
-
         foreach (var parameter in responseHeaders)
             if (parameter.Key.Equals("ETag", StringComparison.OrdinalIgnoreCase))
             {

--- a/Minio/DataModel/ObjectOperationsResponse.cs
+++ b/Minio/DataModel/ObjectOperationsResponse.cs
@@ -192,26 +192,28 @@ internal class NewMultipartUploadResponse : GenericResponse
     internal string UploadId { get; }
 }
 
-internal class PutObjectResponse : GenericResponse
+public class PutObjectResponse : GenericResponse
 {
-    internal string Etag;
+    public string Etag;
+    public string ObjectName;
+    public long Size;
 
-    internal PutObjectResponse(HttpStatusCode statusCode, string responseContent,
-        IDictionary<string, string> responseHeaders)
+    public PutObjectResponse(HttpStatusCode statusCode, string responseContent,
+        IDictionary<string, string> responseHeaders, long size, string name)
         : base(statusCode, responseContent)
     {
         if (responseHeaders.ContainsKey("Etag"))
-        {
             if (!string.IsNullOrEmpty("Etag"))
                 Etag = responseHeaders["ETag"];
-            return;
-        }
 
         foreach (var parameter in responseHeaders)
             if (parameter.Key.Equals("ETag", StringComparison.OrdinalIgnoreCase))
             {
                 Etag = parameter.Value;
-                return;
+                break;
             }
+
+        Size = size;
+        ObjectName = name;
     }
 }


### PR DESCRIPTION
Fixes #707 
PutObjectAsync returns `Etag`, `Size` and `Name` of the uploaded object.