### PR TITLE
AcceptAllHeader

### DIFF
--- a/Minio/DataModel/BucketOperationsArgs.cs
+++ b/Minio/DataModel/BucketOperationsArgs.cs
@@ -46,8 +46,10 @@ public class RemoveBucketArgs : BucketArgs<RemoveBucketArgs>
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
-        if (Headers.ContainsKey(BucketForceDeleteKey))
-            requestMessageBuilder.AddHeaderParameter(BucketForceDeleteKey, Headers[BucketForceDeleteKey]);
+        foreach (var header in Headers)
+        {
+            requestMessageBuilder.AddHeaderParameter(header.Key, Headers[header.Key]);
+        }
         return requestMessageBuilder;
     }
 }


### PR DESCRIPTION
Purpose of this change  is to accept all kind of header in BucketOperationsArgs including BucketForceDeleteKey to build the request. Currently it accepting only BucketForceDeleteKey .