### PR TITLE
use utc instead of local time for measuring elapsed time

### DIFF
--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -61,6 +61,7 @@ public class NegativeTest
         var bucketName = Guid.NewGuid().ToString("N");
         var minio = new MinioClient()
             .WithEndpoint("play.min.io")
+            .WithSSL()
             .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
 

--- a/Minio.Tests/OperationsTest.cs
+++ b/Minio.Tests/OperationsTest.cs
@@ -46,8 +46,8 @@ public class OperationsTest
         // todo how to test this with mock client.
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
 
         var bucket = "bucket";
@@ -85,7 +85,7 @@ public class OperationsTest
 
         var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
             signedUrl);
     }
 
@@ -95,8 +95,8 @@ public class OperationsTest
         // todo how to test this with mock client.
         var client = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
 
         var bucket = "bucket";
@@ -140,7 +140,7 @@ public class OperationsTest
         var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
 
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
             signedUrl);
     }
 }

--- a/Minio.Tests/ReuseTcpConnectionTest.cs
+++ b/Minio.Tests/ReuseTcpConnectionTest.cs
@@ -14,8 +14,8 @@ public class ReuseTcpConnectionTest
     {
         MinioClient = new MinioClient()
             .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
-                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .Build();
     }
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1412,7 +1412,7 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Post, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
 
         var parts = new List<XElement>();
 
@@ -1475,9 +1475,9 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Get, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", $"{partNumberMarker}");
-        requestMessageBuilder.AddQueryParameter("max-parts", "1000");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", partNumberMarker);
+        requestMessageBuilder.AddQueryParameter("max-parts", 1000);
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
@@ -1568,8 +1568,8 @@ public partial class MinioClient : IObjectOperations
             .ConfigureAwait(false);
         if (!string.IsNullOrEmpty(uploadId) && partNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{partNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", partNumber);
         }
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)

--- a/Minio/DataModel/BucketOperationsArgs.cs
+++ b/Minio/DataModel/BucketOperationsArgs.cs
@@ -198,7 +198,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
             requestMessageBuilder.AddOrUpdateHeaderParameter(h.Key, h.Value);
 
         requestMessageBuilder.AddQueryParameter("delimiter", Delimiter);
-        requestMessageBuilder.AddQueryParameter("max-keys", "1000");
+        requestMessageBuilder.AddQueryParameter("max-keys", 1000);
         requestMessageBuilder.AddQueryParameter("encoding-type", "url");
         requestMessageBuilder.AddQueryParameter("prefix", Prefix);
         if (Versions)
@@ -210,7 +210,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
         }
         else if (!Versions && UseV2)
         {
-            requestMessageBuilder.AddQueryParameter("list-type", "2");
+            requestMessageBuilder.AddQueryParameter("list-type", 2);
             if (!string.IsNullOrWhiteSpace(Marker)) requestMessageBuilder.AddQueryParameter("start-after", Marker);
             if (!string.IsNullOrWhiteSpace(ContinuationToken))
                 requestMessageBuilder.AddQueryParameter("continuation-token", ContinuationToken);

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -59,7 +59,7 @@ public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         requestMessageBuilder.AddQueryParameter("select", "");
-        requestMessageBuilder.AddQueryParameter("select-type", "2");
+        requestMessageBuilder.AddQueryParameter("select-type", 2);
 
         if (RequestBody == null)
         {
@@ -231,7 +231,7 @@ public class StatObjectArgs : ObjectConditionalQueryArgs<StatObjectArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         if (!string.IsNullOrEmpty(VersionId))
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
         if (Headers.ContainsKey(S3ZipExtractKey))
             requestMessageBuilder.AddQueryParameter(S3ZipExtractKey, Headers[S3ZipExtractKey]);
 
@@ -445,7 +445,7 @@ public class RemoveUploadArgs : EncryptionArgs<RemoveUploadArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         return requestMessageBuilder;
     }
 }
@@ -553,7 +553,7 @@ public class GetObjectArgs : ObjectConditionalQueryArgs<GetObjectArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", VersionId);
 
         if (CallBack is not null) requestMessageBuilder.ResponseWriter = CallBack;
         else requestMessageBuilder.FunctionResponseWriter = FuncCallBack;
@@ -615,7 +615,7 @@ public class RemoveObjectArgs : ObjectArgs<RemoveObjectArgs>
     {
         if (!string.IsNullOrEmpty(VersionId))
         {
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
             if (BypassGovernanceMode != null && BypassGovernanceMode.Value)
                 requestMessageBuilder.AddOrUpdateHeaderParameter("x-amz-bypass-governance-retention",
                     BypassGovernanceMode.Value.ToString());
@@ -1682,7 +1682,7 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         var parts = new List<XElement>();
 
         for (var i = 1; i <= ETags.Count; i++)
@@ -1691,7 +1691,6 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
                 new XElement("ETag", ETags[i])));
         var completeMultipartUploadXml = new XElement("CompleteMultipartUpload", parts);
         var bodyString = completeMultipartUploadXml.ToString();
-        var body = Encoding.UTF8.GetBytes(bodyString);
         var bodyInBytes = Encoding.UTF8.GetBytes(bodyString);
         requestMessageBuilder.BodyParameters.Add("content-type", "application/xml");
         requestMessageBuilder.SetBody(bodyInBytes);
@@ -1712,7 +1711,7 @@ internal class PutObjectPartArgs : PutObjectArgs
     {
         base.Validate();
         if (string.IsNullOrWhiteSpace(UploadId))
-            throw new ArgumentNullException(nameof(UploadId) + " not assigned for PutObjectPart operation.");
+            throw new ArgumentNullException(nameof(UploadId), $"{nameof(UploadId)} not assigned for PutObjectPart operation.");
     }
 
     public new PutObjectPartArgs WithBucket(string bkt)
@@ -1832,8 +1831,8 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         requestMessageBuilder.AddOrUpdateHeaderParameter("Content-Type", Headers["Content-Type"]);
         if (!string.IsNullOrWhiteSpace(UploadId) && PartNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{PartNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", PartNumber);
         }
 
         if (ObjectTags != null && ObjectTags.TaggingSet != null

--- a/Minio/HttpRequestMessageBuilder.cs
+++ b/Minio/HttpRequestMessageBuilder.cs
@@ -172,6 +172,11 @@ internal class HttpRequestMessageBuilder
         QueryParameters[key] = value;
     }
 
+    public void AddQueryParameter(string key, int value)
+    {
+        QueryParameters[key] = value.ToString();
+    }
+
     public void SetBody(byte[] body)
     {
         Content = body;

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -559,7 +559,7 @@ public partial class MinioClient : IMinioClient
         CancellationToken cancellationToken = default,
         bool isSts = false)
     {
-        var startTime = DateTime.Now;
+        var startTime = DateTime.UtcNow;
         // Logs full url when HTTPtracing is enabled.
         if (trace)
         {
@@ -806,7 +806,7 @@ public partial class MinioClient : IMinioClient
         // Logs Response if HTTP tracing is enabled
         if (trace)
         {
-            var now = DateTime.Now;
+            var now = DateTime.UtcNow;
             LogRequest(response.Request, response, (now - startTime).TotalMilliseconds);
         }
 


### PR DESCRIPTION
When logging the request elapsed time, it is better to use `DateTime.UtcNow` instead of `DateTime.Now`. Not only is it faster not having to compute the timezone offset, it is also will not have issues during daylight savings.  A better approach may be to use `System.Diagnostics.Stopwatch` or a non-allocating stopwatch like introduced in .NET 7. You can copy the source for the similar code below as this library supports older versions of .NET.

```cs
long startingTimestamp = Stopwatch.GetTimestamp();
TimeSpan elapsed = Stopwatch.GetElapsedTime(startingTimestamp);
```