### PR TITLE
Listen notification failure pr830

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 bld/
 [Bb]in/
 [Oo]bj/
+.history
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="4.20.1" />
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 </Project>

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -193,10 +193,9 @@ public partial class MinioClient : IMinioClient
         // Pick region from location HEAD request
         if (rgn?.Length == 0)
         {
-            if (!BucketRegionCache.Instance.Exists(bucketName))
-                rgn = await BucketRegionCache.Update(this, bucketName).ConfigureAwait(false);
-            else
-                rgn = BucketRegionCache.Instance.Region(bucketName);
+            rgn = BucketRegionCache.Instance.Exists(bucketName)
+                ? await BucketRegionCache.Update(this, bucketName).ConfigureAwait(false)
+                : BucketRegionCache.Instance.Region(bucketName);
         }
 
         // Defaults to us-east-1 if region could not be found


### PR DESCRIPTION
This faulty code was there for quite some time.
The issue is fixed by reversing the faulty if condition when there is no BucketCache class is instantiated.

This fix addresses the build test failure hit during PR #830 functional testing.