### PR TITLE
Response header processing

### DIFF
--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -61,6 +61,7 @@ public class NegativeTest
         var bucketName = Guid.NewGuid().ToString("N");
         var minio = new MinioClient()
             .WithEndpoint("play.min.io")
+            .WithSSL()
             .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
 

--- a/Minio.Tests/OperationsTest.cs
+++ b/Minio.Tests/OperationsTest.cs
@@ -46,8 +46,8 @@ public class OperationsTest
         // todo how to test this with mock client.
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
 
         var bucket = "bucket";
@@ -85,7 +85,7 @@ public class OperationsTest
 
         var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
             signedUrl);
     }
 
@@ -95,8 +95,8 @@ public class OperationsTest
         // todo how to test this with mock client.
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
 
         var bucket = "bucket";
@@ -140,7 +140,7 @@ public class OperationsTest
         var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
 
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
             signedUrl);
     }
 }

--- a/Minio.Tests/ReuseTcpConnectionTest.cs
+++ b/Minio.Tests/ReuseTcpConnectionTest.cs
@@ -14,8 +14,8 @@ public class ReuseTcpConnectionTest
     {
         MinioClient = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
     }
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
  * (C) 2017-2021 MinIO, Inc.
  *
@@ -767,7 +767,7 @@ public partial class MinioClient : IObjectOperations
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
         var responseHeaders = new Dictionary<string, string>();
-        foreach (var param in response.Headers.ToList()) responseHeaders.Add(param.Key, param.Value);
+        foreach (var param in response.Headers) responseHeaders.Add(param.Key, param.Value);
         var statResponse = new StatObjectResponse(response.StatusCode, response.Content, response.Headers, args);
 
         return statResponse.ObjectInfo;
@@ -1575,10 +1575,7 @@ public partial class MinioClient : IObjectOperations
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
 
-        string etag = null;
-        foreach (var parameter in response.Headers)
-            if (parameter.Key.Equals("ETag", StringComparison.OrdinalIgnoreCase))
-                etag = parameter.Value;
+        response.Headers.TryGetValue("ETag", out string etag);
         return etag;
     }
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1410,7 +1410,7 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Post, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
 
         var parts = new List<XElement>();
 
@@ -1473,9 +1473,9 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Get, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", $"{partNumberMarker}");
-        requestMessageBuilder.AddQueryParameter("max-parts", "1000");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", partNumberMarker);
+        requestMessageBuilder.AddQueryParameter("max-parts", 1000);
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
@@ -1566,8 +1566,8 @@ public partial class MinioClient : IObjectOperations
             .ConfigureAwait(false);
         if (!string.IsNullOrEmpty(uploadId) && partNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{partNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", partNumber);
         }
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -766,8 +766,6 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var responseHeaders = new Dictionary<string, string>();
-        foreach (var param in response.Headers) responseHeaders.Add(param.Key, param.Value);
         var statResponse = new StatObjectResponse(response.StatusCode, response.Content, response.Headers, args);
 
         return statResponse.ObjectInfo;

--- a/Minio/DataModel/BucketOperationsArgs.cs
+++ b/Minio/DataModel/BucketOperationsArgs.cs
@@ -198,7 +198,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
             requestMessageBuilder.AddOrUpdateHeaderParameter(h.Key, h.Value);
 
         requestMessageBuilder.AddQueryParameter("delimiter", Delimiter);
-        requestMessageBuilder.AddQueryParameter("max-keys", "1000");
+        requestMessageBuilder.AddQueryParameter("max-keys", 1000);
         requestMessageBuilder.AddQueryParameter("encoding-type", "url");
         requestMessageBuilder.AddQueryParameter("prefix", Prefix);
         if (Versions)
@@ -210,7 +210,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
         }
         else if (!Versions && UseV2)
         {
-            requestMessageBuilder.AddQueryParameter("list-type", "2");
+            requestMessageBuilder.AddQueryParameter("list-type", 2);
             if (!string.IsNullOrWhiteSpace(Marker)) requestMessageBuilder.AddQueryParameter("start-after", Marker);
             if (!string.IsNullOrWhiteSpace(ContinuationToken))
                 requestMessageBuilder.AddQueryParameter("continuation-token", ContinuationToken);

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -59,7 +59,7 @@ public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         requestMessageBuilder.AddQueryParameter("select", "");
-        requestMessageBuilder.AddQueryParameter("select-type", "2");
+        requestMessageBuilder.AddQueryParameter("select-type", 2);
 
         if (RequestBody == null)
         {
@@ -231,7 +231,7 @@ public class StatObjectArgs : ObjectConditionalQueryArgs<StatObjectArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         if (!string.IsNullOrEmpty(VersionId))
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
         if (Headers.ContainsKey(S3ZipExtractKey))
             requestMessageBuilder.AddQueryParameter(S3ZipExtractKey, Headers[S3ZipExtractKey]);
 
@@ -445,7 +445,7 @@ public class RemoveUploadArgs : EncryptionArgs<RemoveUploadArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         return requestMessageBuilder;
     }
 }
@@ -553,7 +553,7 @@ public class GetObjectArgs : ObjectConditionalQueryArgs<GetObjectArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", VersionId);
 
         if (CallBack is not null) requestMessageBuilder.ResponseWriter = CallBack;
         else requestMessageBuilder.FunctionResponseWriter = FuncCallBack;
@@ -615,7 +615,7 @@ public class RemoveObjectArgs : ObjectArgs<RemoveObjectArgs>
     {
         if (!string.IsNullOrEmpty(VersionId))
         {
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
             if (BypassGovernanceMode != null && BypassGovernanceMode.Value)
                 requestMessageBuilder.AddOrUpdateHeaderParameter("x-amz-bypass-governance-retention",
                     BypassGovernanceMode.Value.ToString());
@@ -1682,7 +1682,7 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         var parts = new List<XElement>();
 
         for (var i = 1; i <= ETags.Count; i++)
@@ -1691,7 +1691,6 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
                 new XElement("ETag", ETags[i])));
         var completeMultipartUploadXml = new XElement("CompleteMultipartUpload", parts);
         var bodyString = completeMultipartUploadXml.ToString();
-        var body = Encoding.UTF8.GetBytes(bodyString);
         var bodyInBytes = Encoding.UTF8.GetBytes(bodyString);
         requestMessageBuilder.BodyParameters.Add("content-type", "application/xml");
         requestMessageBuilder.SetBody(bodyInBytes);
@@ -1712,7 +1711,7 @@ internal class PutObjectPartArgs : PutObjectArgs
     {
         base.Validate();
         if (string.IsNullOrWhiteSpace(UploadId))
-            throw new ArgumentNullException(nameof(UploadId) + " not assigned for PutObjectPart operation.");
+            throw new ArgumentNullException(nameof(UploadId), $"{nameof(UploadId)} not assigned for PutObjectPart operation.");
     }
 
     public new PutObjectPartArgs WithBucket(string bkt)
@@ -1832,8 +1831,8 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         requestMessageBuilder.AddOrUpdateHeaderParameter("Content-Type", Headers["Content-Type"]);
         if (!string.IsNullOrWhiteSpace(UploadId) && PartNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{PartNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", PartNumber);
         }
 
         if (ObjectTags != null && ObjectTags.TaggingSet != null

--- a/Minio/DataModel/ObjectOperationsResponse.cs
+++ b/Minio/DataModel/ObjectOperationsResponse.cs
@@ -42,7 +42,7 @@ internal class SelectObjectContentResponse : GenericResponse
 internal class StatObjectResponse : GenericResponse
 {
     internal StatObjectResponse(HttpStatusCode statusCode, string responseContent,
-        Dictionary<string, string> responseHeaders, StatObjectArgs args)
+        IReadOnlyDictionary<string, string> responseHeaders, StatObjectArgs args)
         : base(statusCode, responseContent)
     {
         // StatObjectResponse object is populated with available stats from the response.
@@ -220,21 +220,13 @@ internal class PutObjectResponse : GenericResponse
     internal string Etag;
 
     internal PutObjectResponse(HttpStatusCode statusCode, string responseContent,
-        Dictionary<string, string> responseHeaders)
+        IReadOnlyDictionary<string, string> responseHeaders)
         : base(statusCode, responseContent)
     {
-        if (responseHeaders.ContainsKey("Etag"))
+        if (responseHeaders.TryGetValue("Etag", out string etag) && !string.IsNullOrEmpty(etag))
         {
-            if (!string.IsNullOrEmpty("Etag"))
-                Etag = responseHeaders["ETag"];
+            Etag = etag;
             return;
         }
-
-        foreach (var parameter in responseHeaders)
-            if (parameter.Key.Equals("ETag", StringComparison.OrdinalIgnoreCase))
-            {
-                Etag = parameter.Value;
-                return;
-            }
     }
 }

--- a/Minio/DataModel/ObjectStat.cs
+++ b/Minio/DataModel/ObjectStat.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017-2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -47,9 +47,11 @@ public class ObjectStat
     public DateTime? ObjectLockRetainUntilDate { get; private set; }
     public bool? LegalHoldEnabled { get; private set; }
 
-    public static ObjectStat FromResponseHeaders(string objectName, Dictionary<string, string> responseHeaders)
+    public static ObjectStat FromResponseHeaders(string objectName, IReadOnlyDictionary<string, string> responseHeaders)
     {
-        if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("Name of an object cannot be empty");
+        if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException(nameof(objectName), "Name of an object cannot be empty");
+        if (responseHeaders == null) throw new ArgumentNullException(nameof(responseHeaders));
+
         var objInfo = new ObjectStat();
         objInfo.ObjectName = objectName;
         foreach (var paramName in responseHeaders.Keys)

--- a/Minio/HttpRequestMessageBuilder.cs
+++ b/Minio/HttpRequestMessageBuilder.cs
@@ -172,6 +172,11 @@ internal class HttpRequestMessageBuilder
         QueryParameters[key] = value;
     }
 
+    public void AddQueryParameter(string key, int value)
+    {
+        QueryParameters[key] = value.ToString();
+    }
+
     public void SetBody(byte[] body)
     {
         Content = body;

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -646,17 +646,14 @@ public partial class MinioClient : IMinioClient
         MinioException error = null;
         var errorResponse = new ErrorResponse();
 
-        foreach (var parameter in response.Headers)
-        {
-            if (parameter.Key.Equals("x-amz-id-2", StringComparison.CurrentCultureIgnoreCase))
-                errorResponse.HostId = parameter.Value;
+        if (response.Headers.TryGetValue("x-amz-id-2", out string hostId))
+            errorResponse.HostId = hostId;
 
-            if (parameter.Key.Equals("x-amz-request-id", StringComparison.CurrentCultureIgnoreCase))
-                errorResponse.RequestId = parameter.Value;
+        if (response.Headers.TryGetValue("x-amz-request-id", out string requestId))
+            errorResponse.RequestId = requestId;
 
-            if (parameter.Key.Equals("x-amz-bucket-region", StringComparison.CurrentCultureIgnoreCase))
-                errorResponse.BucketRegion = parameter.Value;
-        }
+        if (response.Headers.TryGetValue("x-amz-bucket-region", out string bucketRegion))
+            errorResponse.BucketRegion = bucketRegion;
 
         var pathAndQuery = response.Request.RequestUri.PathAndQuery;
         var host = response.Request.RequestUri.Host;


### PR DESCRIPTION
This PR tidies up the response header processing. HTTP message headers are [case-insensitive](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2) as per the HTTP specification. In .NET, we can create a dictionary with a case-insensitive key comparer like `new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)`. When looking up values in this dictionary, the key lookups are case insensitive. This helps when trying to find a key like `ETag` case-insensitively. The lookups can be simplified.

In addition, this changes the type of `ResponseResult.Headers` from `Dictionary<string, string>` to `IReadOnlyDictionary<string, string>`. Read only dictionary only has the members for getting values from the key, the add/update members are not included. Note that `Dictionary<Tkey, Tvalue>` implements `IReadOnlyDictionary<Tkey, Tvalue>`. By using `IReadOnlyDictionary<string, string>` for the  `ResponseResult.Headers`, there is no easy way for callers to manipulate the response headers by accident.