### PR TITLE
Replace dynamic with class

### DIFF
--- a/Minio.Tests/UtilsTest.cs
+++ b/Minio.Tests/UtilsTest.cs
@@ -159,10 +159,10 @@ public class UtilsTest
     public void TestValidPartSize1()
     {
         // { partSize = 550502400, partCount = 9987, lastPartSize = 241172480 }
-        dynamic partSizeObject = Utils.CalculateMultiPartSize(5497558138880);
-        double partSize = partSizeObject.partSize;
-        double partCount = partSizeObject.partCount;
-        double lastPartSize = partSizeObject.lastPartSize;
+        var partSizeObject = Utils.CalculateMultiPartSize(5497558138880);
+        double partSize = partSizeObject.PartSize;
+        double partCount = partSizeObject.PartCount;
+        double lastPartSize = partSizeObject.LastPartSize;
         Assert.AreEqual(partSize, 553648128);
         Assert.AreEqual(partCount, 9930);
         Assert.AreEqual(lastPartSize, 385875968);
@@ -171,10 +171,10 @@ public class UtilsTest
     [TestMethod]
     public void TestValidPartSize2()
     {
-        dynamic partSizeObject = Utils.CalculateMultiPartSize(500000000000, true);
-        double partSize = partSizeObject.partSize;
-        double partCount = partSizeObject.partCount;
-        double lastPartSize = partSizeObject.lastPartSize;
+        var partSizeObject = Utils.CalculateMultiPartSize(500000000000, true);
+        double partSize = partSizeObject.PartSize;
+        double partCount = partSizeObject.PartCount;
+        double lastPartSize = partSizeObject.LastPartSize;
         Assert.AreEqual(partSize, 536870912);
         Assert.AreEqual(partCount, 932);
         Assert.AreEqual(lastPartSize, 173180928);

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -857,10 +857,10 @@ public partial class MinioClient : IObjectOperations
         CancellationToken cancellationToken = default)
     {
         args?.Validate();
-        dynamic multiPartInfo = Utils.CalculateMultiPartSize(args.ObjectSize);
-        double partSize = multiPartInfo.partSize;
-        double partCount = multiPartInfo.partCount;
-        double lastPartSize = multiPartInfo.lastPartSize;
+        var multiPartInfo = Utils.CalculateMultiPartSize(args.ObjectSize);
+        double partSize = multiPartInfo.PartSize;
+        double partCount = multiPartInfo.PartCount;
+        double lastPartSize = multiPartInfo.LastPartSize;
         var totalParts = new Part[(int)partCount];
 
         var expectedReadSize = partSize;
@@ -928,10 +928,10 @@ public partial class MinioClient : IObjectOperations
     private async Task MultipartCopyUploadAsync(MultipartCopyUploadArgs args,
         CancellationToken cancellationToken = default)
     {
-        dynamic multiPartInfo = Utils.CalculateMultiPartSize(args.CopySize, true);
-        double partSize = multiPartInfo.partSize;
-        double partCount = multiPartInfo.partCount;
-        double lastPartSize = multiPartInfo.lastPartSize;
+        var multiPartInfo = Utils.CalculateMultiPartSize(args.CopySize, true);
+        double partSize = multiPartInfo.PartSize;
+        double partCount = multiPartInfo.PartCount;
+        double lastPartSize = multiPartInfo.LastPartSize;
         var totalParts = new Part[(int)partCount];
 
         var nmuArgs = new NewMultipartUploadCopyArgs()
@@ -1337,10 +1337,10 @@ public partial class MinioClient : IObjectOperations
     {
         // For all sizes greater than 5GB or if Copy byte range specified in conditions and byte range larger
         // than minimum part size (5 MB) do multipart.
-        dynamic multiPartInfo = Utils.CalculateMultiPartSize(copySize, true);
-        double partSize = multiPartInfo.partSize;
-        double partCount = multiPartInfo.partCount;
-        double lastPartSize = multiPartInfo.lastPartSize;
+        var multiPartInfo = Utils.CalculateMultiPartSize(copySize, true);
+        double partSize = multiPartInfo.PartSize;
+        double partCount = multiPartInfo.PartCount;
+        double lastPartSize = multiPartInfo.LastPartSize;
         var totalParts = new Part[(int)partCount];
 
         var sseHeaders = new Dictionary<string, string>(StringComparer.Ordinal);

--- a/Minio/DataModel/MultiPartInfo.cs
+++ b/Minio/DataModel/MultiPartInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Minio.DataModel;
+
+public class MultiPartInfo
+{
+    public double PartSize { get; set; }
+    public double PartCount { get; set; }
+    public double LastPartSize { get; set; }
+}

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -25,6 +25,7 @@ using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Serialization;
+using Minio.DataModel;
 using Minio.Exceptions;
 using Minio.Helper;
 #if !NET6_0_OR_GREATER
@@ -242,7 +243,7 @@ public static class Utils
     /// <param name="size"></param>
     /// <param name="copy"> If true, use COPY part size, else use PUT part size</param>
     /// <returns></returns>
-    public static object CalculateMultiPartSize(long size, bool copy = false)
+    public static MultiPartInfo CalculateMultiPartSize(long size, bool copy = false)
     {
         if (size == -1) size = Constants.MaximumStreamObjectSize;
 
@@ -255,11 +256,13 @@ public static class Utils
         partSize = (double)Math.Ceiling((decimal)partSize / minPartSize) * minPartSize;
         var partCount = Math.Ceiling(size / partSize);
         var lastPartSize = size - (partCount - 1) * partSize;
-        dynamic obj = new ExpandoObject();
-        obj.partSize = partSize;
-        obj.partCount = partCount;
-        obj.lastPartSize = lastPartSize;
-        return obj;
+        
+        return  new MultiPartInfo
+        {
+            PartSize = partSize,
+            PartCount = partCount,
+            LastPartSize = lastPartSize
+        };
     }
 
     /// <summary>


### PR DESCRIPTION
Use `class` instead of `dynamic` in Utils.CalculateMultiPartSize(long size, bool copy = false) for the reasons listed below:
- Better performance
- NativeAOT build friendly