### PR TITLE
Response cleanup

### DIFF
--- a/Minio.Tests/VirtualStream.cs
+++ b/Minio.Tests/VirtualStream.cs
@@ -30,7 +30,7 @@ namespace Minio.Tests;
 /// Virtural stream will create a random data stream up to the user's specific size.
 /// It will not allocate any data. This stream can only be read forward.
 /// </summary>
-public class VirutalStream : Stream
+public class VirtualStream : Stream
 {
     /// <summary>
     /// The current position in the stream
@@ -47,11 +47,11 @@ public class VirutalStream : Stream
     /// </summary>
     private readonly Random _random;
 
-    public VirutalStream(long size) : this(size, Random.Shared)
+    public VirtualStream(long size) : this(size, Random.Shared)
     {
     }
 
-    public VirutalStream(long size, Random random)
+    public VirtualStream(long size, Random random)
     {
         if (size < 0) throw new ArgumentOutOfRangeException(nameof(size), "Size must be greater or equal to zero");
 

--- a/Minio.Tests/VirtualStreamTest.cs
+++ b/Minio.Tests/VirtualStreamTest.cs
@@ -21,19 +21,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace Minio.Tests;
 
 /// <summary>
-/// Tests to ensure the VirutalStream is working correct.
-/// Other tests will use the VirutalStream to test uploading
+/// Tests to ensure the VirtualStream is working correct.
+/// Other tests will use the VirtualStream to test uploading
 /// huge documents to minio/S3.
 /// </summary>
 [TestClass]
-public class VirutalStreamTest
+public class VirtualStreamTest
 {
     [TestMethod]
-    public void zero_size_stream_reads_no_data()
+    public void Zero_size_stream_reads_no_data()
     {
         byte[] buffer = new byte[1024];
 
-        VirutalStream sut = new VirutalStream(0);
+        VirtualStream sut = new VirtualStream(0);
 
         var actual = sut.Read(buffer, 0, buffer.Length);
 
@@ -46,7 +46,7 @@ public class VirutalStreamTest
     {
         byte[] buffer = new byte[1024];
 
-        VirutalStream sut = new VirutalStream(buffer.LongLength);
+        VirtualStream sut = new VirtualStream(buffer.LongLength);
 
         var actual = sut.Read(buffer, 0, buffer.Length);
         Assert.AreEqual(buffer.Length, actual);
@@ -63,7 +63,7 @@ public class VirutalStreamTest
         // this test want to ensure the buffer size and stream size are not multiples of each other
         byte[] buffer = new byte[128];
 
-        VirutalStream sut = new VirutalStream(135);
+        VirtualStream sut = new VirtualStream(135);
 
         // should read the complete buffer
         var actual = sut.Read(buffer, 0, buffer.Length);
@@ -84,7 +84,7 @@ public class VirutalStreamTest
         // this test want to ensure the buffer size and stream size are not multiples of each other
         byte[] buffer = new byte[128];
 
-        VirutalStream sut = new VirutalStream(1024);
+        VirtualStream sut = new VirtualStream(1024);
 
         // should read the complete buffer
         var actual = sut.Read(buffer, buffer.Length / 2, buffer.Length  / 2);

--- a/Minio.Tests/VirutalStream.cs
+++ b/Minio.Tests/VirutalStream.cs
@@ -1,0 +1,102 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017-2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+using Minio.DataModel.Tags;
+using System;
+using System.IO;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading;
+
+namespace Minio.Tests;
+
+/// <summary>
+/// Virtural stream will create a random data stream up to the user's specific size.
+/// It will not allocate any data. This stream can only be read forward.
+/// </summary>
+public class VirutalStream : Stream
+{
+    /// <summary>
+    /// The current position in the stream
+    /// </summary>
+    private long _position = 0;
+
+    /// <summary>
+    /// The total size of data to produce.
+    /// </summary>
+    private readonly long _size;
+
+    /// <summary>
+    /// Random generator for data.
+    /// </summary>
+    private readonly Random _random;
+
+    public VirutalStream(long size) : this(size, Random.Shared)
+    {
+    }
+
+    public VirutalStream(long size, Random random)
+    {
+        if (size < 0) throw new ArgumentOutOfRangeException(nameof(size), "Size must be greater or equal to zero");
+
+        _random = random ?? throw new ArgumentNullException(nameof(random));
+        _size = size;
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position { get => _position; set => throw new NotSupportedException(); }
+    public override void Flush() { }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        // if there is enough data to return count bytes, then return that amount
+        // otherwise return what ever is left over.
+        int bytes = ((_size - _position) >= count)
+            ? count
+            : (int)(_size - _position);
+
+        if (bytes != 0)
+        {
+            var span = buffer.AsSpan(offset, bytes);
+            _random.NextBytes(span);
+
+            _position += bytes;
+        }
+
+        return bytes;
+    }
+
+    public override long Seek(long offset, SeekOrigin origin)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void SetLength(long value)
+    {
+        throw new NotSupportedException();
+    }
+
+    public override void Write(byte[] buffer, int offset, int count)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/Minio.Tests/VirutalStreamTest.cs
+++ b/Minio.Tests/VirutalStreamTest.cs
@@ -1,0 +1,99 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017-2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Minio.Tests;
+
+/// <summary>
+/// Tests to ensure the VirutalStream is working correct.
+/// Other tests will use the VirutalStream to test uploading
+/// huge documents to minio/S3.
+/// </summary>
+[TestClass]
+public class VirutalStreamTest
+{
+    [TestMethod]
+    public void zero_size_stream_reads_no_data()
+    {
+        byte[] buffer = new byte[1024];
+
+        VirutalStream sut = new VirutalStream(0);
+
+        var actual = sut.Read(buffer, 0, buffer.Length);
+
+        Assert.AreEqual(0, actual);
+        Assert.AreEqual(0, sut.Position);
+    }
+
+    [TestMethod]
+    public void can_read_complete_buffer()
+    {
+        byte[] buffer = new byte[1024];
+
+        VirutalStream sut = new VirutalStream(buffer.LongLength);
+
+        var actual = sut.Read(buffer, 0, buffer.Length);
+        Assert.AreEqual(buffer.Length, actual);
+
+        // should not read any data this time
+        actual = sut.Read(buffer, 0, buffer.Length);
+        Assert.AreEqual(0, actual);
+        Assert.AreEqual(buffer.LongLength, sut.Position);
+    }
+
+    [TestMethod]
+    public void should_read_complete_stream()
+    {
+        // this test want to ensure the buffer size and stream size are not multiples of each other
+        byte[] buffer = new byte[128];
+
+        VirutalStream sut = new VirutalStream(135);
+
+        // should read the complete buffer
+        var actual = sut.Read(buffer, 0, buffer.Length);
+        Assert.AreEqual(buffer.Length, actual);
+
+        // read only the remaining data (135 - 128)
+        actual = sut.Read(buffer, 0, buffer.Length);
+        Assert.AreEqual(135 - 128, actual);
+
+        // shouldnt get any more data
+        actual = sut.Read(buffer, 0, buffer.Length);
+        Assert.AreEqual(0, actual);
+    }
+
+    [TestMethod]
+    public void should_read_into_correct_offset()
+    {
+        // this test want to ensure the buffer size and stream size are not multiples of each other
+        byte[] buffer = new byte[128];
+
+        VirutalStream sut = new VirutalStream(1024);
+
+        // should read the complete buffer
+        var actual = sut.Read(buffer, buffer.Length / 2, buffer.Length  / 2);
+        Assert.AreEqual(buffer.Length / 2, actual);
+
+        // first half of the buffer should still be zeros
+        for (int i = 0; i < buffer.Length / 2; i++)
+        {
+            Assert.AreEqual(0, buffer[i]);
+        }
+    }
+}

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
  * (C) 2017-2021 MinIO, Inc.
  *
@@ -194,15 +194,8 @@ public partial class MinioClient : IBucketOperations
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
 
-        var bucketList = new ListAllMyBucketsResult();
-        if (HttpStatusCode.OK.Equals(response.StatusCode))
-            using (var stream = new MemoryStream(response.ContentBytes))
-            {
-                bucketList =
-                    (ListAllMyBucketsResult)new XmlSerializer(typeof(ListAllMyBucketsResult)).Deserialize(stream);
-            }
-
-        return bucketList;
+        var operationResonse = new ListBucketsResponse(response);
+        return operationResonse.BucketsResult ?? new ListAllMyBucketsResult();
     }
 
 
@@ -220,6 +213,7 @@ public partial class MinioClient : IBucketOperations
             var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
             using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
                 .ConfigureAwait(false);
+
         }
         catch (InternalClientException ice)
         {
@@ -227,10 +221,9 @@ public partial class MinioClient : IBucketOperations
                 || ice.ServerResponse == null)
                 return false;
         }
-        catch (Exception ex)
+        catch (BucketNotFoundException)
         {
-            if (ex.GetType() == typeof(BucketNotFoundException)) return false;
-            throw;
+            return false;
         }
 
         return true;
@@ -250,8 +243,8 @@ public partial class MinioClient : IBucketOperations
     {
         args.Validate();
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using var response = await ExecuteTaskAsync(NoErrorHandlers,
-            requestMessageBuilder, cancellationToken).ConfigureAwait(false);
+        using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -298,7 +291,7 @@ public partial class MinioClient : IBucketOperations
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
 
-        var versioningResponse = new GetVersioningResponse(responseResult.StatusCode, responseResult.Content);
+        var versioningResponse = new GetVersioningResponse(responseResult);
         return versioningResponse.VersioningConfig;
     }
 
@@ -318,8 +311,8 @@ public partial class MinioClient : IBucketOperations
     {
         args.Validate();
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
-        using var response = await ExecuteTaskAsync(NoErrorHandlers,
-            requestMessageBuilder, cancellationToken).ConfigureAwait(false);
+        using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
+            .ConfigureAwait(false);
     }
 
 
@@ -416,9 +409,8 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var getBucketNotificationsResponse =
-            new GetBucketNotificationsResponse(responseResult.StatusCode, responseResult.Content);
-        return getBucketNotificationsResponse.BucketNotificationConfiguration;
+        var getBucketNotificationsResponse = new GetBucketNotificationsResponse(responseResult);
+        return getBucketNotificationsResponse.BucketNotificationConfiguration ?? new BucketNotification();
     }
 
     /// <summary>
@@ -515,8 +507,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var getBucketNotificationsResponse =
-            new GetBucketTagsResponse(responseResult.StatusCode, responseResult.Content);
+        var getBucketNotificationsResponse = new GetBucketTagsResponse(responseResult);
         return getBucketNotificationsResponse.BucketTags;
     }
 
@@ -559,8 +550,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var getBucketEncryptionResponse =
-            new GetBucketEncryptionResponse(responseResult.StatusCode, responseResult.Content);
+        var getBucketEncryptionResponse = new GetBucketEncryptionResponse(responseResult);
         return getBucketEncryptionResponse.BucketEncryptionConfiguration;
     }
 
@@ -669,7 +659,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var resp = new GetObjectLockConfigurationResponse(responseResult.StatusCode, responseResult.Content);
+        var resp = new GetObjectLockConfigurationResponse(responseResult);
         return resp.LockConfiguration;
     }
 
@@ -737,7 +727,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var response = new GetBucketLifecycleResponse(responseResult.StatusCode, responseResult.Content);
+        var response = new GetBucketLifecycleResponse(responseResult);
         return response.BucketLifecycle;
     }
 
@@ -781,7 +771,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var response = new GetBucketReplicationResponse(responseResult.StatusCode, responseResult.Content);
+        var response = new GetBucketReplicationResponse(responseResult);
         return response.Config;
     }
 
@@ -870,7 +860,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var getPolicyResponse = new GetPolicyResponse(responseResult.StatusCode, responseResult.Content);
+        var getPolicyResponse = new GetPolicyResponse(responseResult);
         return getPolicyResponse.PolicyJsonString;
     }
 
@@ -924,7 +914,7 @@ public partial class MinioClient : IBucketOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var getObjectsListResponse = new GetObjectsListResponse(responseResult.StatusCode, responseResult.Content);
+        var getObjectsListResponse = new GetObjectsListResponse(responseResult);
         return getObjectsListResponse.ObjectsTuple;
     }
 
@@ -945,7 +935,7 @@ public partial class MinioClient : IBucketOperations
         using var responseResult = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
         var getObjectsVersionsListResponse =
-            new GetObjectsVersionsListResponse(responseResult.StatusCode, responseResult.Content);
+            new GetObjectsVersionsListResponse(responseResult);
         return getObjectsVersionsListResponse.ObjectsTuple;
     }
 

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1412,7 +1412,7 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Post, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
 
         var parts = new List<XElement>();
 
@@ -1475,9 +1475,9 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(HttpMethod.Get, bucketName,
                 objectName)
             .ConfigureAwait(false);
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", $"{partNumberMarker}");
-        requestMessageBuilder.AddQueryParameter("max-parts", "1000");
+        requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+        if (partNumberMarker > 0) requestMessageBuilder.AddQueryParameter("part-number-marker", partNumberMarker);
+        requestMessageBuilder.AddQueryParameter("max-parts", 1000);
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
@@ -1568,8 +1568,8 @@ public partial class MinioClient : IObjectOperations
             .ConfigureAwait(false);
         if (!string.IsNullOrEmpty(uploadId) && partNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{uploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{partNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", uploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", partNumber);
         }
 
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)

--- a/Minio/BucketRegionCache.cs
+++ b/Minio/BucketRegionCache.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/Minio/Credentials/AssumeRoleBaseProvider.cs
+++ b/Minio/Credentials/AssumeRoleBaseProvider.cs
@@ -125,7 +125,8 @@ public abstract class AssumeRoleBaseProvider<T> : ClientProvider
             ResponseResult responseMessage = null;
             try
             {
-                responseMessage = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder);
+                responseMessage = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder)
+                    .ConfigureAwait(false);
             }
             finally
             {

--- a/Minio/Credentials/AssumeRoleProvider.cs
+++ b/Minio/Credentials/AssumeRoleProvider.cs
@@ -119,9 +119,7 @@ public class AssumeRoleProvider : AssumeRoleBaseProvider<AssumeRoleProvider>
                 AssumeRoleResponse assumeRoleResp = null;
                 if (responseResult.Response.IsSuccessStatusCode)
                 {
-                    var contentBytes = Encoding.UTF8.GetBytes(responseResult.Content);
-
-                    using (var stream = new MemoryStream(contentBytes))
+                    using (var stream = new MemoryStream(responseResult.ContentBytes))
                     {
                         assumeRoleResp =
                             (AssumeRoleResponse)new XmlSerializer(typeof(AssumeRoleResponse)).Deserialize(stream);

--- a/Minio/Credentials/AssumeRoleProvider.cs
+++ b/Minio/Credentials/AssumeRoleProvider.cs
@@ -114,7 +114,8 @@ public class AssumeRoleProvider : AssumeRoleBaseProvider<AssumeRoleProvider>
             ResponseResult responseResult = null;
             try
             {
-                responseResult = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder, isSts: true);
+                responseResult = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder, isSts: true)
+                    .ConfigureAwait(false);
 
                 AssumeRoleResponse assumeRoleResp = null;
                 if (responseResult.Response.IsSuccessStatusCode)

--- a/Minio/Credentials/IAMAWSProvider.cs
+++ b/Minio/Credentials/IAMAWSProvider.cs
@@ -121,6 +121,7 @@ public class IAMAWSProvider : EnvironmentProvider
 
         using var response =
             await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder);
+
         if (string.IsNullOrWhiteSpace(response.Content) ||
             !HttpStatusCode.OK.Equals(response.StatusCode))
             throw new CredentialsProviderException("IAMAWSProvider",
@@ -187,7 +188,6 @@ public class IAMAWSProvider : EnvironmentProvider
 
         using var response =
             await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder);
-
 
         if (string.IsNullOrWhiteSpace(response.Content) ||
             !HttpStatusCode.OK.Equals(response.StatusCode))

--- a/Minio/Credentials/IAMAWSProvider.cs
+++ b/Minio/Credentials/IAMAWSProvider.cs
@@ -119,8 +119,8 @@ public class IAMAWSProvider : EnvironmentProvider
         var requestBuilder = new HttpRequestMessageBuilder(HttpMethod.Get, url);
         requestBuilder.AddQueryParameter("location", "");
 
-        using var response =
-            await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder);
+        using var response = await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder)
+            .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(response.Content) ||
             !HttpStatusCode.OK.Equals(response.StatusCode))
@@ -186,8 +186,8 @@ public class IAMAWSProvider : EnvironmentProvider
         var requestBuilder = new HttpRequestMessageBuilder(HttpMethod.Get, url);
         requestBuilder.AddQueryParameter("location", "");
 
-        using var response =
-            await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder);
+        using var response = await Minio_Client.ExecuteTaskAsync(Enumerable.Empty<ApiResponseErrorHandlingDelegate>(), requestBuilder)
+            .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(response.Content) ||
             !HttpStatusCode.OK.Equals(response.StatusCode))

--- a/Minio/DataModel/BucketOperationsArgs.cs
+++ b/Minio/DataModel/BucketOperationsArgs.cs
@@ -198,7 +198,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
             requestMessageBuilder.AddOrUpdateHeaderParameter(h.Key, h.Value);
 
         requestMessageBuilder.AddQueryParameter("delimiter", Delimiter);
-        requestMessageBuilder.AddQueryParameter("max-keys", "1000");
+        requestMessageBuilder.AddQueryParameter("max-keys", 1000);
         requestMessageBuilder.AddQueryParameter("encoding-type", "url");
         requestMessageBuilder.AddQueryParameter("prefix", Prefix);
         if (Versions)
@@ -210,7 +210,7 @@ internal class GetObjectListArgs : BucketArgs<GetObjectListArgs>
         }
         else if (!Versions && UseV2)
         {
-            requestMessageBuilder.AddQueryParameter("list-type", "2");
+            requestMessageBuilder.AddQueryParameter("list-type", 2);
             if (!string.IsNullOrWhiteSpace(Marker)) requestMessageBuilder.AddQueryParameter("start-after", Marker);
             if (!string.IsNullOrWhiteSpace(ContinuationToken))
                 requestMessageBuilder.AddQueryParameter("continuation-token", ContinuationToken);

--- a/Minio/DataModel/GenericResponse.cs
+++ b/Minio/DataModel/GenericResponse.cs
@@ -14,18 +14,37 @@
  * limitations under the License.
  */
 
+using Minio.DataModel;
+using System.Collections.Generic;
+using System.IO;
 using System.Net;
+using System.Text;
 
 namespace Minio;
 
-public class GenericResponse
+public abstract class GenericResponse
 {
-    internal GenericResponse(HttpStatusCode statusCode, string responseContent)
+    private readonly ResponseResult _responseResult;
+
+    protected GenericResponse(ResponseResult result)
     {
-        ResponseContent = responseContent;
-        ResponseStatusCode = ResponseStatusCode;
+        if (result == null) throw new System.ArgumentNullException(nameof(result));
+        _responseResult = result;
     }
 
-    internal string ResponseContent { get; }
-    internal HttpStatusCode ResponseStatusCode { get; }
+    internal string ResponseContent => _responseResult.Content;
+    internal HttpStatusCode ResponseStatusCode => _responseResult.StatusCode;
+
+    /// <summary>
+    /// The headers from the response.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Headers => _responseResult.Headers;
+
+    protected bool IsOkWithContent
+    {
+        get
+        {
+            return _responseResult.StatusCode == HttpStatusCode.OK && !string.IsNullOrEmpty(_responseResult.Content);
+        }
+    }
 }

--- a/Minio/DataModel/GenericXmlResponse.cs
+++ b/Minio/DataModel/GenericXmlResponse.cs
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+using Minio.DataModel;
 using System.IO;
+using System.Text;
 using System.Xml.Serialization;
 
 namespace Minio;
@@ -37,9 +39,12 @@ public abstract class GenericXmlResponse<TResult> : GenericResponse
             return;
         }
 
-        using var stream = new MemoryStream(result.ContentBytes);
+        // convert the content if required
+        var content = ConvertContent(Encoding.UTF8.GetString(result.ContentBytes));
+
+        using TextReader reader = new StringReader(content);
         var serializer = new XmlSerializer(typeof(TResult));
-        _result = (TResult)serializer.Deserialize(stream);
+        _result = (TResult)serializer.Deserialize(reader);
     }
 
     /// <summary>

--- a/Minio/DataModel/GenericXmlResponse.cs
+++ b/Minio/DataModel/GenericXmlResponse.cs
@@ -1,0 +1,51 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.IO;
+using System.Xml.Serialization;
+
+namespace Minio;
+
+/// <summary>
+/// Represents a response where the content is XML.
+/// </summary>
+/// <typeparam name="TResult">The type of the XML content</typeparam>
+public abstract class GenericXmlResponse<TResult> : GenericResponse
+{
+    /// <summary>
+    /// The parsed result, or null if the 
+    /// </summary>
+    protected TResult _result;
+
+    public GenericXmlResponse(ResponseResult result) : base(result)
+    {
+        if (!IsOkWithContent)
+        {
+            return;
+        }
+
+        using var stream = new MemoryStream(result.ContentBytes);
+        var serializer = new XmlSerializer(typeof(TResult));
+        _result = (TResult)serializer.Deserialize(stream);
+    }
+
+    /// <summary>
+    /// Convert the content if required.
+    /// </summary>
+    /// <param name="content"></param>
+    /// <returns></returns>
+    protected virtual string ConvertContent(string content) => content;
+}

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -59,7 +59,7 @@ public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         requestMessageBuilder.AddQueryParameter("select", "");
-        requestMessageBuilder.AddQueryParameter("select-type", "2");
+        requestMessageBuilder.AddQueryParameter("select-type", 2);
 
         if (RequestBody == null)
         {
@@ -231,7 +231,7 @@ public class StatObjectArgs : ObjectConditionalQueryArgs<StatObjectArgs>
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         if (!string.IsNullOrEmpty(VersionId))
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
         if (Headers.ContainsKey(S3ZipExtractKey))
             requestMessageBuilder.AddQueryParameter(S3ZipExtractKey, Headers[S3ZipExtractKey]);
 
@@ -445,7 +445,7 @@ public class RemoveUploadArgs : EncryptionArgs<RemoveUploadArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         return requestMessageBuilder;
     }
 }
@@ -553,7 +553,7 @@ public class GetObjectArgs : ObjectConditionalQueryArgs<GetObjectArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+        if (!string.IsNullOrEmpty(VersionId)) requestMessageBuilder.AddQueryParameter("versionId", VersionId);
 
         if (CallBack is not null) requestMessageBuilder.ResponseWriter = CallBack;
         else requestMessageBuilder.FunctionResponseWriter = FuncCallBack;
@@ -615,7 +615,7 @@ public class RemoveObjectArgs : ObjectArgs<RemoveObjectArgs>
     {
         if (!string.IsNullOrEmpty(VersionId))
         {
-            requestMessageBuilder.AddQueryParameter("versionId", $"{VersionId}");
+            requestMessageBuilder.AddQueryParameter("versionId", VersionId);
             if (BypassGovernanceMode != null && BypassGovernanceMode.Value)
                 requestMessageBuilder.AddOrUpdateHeaderParameter("x-amz-bypass-governance-retention",
                     BypassGovernanceMode.Value.ToString());
@@ -1682,7 +1682,7 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
+        requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
         var parts = new List<XElement>();
 
         for (var i = 1; i <= ETags.Count; i++)
@@ -1691,7 +1691,6 @@ internal class CompleteMultipartUploadArgs : ObjectWriteArgs<CompleteMultipartUp
                 new XElement("ETag", ETags[i])));
         var completeMultipartUploadXml = new XElement("CompleteMultipartUpload", parts);
         var bodyString = completeMultipartUploadXml.ToString();
-        var body = Encoding.UTF8.GetBytes(bodyString);
         var bodyInBytes = Encoding.UTF8.GetBytes(bodyString);
         requestMessageBuilder.BodyParameters.Add("content-type", "application/xml");
         requestMessageBuilder.SetBody(bodyInBytes);
@@ -1712,7 +1711,7 @@ internal class PutObjectPartArgs : PutObjectArgs
     {
         base.Validate();
         if (string.IsNullOrWhiteSpace(UploadId))
-            throw new ArgumentNullException(nameof(UploadId) + " not assigned for PutObjectPart operation.");
+            throw new ArgumentNullException(nameof(UploadId), $"{nameof(UploadId)} not assigned for PutObjectPart operation.");
     }
 
     public new PutObjectPartArgs WithBucket(string bkt)
@@ -1832,8 +1831,8 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         requestMessageBuilder.AddOrUpdateHeaderParameter("Content-Type", Headers["Content-Type"]);
         if (!string.IsNullOrWhiteSpace(UploadId) && PartNumber > 0)
         {
-            requestMessageBuilder.AddQueryParameter("uploadId", $"{UploadId}");
-            requestMessageBuilder.AddQueryParameter("partNumber", $"{PartNumber}");
+            requestMessageBuilder.AddQueryParameter("uploadId", UploadId);
+            requestMessageBuilder.AddQueryParameter("partNumber", PartNumber);
         }
 
         if (ObjectTags != null && ObjectTags.TaggingSet != null

--- a/Minio/DataModel/ObjectStat.cs
+++ b/Minio/DataModel/ObjectStat.cs
@@ -47,7 +47,7 @@ public class ObjectStat
     public DateTime? ObjectLockRetainUntilDate { get; private set; }
     public bool? LegalHoldEnabled { get; private set; }
 
-    public static ObjectStat FromResponseHeaders(string objectName, Dictionary<string, string> responseHeaders)
+    public static ObjectStat FromResponseHeaders(string objectName, IReadOnlyDictionary<string, string> responseHeaders)
     {
         if (string.IsNullOrEmpty(objectName)) throw new ArgumentNullException("Name of an object cannot be empty");
         var objInfo = new ObjectStat();

--- a/Minio/Helper/OperationsHelper.cs
+++ b/Minio/Helper/OperationsHelper.cs
@@ -159,7 +159,7 @@ public partial class MinioClient : IObjectOperations
         var requestMessageBuilder = await CreateRequest(args).ConfigureAwait(false);
         using var response = await ExecuteTaskAsync(NoErrorHandlers, requestMessageBuilder, cancellationToken)
             .ConfigureAwait(false);
-        var removeObjectsResponse = new RemoveObjectsResponse(response.StatusCode, response.Content);
+        var removeObjectsResponse = new RemoveObjectsResponse(response);
         return removeObjectsResponse.DeletedObjectsResult.errorList;
     }
 

--- a/Minio/HttpRequestMessageBuilder.cs
+++ b/Minio/HttpRequestMessageBuilder.cs
@@ -172,6 +172,11 @@ internal class HttpRequestMessageBuilder
         QueryParameters[key] = value;
     }
 
+    public void AddQueryParameter(string key, int value)
+    {
+        QueryParameters[key] = value.ToString();
+    }
+
     public void SetBody(byte[] body)
     {
         Content = body;

--- a/Minio/ReadOnlyDictionaryExtensions.cs
+++ b/Minio/ReadOnlyDictionaryExtensions.cs
@@ -1,0 +1,29 @@
+﻿/*
+* MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+* (C) 2017-2021 MinIO, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+
+namespace Minio;
+
+public static class ReadOnlyDictionaryExtensions
+{
+    public static string GetValueOrNull(this IReadOnlyDictionary<string, string> values, string key)
+    {
+        values.TryGetValue(key, out var value);
+        return value;
+    }
+}

--- a/Minio/ResponseHeaderCollection.cs
+++ b/Minio/ResponseHeaderCollection.cs
@@ -1,0 +1,83 @@
+﻿/*
+* MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+* (C) 2017-2021 MinIO, Inc.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Minio;
+
+public class ResponseHeaderCollection : IReadOnlyDictionary<string, string>
+{
+    private readonly Dictionary<string, string> _headers;
+
+    public static readonly ResponseHeaderCollection Empty = new ResponseHeaderCollection();
+
+    private ResponseHeaderCollection()
+    {
+        _headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public ResponseHeaderCollection(HttpResponseMessage response)
+    {
+        _headers = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (response.Content != null)
+        {
+            foreach (var header in response.Content.Headers)
+            {
+                var value = header.Value.FirstOrDefault();
+                if (value != null)
+                {
+                    _headers.Add(header.Key, value);
+                }
+            }
+        }
+
+        foreach (var header in response.Headers)
+        {
+            // if the content header already has this header value,
+            // avoid ArgumentException if the key already exists
+            if (!_headers.ContainsKey(header.Key))
+            {
+                var value = header.Value.FirstOrDefault();
+                if (value != null)
+                {
+                    _headers.Add(header.Key, value);
+                }
+            }
+        }
+    }
+
+    public string this[string key] => _headers[key];
+
+    public IEnumerable<string> Keys => _headers.Keys;
+
+    public IEnumerable<string> Values => _headers.Values;
+
+    public int Count => _headers.Count;
+
+    public bool ContainsKey(string key) => _headers.ContainsKey(key);
+
+    public IEnumerator<KeyValuePair<string, string>> GetEnumerator() => _headers.GetEnumerator();
+
+    public bool TryGetValue(string key, out string value) => _headers.TryGetValue(key, out value);
+
+    IEnumerator IEnumerable.GetEnumerator() => _headers.GetEnumerator();
+}


### PR DESCRIPTION
This PR cleans up the Response types.

- Removed a few places where the content string is converted back to byte array just to be read from a memory stream. They bytes are available as a property.
- Change `GenericResponse` to be abstract
- Added abstract` GenericXmlResponse<TResult>` that inherits from `GenericResponse`
   - consolidates the logic to deserialize the response content as XML of type TResult
   - has optional function to convert content for those few xml types that need namespaces removed
- Change almost all response types to only take a single `ResponseResult` constructor argument
- Fix a few`ExecuteTaskAsync` calls that did not `.ConfigureAwait(false)` on them
- Remove the `Response.Content.ReadAsStreamAsync().Result)` and replaced with `Response.Content.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult()`
- Add `ResponseHeaderCollection` for consistent Ordinal Ignore-Case header lookup
- Add extension method on `IReadOnlyDictionary<string, string>` to get a header as string or null if it doesn't exist `GetValueOrNull`
- Added a `VirutalStream` class to the Test project for future testing of uploading large streams without really allocating memory or using disk.
- Try to clean up ResponseResult's `ContentBytes`, `Content` and `ContentStream`
   - removed ContentStream because reading the result content more than once should throw an error
   - move the ContentStream logic into the initializing `ContentBytes` lazyily.
 - Replaced ResponseResult's `public Dictionary<string, string> Headers` property with a initialized ResponseHeaderCollection based on the incoming response. If there is no response, headers gets initialized to statically allocated `ResponseHeaderCollection.Empty` instance.