### PR TITLE
Reverses the wrong condition when a new bucket cache is needed

### DIFF
--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -175,7 +175,7 @@ jobs:
             sudo cp /tmp/minio-config/certs/public.crt /etc/ssl/certs/
             sudo cp /tmp/minio-config/certs/private.key /etc/ssl/private/
             /tmp/minio -C /tmp/minio-config server /tmp/fs{1...4} &
-            dotnet Minio.Functional.Tests/bin/Release/net6.0/Minio.Functional.Tests.dll
+            dotnet Minio.Functional.Tests/bin/Release/net7.0/Minio.Functional.Tests.dll
 
   push_to_nuget:
     needs: [build, unit_tests, functional_tests, format-check]

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@
 bld/
 [Bb]in/
 [Oo]bj/
+.history
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Tests/DateTimeTests.cs
+++ b/Minio.Tests/DateTimeTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System.Globalization;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Minio.DataModel;
 using Minio.DataModel.Args;
 using Minio.Helper;
@@ -55,7 +56,10 @@ public class DateTimeTests
     public void TestObjectStatExpires()
     {
         var d = TruncateMilliseconds(DateTime.Now);
-        var headers = new Dictionary<string, string> { ["x-amz-expiration"] = d.ToUniversalTime().ToString("r") };
+        var headers = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["x-amz-expiration"] = d.ToUniversalTime().ToString("r", CultureInfo.InvariantCulture)
+        };
         var stat = ObjectStat.FromResponseHeaders("test", headers);
         Assert.AreEqual(d.ToUniversalTime(), stat.Expires?.ToUniversalTime());
     }
@@ -64,7 +68,7 @@ public class DateTimeTests
     public void TestObjectStatObjectLockRetainUntilDate()
     {
         var d = TruncateMilliseconds(DateTime.Now);
-        var headers = new Dictionary<string, string>
+        var headers = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
         {
             ["x-amz-object-lock-retain-until-date"] = d.ToUniversalTime().ToString("O")
         };
@@ -77,7 +81,7 @@ public class DateTimeTests
     {
         var d = TruncateMilliseconds(DateTime.Now);
         var converted = Utils.To8601String(d);
-        var parsed = DateTime.Parse(converted);
+        var parsed = DateTime.Parse(converted, CultureInfo.InvariantCulture);
         Assert.AreEqual(d, parsed);
         Assert.AreEqual(d.Kind, parsed.Kind);
     }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -190,11 +190,9 @@ public partial class MinioClient : IMinioClient
 
         // Pick region from location HEAD request
         if (rgn?.Length == 0)
-        {
             rgn = BucketRegionCache.Instance.Exists(bucketName)
                 ? await BucketRegionCache.Update(this, bucketName).ConfigureAwait(false)
                 : BucketRegionCache.Instance.Region(bucketName);
-        }
 
         // Defaults to us-east-1 if region could not be found
         return rgn?.Length == 0 ? "us-east-1" : rgn;

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -191,10 +191,9 @@ public partial class MinioClient : IMinioClient
         // Pick region from location HEAD request
         if (rgn?.Length == 0)
         {
-            if (!BucketRegionCache.Instance.Exists(bucketName))
-                rgn = await BucketRegionCache.Update(this, bucketName).ConfigureAwait(false);
-            else
-                rgn = BucketRegionCache.Instance.Region(bucketName);
+            rgn = BucketRegionCache.Instance.Exists(bucketName)
+                ? await BucketRegionCache.Update(this, bucketName).ConfigureAwait(false)
+                : BucketRegionCache.Instance.Region(bucketName);
         }
 
         // Defaults to us-east-1 if region could not be found


### PR DESCRIPTION
This faulty code was there for quite some time.
The issue is fixed by reversing the faulty if condition when there is no BucketCache class is instantiated.

This fix addresses the build test failure hit during PR #830 functional testing.