### PR TITLE
Bump jetbrains.resharper.globaltools from 2023.1.2 to 2023.2.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "jetbrains.resharper.globaltools": {
-      "version": "2023.1.4",
+      "version": "2023.2.0",
       "commands": [
         "jb"
       ]


### PR DESCRIPTION
Bumps jetbrains.resharper.globaltools from 2023.1.2 to 2023.2.0.

---
updated-dependencies:
- dependency-name: jetbrains.resharper.globaltools dependency-type: direct:production update-type: version-update:semver-minor ...