### PR TITLE
PutObjectAsync with Snowball header must not use multipart

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -562,11 +562,12 @@ public partial class MinioClient : IObjectOperations
         args.SSE?.Marshal(args.Headers);
 
         var isSnowball = args.Headers.ContainsKey("X-Amz-Meta-Snowball-Auto-Extract") &&
-            Convert.ToBoolean(args.Headers["X-Amz-Meta-Snowball-Auto-Extract"]);
+                         Convert.ToBoolean(args.Headers["X-Amz-Meta-Snowball-Auto-Extract"]);
 
         // Upload object in single part if size falls under restricted part size
         // or the request has snowball objects
-        if ((args.ObjectSize < Constants.MinimumPartSize || isSnowball) && args.ObjectSize >= 0 && args.ObjectStreamData is not null)
+        if ((args.ObjectSize < Constants.MinimumPartSize || isSnowball) && args.ObjectSize >= 0 &&
+            args.ObjectStreamData is not null)
         {
             var bytes = await ReadFullAsync(args.ObjectStreamData, (int)args.ObjectSize).ConfigureAwait(false);
             var bytesRead = bytes.Length;

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -561,8 +561,12 @@ public partial class MinioClient : IObjectOperations
         args?.Validate();
         args.SSE?.Marshal(args.Headers);
 
-        // Upload object in single part if size falls under restricted part size.
-        if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0 && args.ObjectStreamData is not null)
+        var isSnowball = args.Headers.ContainsKey("X-Amz-Meta-Snowball-Auto-Extract") &&
+            Convert.ToBoolean(args.Headers["X-Amz-Meta-Snowball-Auto-Extract"]);
+
+        // Upload object in single part if size falls under restricted part size
+        // or the request has snowball objects
+        if ((args.ObjectSize < Constants.MinimumPartSize || isSnowball) && args.ObjectSize >= 0 && args.ObjectStreamData is not null)
         {
             var bytes = await ReadFullAsync(args.ObjectStreamData, (int)args.ObjectSize).ConfigureAwait(false);
             var bytesRead = bytes.Length;


### PR DESCRIPTION
PutObjectAsync must not use multipart if has header "X-Amz-Meta-Snowball-Auto-Extract=true".
See https://github.com/minio/minio/issues/17033