### PR TITLE
.Net4.x workaround for unhandled special chars

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -4885,7 +4885,8 @@ public static class FunctionalTest
         }
         catch (Exception ex)
         {
-            new MintLogger("GetObject_AsyncCallback_Test1", getObjectSignature, "Tests whether GetObject as stream works",
+            new MintLogger("GetObject_AsyncCallback_Test1", getObjectSignature,
+                "Tests whether GetObject as stream works",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -247,7 +247,11 @@ public static class FunctionalTest
     {
         // Server side does not allow the following characters in object names
         // '-', '_', '.', '/', '*'
+#if NET6_0_OR_GREATER
         var characters = "abcd+%$#@&{}[]()";
+#else
+        var characters = "abcdefgh+%$#@&";
+#endif
         var result = new StringBuilder(length);
 
         for (var i = 0; i < length; i++) result.Append(characters[rnd.Next(characters.Length)]);
@@ -4818,6 +4822,7 @@ public static class FunctionalTest
             }
         }
     }
+
 #if NET6_0_OR_GREATER
     internal static async Task GetObject_AsyncCallback_Test1(MinioClient minio)
     {
@@ -4874,13 +4879,13 @@ public static class FunctionalTest
             file_read_size = writtenInfo.Length;
             Assert.AreEqual(size, file_read_size);
 
-            new MintLogger("GetObject_LargeFile_Test0", getObjectSignature,
+            new MintLogger("GetObject_AsyncCallback_Test1", getObjectSignature,
                 "Tests whether GetObject as stream works",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger("GetObject_LargeFile_Test0", getObjectSignature, "Tests whether GetObject as stream works",
+            new MintLogger("GetObject_AsyncCallback_Test1", getObjectSignature, "Tests whether GetObject as stream works",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }
@@ -4894,6 +4899,7 @@ public static class FunctionalTest
         }
     }
 #endif
+
     internal static async Task FGetObject_Test1(MinioClient minio)
     {
         var startTime = DateTime.Now;

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -16,6 +16,7 @@
 */
 
 using System.Net;
+using System.Reflection;
 
 namespace Minio.Functional.Tests;
 
@@ -86,6 +87,10 @@ internal static class Program
 
         // Set HTTP Tracing Off
         // minioClient.SetTraceOff();
+
+        // Print Minio version in use
+        var version = typeof(MinioClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        Console.WriteLine($"\n  Minio package version is {version.Substring(0, version.IndexOf('+'))}\n");
 
         var runMode = Environment.GetEnvironmentVariable("MINT_MODE");
 

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -89,8 +89,8 @@ internal static class Program
         // minioClient.SetTraceOff();
 
         // Print Minio version in use
-        var version = typeof(MinioClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-        Console.WriteLine($"\n  Minio package version is {version.Substring(0, version.IndexOf('+'))}\n");
+        // var version = typeof(MinioClient).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
+        // Console.WriteLine($"\n  Minio package version is {version.Substring(0, version.IndexOf('+'))}\n");
 
         var runMode = Environment.GetEnvironmentVariable("MINT_MODE");
 

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -16,7 +16,6 @@
 */
 
 using System.Net;
-using System.Reflection;
 
 namespace Minio.Functional.Tests;
 


### PR DESCRIPTION
workaround for the Uri encoding not taking care of some special characters we use in object names, like `{`, `}`, `(`, `)`, ...

also commented out option to print version of the Minio.nupkg currently under use before the functional tests start