### PR TITLE
.Net4.x support and parallel test run fixes

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -333,7 +333,7 @@ public static class FunctionalTest
         };
 
         var MaxNoOfParallelProcesses = 4;
-        await Utils.ForEachAsync(coreTestsTasks, MaxNoOfParallelProcesses,
+        await coreTestsTasks.ForEachAsync(MaxNoOfParallelProcesses,
             async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
     }
 
@@ -478,14 +478,20 @@ public static class FunctionalTest
     internal static async Task ListBuckets_Test(MinioClient minio)
     {
         var startTime = DateTime.Now;
-        var args = new Dictionary<string, string>();
         IList<Bucket> bucketList = new List<Bucket>();
-        var bucketName = "buucketnaame";
+        var bucketNameSuffix = "listbucketstest";
         var noOfBuckets = 5;
+
+        var args = new Dictionary<string, string>
+        {
+            { "bucketNameSuffix", bucketNameSuffix },
+            { "noOfBuckets", noOfBuckets.ToString() }
+        };
+
         try
         {
             foreach (var indx in Enumerable.Range(1, noOfBuckets))
-                await Setup_Test(minio, bucketName + indx).ConfigureAwait(false);
+                await Setup_Test(minio, "bucket" + indx + bucketNameSuffix).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -503,7 +509,7 @@ public static class FunctionalTest
         {
             var list = await minio.ListBucketsAsync().ConfigureAwait(false);
             bucketList = list.Buckets;
-            bucketList = bucketList.Where(x => x.Name.StartsWith(bucketName)).ToList();
+            bucketList = bucketList.Where(x => x.Name.EndsWith(bucketNameSuffix)).ToList();
             Assert.AreEqual(noOfBuckets, bucketList.Count);
             bucketList.ToList().Sort((x, y) =>
             {
@@ -516,7 +522,7 @@ public static class FunctionalTest
             foreach (var bucket in bucketList)
             {
                 indx++;
-                Assert.AreEqual(bucketName + indx, bucket.Name);
+                Assert.AreEqual("bucket" + indx + bucketNameSuffix, bucket.Name);
             }
 
             new MintLogger(nameof(ListBuckets_Test), listBucketsSignature, "Tests whether ListBucket passes",
@@ -1472,7 +1478,7 @@ public static class FunctionalTest
         var startTime = DateTime.Now;
         var bucketName = GetRandomName(15);
         var objectName = GetRandomObjectName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-SelectObjectContent_Test";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -1855,7 +1861,7 @@ public static class FunctionalTest
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.Tags);
             var tagsRes = tagObj.Tags;
-            Assert.AreEqual(tagObj.Tags.Count, tags.Count);
+            Assert.AreEqual(tagsRes.Count, tags.Count);
 
             new MintLogger(nameof(BucketTagsAsync_Test1), getBucketTagsSignature,
                 "Tests whether GetBucketTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -3541,7 +3547,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-CopyObject_Test1";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -3699,7 +3705,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-CopyObject_Test3";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -3776,7 +3782,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-CopyObject_Test4";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -3850,7 +3856,6 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        // string outFileName = "outFileName";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -3927,7 +3932,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-CopyObject_Test6";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4172,7 +4177,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-CopyObject_Test9";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4260,7 +4265,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-EncryptedCopyObject_Test1";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4343,7 +4348,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-EncryptedCopyObject_Test2";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4424,7 +4429,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-EncryptedCopyObject_Test3";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4498,7 +4503,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var destBucketName = GetRandomName(15);
         var destObjectName = GetRandomName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-EncryptedCopyObject_Test4";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
@@ -4914,7 +4919,7 @@ public static class FunctionalTest
         var startTime = DateTime.Now;
         var bucketName = GetRandomName(15);
         var objectName = GetRandomObjectName(10);
-        var outFileName = "outFileName";
+        var outFileName = "outFileName-FGetObject_Test1";
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,13 +332,9 @@ public static class FunctionalTest
             GetBucketPolicy_Test1(minioClient)
         };
 
-        ParallelOptions parallelOptions = new()
-        {
-            MaxDegreeOfParallelism = 4
-        };
-        await Parallel
-            .ForEachAsync(coreTestsTasks, parallelOptions,
-                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+        var MaxNoOfParallelProcesses = 4;
+        await Utils.ForEachAsync(coreTestsTasks, MaxNoOfParallelProcesses,
+            async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
     }
 
     internal static async Task BucketExists_Test(MinioClient minio)
@@ -1859,7 +1855,7 @@ public static class FunctionalTest
             Assert.IsNotNull(tagObj);
             Assert.IsNotNull(tagObj.Tags);
             var tagsRes = tagObj.Tags;
-            Assert.AreEqual(tagsRes.Count, tags.Count);
+            Assert.AreEqual(tagObj.Tags.Count, tags.Count);
 
             new MintLogger(nameof(BucketTagsAsync_Test1), getBucketTagsSignature,
                 "Tests whether GetBucketTagsAsync passes", TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2861,10 +2857,10 @@ public static class FunctionalTest
             var sleepTime = 1000; // Milliseconds
             await Task.Delay(sleepTime).ConfigureAwait(false);
 
-            var modelJson = "{\"test\": \"test\"}";
+            var modelJson = "{\"test2\": \"test2\"}";
             using var stream = Encoding.UTF8.GetBytes(modelJson).AsMemory().AsStream();
             var putObjectArgs = new PutObjectArgs()
-                .WithObject("test.json")
+                .WithObject("test2.json")
                 .WithBucket(bucketName)
                 .WithContentType(contentType)
                 .WithStreamData(stream)
@@ -2942,11 +2938,11 @@ public static class FunctionalTest
                 .WithSuffix(suffix)
                 .WithEvents(events);
 
-            var modelJson = "{\"test\": \"test\"}";
+            var modelJson = "{\"test3\": \"test3\"}";
 
             using var stream = Encoding.UTF8.GetBytes(modelJson).AsMemory().AsStream();
             var putObjectArgs = new PutObjectArgs()
-                .WithObject("test.json")
+                .WithObject("test3.json")
                 .WithBucket(bucketName)
                 .WithContentType(contentType)
                 .WithStreamData(stream)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,9 +332,20 @@ public static class FunctionalTest
             GetBucketPolicy_Test1(minioClient)
         };
 
-        var MaxNoOfParallelProcesses = 4;
-        await coreTestsTasks.ForEachAsync(MaxNoOfParallelProcesses,
-            async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+#if NET6_0_OR_GREATER
+        ParallelOptions parallelOptions = new()
+        {
+            MaxDegreeOfParallelism = 4
+        };
+        await Parallel
+            .ForEachAsync(coreTestsTasks, parallelOptions,
+                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+#else
+        await coreTestsTasks.ForEachAsync(async task =>
+        {
+            await task.ConfigureAwait(false);
+        }).ConfigureAwait(false);
+#endif
     }
 
     internal static async Task BucketExists_Test(MinioClient minio)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,10 +332,8 @@ public static class FunctionalTest
             GetBucketPolicy_Test1(minioClient)
         };
 
-        await Utils.RunInParallel(coreTestsTasks, async (task, _) =>
-        {
-            await task.ConfigureAwait(false);
-        }).ConfigureAwait(false);
+        await Utils.RunInParallel(coreTestsTasks, async (task, _) => { await task.ConfigureAwait(false); })
+            .ConfigureAwait(false);
     }
 
     internal static async Task BucketExists_Test(MinioClient minio)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -332,20 +332,10 @@ public static class FunctionalTest
             GetBucketPolicy_Test1(minioClient)
         };
 
-#if NET6_0_OR_GREATER
-        ParallelOptions parallelOptions = new()
-        {
-            MaxDegreeOfParallelism = 4
-        };
-        await Parallel
-            .ForEachAsync(coreTestsTasks, parallelOptions,
-                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
-#else
-        await coreTestsTasks.ForEachAsync(async task =>
+        await Utils.RunInParallel(coreTestsTasks, async (task, _) =>
         {
             await task.ConfigureAwait(false);
         }).ConfigureAwait(false);
-#endif
     }
 
     internal static async Task BucketExists_Test(MinioClient minio)

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -244,19 +244,9 @@ internal static class Program
             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
         }
 
-#if NET6_0_OR_GREATER
-        ParallelOptions parallelOptions = new()
-        {
-            MaxDegreeOfParallelism = 4
-        };
-        await Parallel
-            .ForEachAsync(functionalTestTasks, parallelOptions,
-                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
-#else
-        await functionalTestTasks.ForEachAsync(async task =>
+        await Utils.RunInParallel(functionalTestTasks, async (task, _) =>
         {
             await task.ConfigureAwait(false);
         }).ConfigureAwait(false);
-#endif
     }
 }

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -244,12 +244,8 @@ internal static class Program
             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
         }
 
-        ParallelOptions parallelOptions = new()
-        {
-            MaxDegreeOfParallelism = 4
-        };
-        await Parallel
-            .ForEachAsync(functionalTestTasks, parallelOptions,
-                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+        var MaxNoOfParallelProcesses = 4;
+        await Utils.ForEachAsync(functionalTestTasks, MaxNoOfParallelProcesses,
+            async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
     }
 }

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -244,9 +244,7 @@ internal static class Program
             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
         }
 
-        await Utils.RunInParallel(functionalTestTasks, async (task, _) =>
-        {
-            await task.ConfigureAwait(false);
-        }).ConfigureAwait(false);
+        await Utils.RunInParallel(functionalTestTasks, async (task, _) => { await task.ConfigureAwait(false); })
+            .ConfigureAwait(false);
     }
 }

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -245,7 +245,7 @@ internal static class Program
         }
 
         var MaxNoOfParallelProcesses = 4;
-        await Utils.ForEachAsync(functionalTestTasks, MaxNoOfParallelProcesses,
+        await functionalTestTasks.ForEachAsync(MaxNoOfParallelProcesses,
             async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
     }
 }

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -244,8 +244,19 @@ internal static class Program
             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
         }
 
-        var MaxNoOfParallelProcesses = 4;
-        await functionalTestTasks.ForEachAsync(MaxNoOfParallelProcesses,
-            async task => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+#if NET6_0_OR_GREATER
+        ParallelOptions parallelOptions = new()
+        {
+            MaxDegreeOfParallelism = 4
+        };
+        await Parallel
+            .ForEachAsync(functionalTestTasks, parallelOptions,
+                async (task, _) => { await task.ConfigureAwait(false); }).ConfigureAwait(false);
+#else
+        await functionalTestTasks.ForEachAsync(async task =>
+        {
+            await task.ConfigureAwait(false);
+        }).ConfigureAwait(false);
+#endif
     }
 }

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -15,6 +15,7 @@
  */
 
 using System.ComponentModel;
+using System.Collections.Concurrent;
 using System.Dynamic;
 using System.Globalization;
 using System.Reflection;

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -15,7 +15,6 @@
  */
 
 using System.ComponentModel;
-using System.Collections.Concurrent;
 using System.Dynamic;
 using System.Globalization;
 using System.Reflection;
@@ -28,6 +27,9 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using Minio.Exceptions;
 using Minio.Helper;
+#if !NET6_0_OR_GREATER
+using System.Collections.Concurrent;
+#endif
 
 namespace Minio;
 

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Dynamic;
 using System.Globalization;
@@ -197,7 +196,8 @@ public static class Utils
         return !l2.Except(l1).Any();
     }
 
-    public static async Task RunInParallel<TSource>(IEnumerable<TSource> source, Func<TSource, CancellationToken, ValueTask> body)
+    public static async Task RunInParallel<TSource>(IEnumerable<TSource> source,
+        Func<TSource, CancellationToken, ValueTask> body)
     {
         var maxNoOfParallelProcesses = 4;
 #if NET6_0_OR_GREATER
@@ -209,14 +209,14 @@ public static class Utils
 #else
         await Task.WhenAll(Partitioner.Create(source).GetPartitions(maxNoOfParallelProcesses)
             .Select(partition => Task.Run(async delegate
-            {
-                using (partition)
                 {
-                    while (partition.MoveNext())
-                        await body(partition.Current, new CancellationToken());
+                    using (partition)
+                    {
+                        while (partition.MoveNext())
+                            await body(partition.Current, new CancellationToken());
+                    }
                 }
-            }
-        )));
+            )));
 #endif
     }
 

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -197,10 +197,11 @@ public static class Utils
         return !l2.Except(l1).Any();
     }
 
-    public static Task ForEachAsync<T>(this IEnumerable<T> source, int dop, Func<T, Task> body)
+    public static Task ForEachAsync<T>(this IEnumerable<T> source, Func<T, Task> body)
     {
+        var MaxNoOfParallelProcesses = 4;
         return Task.WhenAll(
-            from partition in Partitioner.Create(source).GetPartitions(dop)
+            from partition in Partitioner.Create(source).GetPartitions(MaxNoOfParallelProcesses)
             select Task.Run(async delegate
             {
                 using (partition)


### PR DESCRIPTION
Fixes #787

Replaces the offending `Parallel.ForEachAsync()` function with its local implementation and fixed 2 other net4.x support problems I noticed.

I've tested and verified the fix with net6.0, net462 and net48.