### PR TITLE
This is a fix to set the field value before Validate()

### DIFF
--- a/Minio/Credentials/WebIdentityProvider.cs
+++ b/Minio/Credentials/WebIdentityProvider.cs
@@ -52,8 +52,8 @@ public class WebIdentityProvider : WebIdentityClientGrantsProvider<WebIdentityPr
 
     internal WebIdentityProvider WithJWTSupplier(Func<JsonWebToken> f)
     {
-        Validate();
         JWTSupplier = (Func<JsonWebToken>)f.Clone();
+        Validate();
         return this;
     }
 


### PR DESCRIPTION
`Validate()` verifies the field `JWTSupplier` is not null before its assigned, causing  a `Parameter 'JWTSupplier JWT Token supplier cannot be null.'` exception.

Breakins IAMAWSProvider.GetAccessCredentials
https://github.com/minio/minio-dotnet/blob/b332b78f47996ee40e2ed263b9374ad0e2663286/Minio/Credentials/IAMAWSProvider.cs#L93-L103
This is a fix to set the field value before Validate().