### PR TITLE
Replaces 'http' with 'https' in Minio.Tests for 'play.min.io'

### DIFF
--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -46,8 +46,10 @@ public class NegativeTest
     {
         var badName = new string('A', 260);
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithEndpoint("play.min.io", 443)
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
         var args = new BucketExistsArgs()
             .WithBucket(badName);
@@ -60,8 +62,10 @@ public class NegativeTest
         var badName = new string('A', 260);
         var bucketName = Guid.NewGuid().ToString("N");
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithEndpoint("play.min.io", 443)
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
 
         try

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -46,7 +46,7 @@ public class NegativeTest
     {
         var badName = new string('A', 260);
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -62,7 +62,7 @@ public class NegativeTest
         var badName = new string('A', 260);
         var bucketName = Guid.NewGuid().ToString("N");
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/OperationsTest.cs
+++ b/Minio.Tests/OperationsTest.cs
@@ -30,7 +30,7 @@ public class OperationsTest
                 .WithBucket(bucket)
                 .WithObject(objectName)
                 .WithCallbackStream(stream => { });
-            await client.GetObjectAsync(getObjectArgs);
+            await client.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
 
             return true;
         }
@@ -45,9 +45,10 @@ public class OperationsTest
     {
         // todo how to test this with mock client.
         var client = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
 
         var bucket = "bucket";
@@ -55,12 +56,12 @@ public class OperationsTest
 
         var bktExistArgs = new BucketExistsArgs()
             .WithBucket(bucket);
-        var found = await client.BucketExistsAsync(bktExistArgs);
+        var found = await client.BucketExistsAsync(bktExistArgs).ConfigureAwait(false);
         if (!found)
         {
             var mkBktArgs = new MakeBucketArgs()
                 .WithBucket(bucket);
-            await client.MakeBucketAsync(mkBktArgs);
+            await client.MakeBucketAsync(mkBktArgs).ConfigureAwait(false);
         }
 
         if (!await ObjectExistsAsync(client, bucket, objectName))
@@ -74,7 +75,7 @@ public class OperationsTest
                 .WithObject(objectName)
                 .WithStreamData(helloStream)
                 .WithObjectSize(helloData.Length);
-            await client.PutObjectAsync(PutObjectArgs);
+            await client.PutObjectAsync(PutObjectArgs).ConfigureAwait(false);
         }
 
         var presignedGetObjectArgs = new PresignedGetObjectArgs()
@@ -83,9 +84,9 @@ public class OperationsTest
             .WithExpiry(3600)
             .WithRequestDate(_requestDate);
 
-        var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
+        var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs).ConfigureAwait(false);
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&X-Amz-Signature=d4202da690618f77142d6f0557c97839f0773b2c718082e745cd9b199aa6b28f",
             signedUrl);
     }
 
@@ -94,9 +95,10 @@ public class OperationsTest
     {
         // todo how to test this with mock client.
         var client = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
 
         var bucket = "bucket";
@@ -109,12 +111,12 @@ public class OperationsTest
 
         var bktExistArgs = new BucketExistsArgs()
             .WithBucket(bucket);
-        var found = await client.BucketExistsAsync(bktExistArgs);
+        var found = await client.BucketExistsAsync(bktExistArgs).ConfigureAwait(false);
         if (!found)
         {
             var mkBktArgs = new MakeBucketArgs()
                 .WithBucket(bucket);
-            await client.MakeBucketAsync(mkBktArgs);
+            await client.MakeBucketAsync(mkBktArgs).ConfigureAwait(false);
         }
 
         if (!await ObjectExistsAsync(client, bucket, objectName))
@@ -127,7 +129,7 @@ public class OperationsTest
                 .WithObject(objectName)
                 .WithStreamData(helloStream)
                 .WithObjectSize(helloData.Length);
-            await client.PutObjectAsync(PutObjectArgs);
+            await client.PutObjectAsync(PutObjectArgs).ConfigureAwait(false);
         }
 
         var presignedGetObjectArgs = new PresignedGetObjectArgs()
@@ -137,10 +139,10 @@ public class OperationsTest
             .WithHeaders(reqParams)
             .WithRequestDate(_requestDate);
 
-        var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs);
+        var signedUrl = await client.PresignedGetObjectAsync(presignedGetObjectArgs).ConfigureAwait(false);
 
         Assert.AreEqual(
-            "http://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
+            "https://play.min.io/bucket/object-name?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=Q3AM3UQ867SPQQA43P2F%2F20200501%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200501T154533Z&X-Amz-Expires=3600&X-Amz-SignedHeaders=host&response-content-disposition=attachment%3B%20filename%3D%22filename.jpg%22&X-Amz-Signature=de66f04dd4ac35838b9e83d669f7b5a70b452c6468e2b4a9e9c29f42e7fa102d",
             signedUrl);
     }
 }

--- a/Minio.Tests/OperationsTest.cs
+++ b/Minio.Tests/OperationsTest.cs
@@ -45,7 +45,7 @@ public class OperationsTest
     {
         // todo how to test this with mock client.
         var client = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -95,7 +95,7 @@ public class OperationsTest
     {
         // todo how to test this with mock client.
         var client = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -28,7 +28,7 @@ public class RetryHandlerTest
     public async Task TestRetryPolicyOnSuccess()
     {
         var client = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -53,7 +53,7 @@ public class RetryHandlerTest
     public async Task TestRetryPolicyOnFailure()
     {
         var client = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/RetryHandlerTest.cs
+++ b/Minio.Tests/RetryHandlerTest.cs
@@ -28,7 +28,7 @@ public class RetryHandlerTest
     public async Task TestRetryPolicyOnSuccess()
     {
         var client = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -44,7 +44,7 @@ public class RetryHandlerTest
 
         var bktArgs = new BucketExistsArgs()
             .WithBucket(Guid.NewGuid().ToString());
-        var result = await client.BucketExistsAsync(bktArgs);
+        var result = await client.BucketExistsAsync(bktArgs).ConfigureAwait(false);
         Assert.IsFalse(result);
         Assert.AreEqual(invokeCount, 1);
     }
@@ -53,7 +53,7 @@ public class RetryHandlerTest
     public async Task TestRetryPolicyOnFailure()
     {
         var client = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -86,7 +86,7 @@ public class RetryHandlerTest
             .WithObject("aa")
             .WithCallbackStream(s => { });
         await Assert.ThrowsExceptionAsync<BucketNotFoundException>(
-            () => client.GetObjectAsync(getObjectArgs));
+            () => client.GetObjectAsync(getObjectArgs)).ConfigureAwait(false);
         Assert.AreEqual(invokeCount, retryCount);
     }
 }

--- a/Minio.Tests/ReuseTcpConnectionTest.cs
+++ b/Minio.Tests/ReuseTcpConnectionTest.cs
@@ -13,7 +13,7 @@ public class ReuseTcpConnectionTest
     public ReuseTcpConnectionTest()
     {
         MinioClient = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/ReuseTcpConnectionTest.cs
+++ b/Minio.Tests/ReuseTcpConnectionTest.cs
@@ -13,9 +13,10 @@ public class ReuseTcpConnectionTest
     public ReuseTcpConnectionTest()
     {
         MinioClient = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
     }
 
@@ -29,7 +30,7 @@ public class ReuseTcpConnectionTest
                 .WithBucket("bucket")
                 .WithObject(objectName)
                 .WithFile("testfile");
-            await client.GetObjectAsync(getObjectArgs);
+            await client.GetObjectAsync(getObjectArgs).ConfigureAwait(false);
 
             return true;
         }

--- a/Minio.Tests/UnitTest1.cs
+++ b/Minio.Tests/UnitTest1.cs
@@ -34,9 +34,10 @@ public class UnitTest1
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io")
+            .WithEndpoint("play.min.io", 443)
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
     }
 
@@ -180,8 +181,10 @@ public class UnitTest2
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithEndpoint("play.min.io", 443)
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
     }
 

--- a/Minio.Tests/UnitTest1.cs
+++ b/Minio.Tests/UnitTest1.cs
@@ -34,7 +34,7 @@ public class UnitTest1
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()
@@ -181,7 +181,7 @@ public class UnitTest2
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/UrlTests.cs
+++ b/Minio.Tests/UrlTests.cs
@@ -33,7 +33,7 @@ public class UrlTests
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io", 443)
+            .WithEndpoint("play.min.io")
             .WithCredentials("Q3AM3UQ867SPQQA43P2F",
                 "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
             .WithSSL()

--- a/Minio.Tests/UrlTests.cs
+++ b/Minio.Tests/UrlTests.cs
@@ -33,8 +33,10 @@ public class UrlTests
                                                | SecurityProtocolType.Tls11
                                                | SecurityProtocolType.Tls12;
         var minio = new MinioClient()
-            .WithEndpoint("play.min.io")
-            .WithCredentials("Q3AM3UQ867SPQQA43P2F", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithEndpoint("play.min.io", 443)
+            .WithCredentials("Q3AM3UQ867SPQQA43P2F",
+                "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
+            .WithSSL()
             .Build();
     }
 


### PR DESCRIPTION
Replaces Minio client `endpoint` `http://play.min.io:80` with `https://play.min.io:443` for `Minio.Tests`.
The `Minio.Tests` started failing during build tests after `play` server is decommissioned.
Anyways, we were supposed to use `https`.