### PR TITLE
Lifecycle expiration date, WithEndpoint, WithSSL issues cause functional tests to fail

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2730,7 +2730,7 @@ public static class FunctionalTest
                 listenBucketNotificationsSignature,
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
-                await TearDown(minio, bucketName).ConfigureAwait(false);
+            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -632,7 +632,7 @@ public static class FunctionalTest
             exceptionList.Add,
             () => { });
 
-        await Task.Delay(4500).ConfigureAwait(false);
+        await Task.Delay(9000).ConfigureAwait(false);
         if (lockConfig?.ObjectLockEnabled.Equals(ObjectLockConfiguration.LockEnabled,
                 StringComparison.OrdinalIgnoreCase) == true)
         {
@@ -2701,7 +2701,7 @@ public static class FunctionalTest
                         Exception ex = new UnexpectedMinioException(err.Message);
                         if (string.Equals(err.Code, "NotImplemented", StringComparison.OrdinalIgnoreCase))
                             ex = new NotImplementedException(err.Message);
-
+                        await TearDown(minio, bucketName).ConfigureAwait(false);
                         throw ex;
                     }
 
@@ -2730,6 +2730,7 @@ public static class FunctionalTest
                 listenBucketNotificationsSignature,
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+                await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -2738,6 +2739,7 @@ public static class FunctionalTest
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();
+            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -2769,12 +2771,9 @@ public static class FunctionalTest
                     "Tests whether ListenBucketNotifications passes for small object",
                     TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                     ex.ToString(), args: args).Log();
+                await TearDown(minio, bucketName).ConfigureAwait(false);
                 throw;
             }
-        }
-        finally
-        {
-            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
 
@@ -5388,7 +5387,7 @@ public static class FunctionalTest
                 () => { });
         }
 
-        await Task.Delay(5000).ConfigureAwait(false);
+        await Task.Delay(20000).ConfigureAwait(false);
         Assert.AreEqual(numObjects, count);
     }
 
@@ -6045,7 +6044,7 @@ public static class FunctionalTest
         catch (Exception ex)
         {
             await TearDown(minio, bucketName).ConfigureAwait(false);
-            new MintLogger(nameof(BucketLifecycleAsync_Test1), setBucketLifecycleSignature,
+            new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".0", setBucketLifecycleSignature,
                 "Tests whether SetBucketLifecycleAsync passes", TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();
             throw;

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -6100,8 +6100,8 @@ public static class FunctionalTest
             Assert.IsNotNull(lfcObj.Rules);
             Assert.IsTrue(lfcObj.Rules.Count > 0);
             Assert.AreEqual(lfcObj.Rules.Count, lfc.Rules.Count);
-            var lfcDate = DateTime.Parse(lfcObj.Rules[0].Expiration.Date, null, DateTimeStyles.RoundtripKind);
-            Assert.AreEqual(Math.Floor((lfcDate - baseDate).TotalDays), expInDays);
+            var lfcDate = DateTime.Parse(lfcObj.Rules[0].Expiration.ExpiryDate, null, DateTimeStyles.RoundtripKind);
+            Assert.AreEqual((lfcDate.Date - baseDate.Date).TotalDays, expInDays);
             new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".2", getBucketLifecycleSignature,
                     "Tests whether GetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -6053,14 +6053,16 @@ public static class FunctionalTest
         }
 
         var rules = new List<LifecycleRule>();
-        var exp = new Expiration(DateTime.Now.AddYears(1));
-        var compareDate = new DateTime(DateTime.Now.Year, DateTime.Now.Month, DateTime.Now.Day, 0, 0, 0);
-        var expInDays = (compareDate.AddYears(1) - compareDate).TotalDays;
+        var baseDate = DateTime.Now;
+        var expDate = baseDate.AddYears(1);
+        var exp = new Expiration(expDate);
+
+        var calculatedExpDate = expDate.AddDays(1).AddSeconds(-1).ToUniversalTime().Date.ToString("o");
+        var realExpDate = DateTime.Parse(calculatedExpDate, CultureInfo.InvariantCulture);
+        var expInDays = (realExpDate.Date - baseDate.Date).TotalDays;
 
         var rule1 = new LifecycleRule(null, "txt", exp, null,
-            new RuleFilter(null, "txt/", null),
-            null, null, LifecycleRule.LifecycleRuleStatusEnabled
-        );
+            new RuleFilter(null, "txt/", null), null, null, LifecycleRule.LifecycleRuleStatusEnabled);
         rules.Add(rule1);
         var lfc = new LifecycleConfiguration(rules);
         try
@@ -6099,7 +6101,7 @@ public static class FunctionalTest
             Assert.IsTrue(lfcObj.Rules.Count > 0);
             Assert.AreEqual(lfcObj.Rules.Count, lfc.Rules.Count);
             var lfcDate = DateTime.Parse(lfcObj.Rules[0].Expiration.Date, null, DateTimeStyles.RoundtripKind);
-            Assert.AreEqual(Math.Floor((lfcDate - compareDate).TotalDays), expInDays);
+            Assert.AreEqual(Math.Floor((lfcDate - baseDate).TotalDays), expInDays);
             new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".2", getBucketLifecycleSignature,
                     "Tests whether GetBucketLifecycleAsync passes", TestStatus.PASS, DateTime.Now - startTime,
                     args: args)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -590,10 +590,9 @@ public static class FunctionalTest
             new GetObjectLockConfigurationArgs()
                 .WithBucket(bucketName);
         ObjectLockConfiguration lockConfig = null;
-        VersioningConfiguration versioningConfig = null;
         try
         {
-            versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
+            var versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
                 .WithBucket(bucketName)).ConfigureAwait(false);
             if (versioningConfig is not null &&
                 (versioningConfig.Status.Contains("Enabled", StringComparison.Ordinal) ||
@@ -6057,9 +6056,8 @@ public static class FunctionalTest
         var expDate = baseDate.AddYears(1);
         var exp = new Expiration(expDate);
 
-        var calculatedExpDate = expDate.AddDays(1).AddSeconds(-1).ToUniversalTime().Date.ToString("o");
-        var realExpDate = DateTime.Parse(calculatedExpDate, CultureInfo.InvariantCulture);
-        var expInDays = (realExpDate.Date - baseDate.Date).TotalDays;
+        var calculatedExpDate = expDate.AddDays(1).AddSeconds(-1).ToUniversalTime().Date;
+        var expInDays = (calculatedExpDate.ToLocalTime().Date - baseDate.Date).TotalDays;
 
         var rule1 = new LifecycleRule(null, "txt", exp, null,
             new RuleFilter(null, "txt/", null), null, null, LifecycleRule.LifecycleRuleStatusEnabled);
@@ -6084,7 +6082,6 @@ public static class FunctionalTest
         }
         catch (Exception ex)
         {
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(BucketLifecycleAsync_Test1) + ".1", setBucketLifecycleSignature,
                 "Tests whether SetBucketLifecycleAsync passes", TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -632,7 +632,7 @@ public static class FunctionalTest
             exceptionList.Add,
             () => { });
 
-        await Task.Delay(9000).ConfigureAwait(false);
+        await Task.Delay(20000).ConfigureAwait(false);
         if (lockConfig?.ObjectLockEnabled.Equals(ObjectLockConfiguration.LockEnabled,
                 StringComparison.OrdinalIgnoreCase) == true)
         {
@@ -5387,7 +5387,7 @@ public static class FunctionalTest
                 () => { });
         }
 
-        await Task.Delay(20000).ConfigureAwait(false);
+        await Task.Delay(40000).ConfigureAwait(false);
         Assert.AreEqual(numObjects, count);
     }
 

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -26,7 +26,7 @@ namespace Minio.Functional.Tests;
 internal static class Program
 {
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Needs to run all tests")]
-    public static async Task Main(string[] args)
+    public static async Task Main()
     {
         string endPoint = null;
         string accessKey = null;
@@ -112,144 +112,144 @@ internal static class Program
         // If the following test is run against AWS, then the SDK throws
         // "Listening for bucket notification is specific only to `minio`
         // server endpoints".
-        await FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
-        functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient));
+        // await FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
+        // functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient));
+        // functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient));
 
-        // Check if bucket exists
-        functionalTestTasks.Add(FunctionalTest.BucketExists_Test(minioClient));
-        functionalTestTasks.Add(FunctionalTest.MakeBucket_Test5(minioClient));
+//         // Check if bucket exists
+//         functionalTestTasks.Add(FunctionalTest.BucketExists_Test(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.MakeBucket_Test5(minioClient));
 
-        if (useAWS)
-        {
-            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test2(minioClient, useAWS));
-            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test3(minioClient, useAWS));
-            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test4(minioClient, useAWS));
-        }
+//         if (useAWS)
+//         {
+//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test2(minioClient, useAWS));
+//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test3(minioClient, useAWS));
+//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test4(minioClient, useAWS));
+//         }
 
-        // Test removal of bucket
-        functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test2(minioClient));
+//         // Test removal of bucket
+//         functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test2(minioClient));
 
-        // Test ListBuckets function
-        functionalTestTasks.Add(FunctionalTest.ListBuckets_Test(minioClient));
+//         // Test ListBuckets function
+//         functionalTestTasks.Add(FunctionalTest.ListBuckets_Test(minioClient));
 
-        // Test Putobject function
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
+//         // Test Putobject function
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
 
-        // Test StatObject function
-        functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));
+//         // Test StatObject function
+//         functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));
 
-        // Test GetObjectAsync function
-        functionalTestTasks.Add(FunctionalTest.GetObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.GetObject_Test2(minioClient));
-        // 3 tests will run to check different values of offset and length parameters
-        // when GetObject api returns part of the object as defined by the offset
-        // and length parameters. Tests will be reported as GetObject_Test3,
-        // GetObject_Test4 and GetObject_Test5.
-        functionalTestTasks.Add(FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient));
+//         // Test GetObjectAsync function
+//         functionalTestTasks.Add(FunctionalTest.GetObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.GetObject_Test2(minioClient));
+//         // 3 tests will run to check different values of offset and length parameters
+//         // when GetObject api returns part of the object as defined by the offset
+//         // and length parameters. Tests will be reported as GetObject_Test3,
+//         // GetObject_Test4 and GetObject_Test5.
+//         functionalTestTasks.Add(FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient));
 
-#if NET6_0_OR_GREATER
-        // Test async callback function to download an object
-        functionalTestTasks.Add(FunctionalTest.GetObject_AsyncCallback_Test1(minioClient));
-#endif
+// #if NET6_0_OR_GREATER
+//         // Test async callback function to download an object
+//         functionalTestTasks.Add(FunctionalTest.GetObject_AsyncCallback_Test1(minioClient));
+// #endif
 
-        // Test File GetObject and PutObject functions
-        functionalTestTasks.Add(FunctionalTest.FGetObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.FPutObject_Test2(minioClient));
+//         // Test File GetObject and PutObject functions
+//         functionalTestTasks.Add(FunctionalTest.FGetObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.FPutObject_Test2(minioClient));
 
-        // Test SelectObjectContentAsync function
-        functionalTestTasks.Add(FunctionalTest.SelectObjectContent_Test(minioClient));
+//         // Test SelectObjectContentAsync function
+//         functionalTestTasks.Add(FunctionalTest.SelectObjectContent_Test(minioClient));
 
-        // Test ListObjectAsync function
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test4(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
+//         // Test ListObjectAsync function
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test3(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test4(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
 
-        // Test RemoveObjectAsync function
-        functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test3(minioClient));
+//         // Test RemoveObjectAsync function
+//         functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test3(minioClient));
 
-        // Test CopyObjectAsync function
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test4(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test5(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test6(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test7(minioClient));
-        functionalTestTasks.Add(FunctionalTest.CopyObject_Test8(minioClient));
+//         // Test CopyObjectAsync function
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test3(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test4(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test5(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test6(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test7(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test8(minioClient));
 
-        // Test SetPolicyAsync function
-        functionalTestTasks.Add(FunctionalTest.SetBucketPolicy_Test1(minioClient));
+//         // Test SetPolicyAsync function
+//         functionalTestTasks.Add(FunctionalTest.SetBucketPolicy_Test1(minioClient));
 
-        // Test S3Zip function
-        functionalTestTasks.Add(FunctionalTest.GetObjectS3Zip_Test1(minioClient));
+//         // Test S3Zip function
+//         functionalTestTasks.Add(FunctionalTest.GetObjectS3Zip_Test1(minioClient));
 
-        // Test Presigned Get/Put operations
-        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
-        // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
+//         // Test Presigned Get/Put operations
+//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test3(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
+//         // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
 
-        // Test incomplete uploads
-        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.RemoveIncompleteUpload_Test(minioClient));
+//         // Test incomplete uploads
+//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test2(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test3(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.RemoveIncompleteUpload_Test(minioClient));
 
-        // Test GetBucket policy
-        functionalTestTasks.Add(FunctionalTest.GetBucketPolicy_Test1(minioClient));
+//         // Test GetBucket policy
+//         functionalTestTasks.Add(FunctionalTest.GetBucketPolicy_Test1(minioClient));
 
-        // Test object versioning
-        functionalTestTasks.Add(FunctionalTest.ObjectVersioningAsync_Test1(minioClient));
+//         // Test object versioning
+//         functionalTestTasks.Add(FunctionalTest.ObjectVersioningAsync_Test1(minioClient));
 
-        // Test Object Lock Configuration
-        functionalTestTasks.Add(FunctionalTest.ObjectLockConfigurationAsync_Test1(minioClient));
+//         // Test Object Lock Configuration
+//         functionalTestTasks.Add(FunctionalTest.ObjectLockConfigurationAsync_Test1(minioClient));
 
-        // Test Bucket, Object Tags
-        functionalTestTasks.Add(FunctionalTest.BucketTagsAsync_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ObjectTagsAsync_Test1(minioClient));
+//         // Test Bucket, Object Tags
+//         functionalTestTasks.Add(FunctionalTest.BucketTagsAsync_Test1(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.ObjectTagsAsync_Test1(minioClient));
 
-        // Test Bucket Lifecycle configuration
+//         // Test Bucket Lifecycle configuration
         functionalTestTasks.Add(FunctionalTest.BucketLifecycleAsync_Test1(minioClient));
         functionalTestTasks.Add(FunctionalTest.BucketLifecycleAsync_Test2(minioClient));
 
-        // Test encryption
-        if (isSecure)
-        {
-#pragma warning disable MA0039 // Do not write your own certificate validation method
-            ServicePointManager.ServerCertificateValidationCallback +=
-                (sender, certificate, chain, sslPolicyErrors) => true;
-#pragma warning restore MA0039 // Do not write your own certificate validation method
+//         // Test encryption
+//         if (isSecure)
+//         {
+// #pragma warning disable MA0039 // Do not write your own certificate validation method
+//             ServicePointManager.ServerCertificateValidationCallback +=
+//                 (sender, certificate, chain, sslPolicyErrors) => true;
+// #pragma warning restore MA0039 // Do not write your own certificate validation method
 
-            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test1(minioClient));
-            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test2(minioClient));
+//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test1(minioClient));
+//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test2(minioClient));
 
-            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test1(minioClient));
-            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test2(minioClient));
-        }
+//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test1(minioClient));
+//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test2(minioClient));
+//         }
 
-        if (kmsEnabled is not null && string.Equals(kmsEnabled, "1", StringComparison.OrdinalIgnoreCase))
-        {
-            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test3(minioClient));
-            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test3(minioClient));
-            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
-        }
+//         if (kmsEnabled is not null && string.Equals(kmsEnabled, "1", StringComparison.OrdinalIgnoreCase))
+//         {
+//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test3(minioClient));
+//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test3(minioClient));
+//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
+//         }
 
         await functionalTestTasks.ForEachAsync().ConfigureAwait(false);
     }

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -26,7 +26,7 @@ namespace Minio.Functional.Tests;
 internal static class Program
 {
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Needs to run all tests")]
-    public static async Task Main()
+    public static async Task Main(string[] args)
     {
         string endPoint = null;
         string accessKey = null;
@@ -112,144 +112,144 @@ internal static class Program
         // If the following test is run against AWS, then the SDK throws
         // "Listening for bucket notification is specific only to `minio`
         // server endpoints".
-        // await FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
-        // functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient));
-        // functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient));
+        await FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
+        functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient));
 
-//         // Check if bucket exists
-//         functionalTestTasks.Add(FunctionalTest.BucketExists_Test(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.MakeBucket_Test5(minioClient));
+        // Check if bucket exists
+        functionalTestTasks.Add(FunctionalTest.BucketExists_Test(minioClient));
+        functionalTestTasks.Add(FunctionalTest.MakeBucket_Test5(minioClient));
 
-//         if (useAWS)
-//         {
-//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test2(minioClient, useAWS));
-//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test3(minioClient, useAWS));
-//             functionalTestTasks.Add(FunctionalTest.MakeBucket_Test4(minioClient, useAWS));
-//         }
+        if (useAWS)
+        {
+            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test2(minioClient, useAWS));
+            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test3(minioClient, useAWS));
+            functionalTestTasks.Add(FunctionalTest.MakeBucket_Test4(minioClient, useAWS));
+        }
 
-//         // Test removal of bucket
-//         functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test2(minioClient));
+        // Test removal of bucket
+        functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.RemoveBucket_Test2(minioClient));
 
-//         // Test ListBuckets function
-//         functionalTestTasks.Add(FunctionalTest.ListBuckets_Test(minioClient));
+        // Test ListBuckets function
+        functionalTestTasks.Add(FunctionalTest.ListBuckets_Test(minioClient));
 
-//         // Test Putobject function
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
+        // Test Putobject function
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
 
-//         // Test StatObject function
-//         functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));
+        // Test StatObject function
+        functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));
 
-//         // Test GetObjectAsync function
-//         functionalTestTasks.Add(FunctionalTest.GetObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.GetObject_Test2(minioClient));
-//         // 3 tests will run to check different values of offset and length parameters
-//         // when GetObject api returns part of the object as defined by the offset
-//         // and length parameters. Tests will be reported as GetObject_Test3,
-//         // GetObject_Test4 and GetObject_Test5.
-//         functionalTestTasks.Add(FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient));
+        // Test GetObjectAsync function
+        functionalTestTasks.Add(FunctionalTest.GetObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetObject_Test2(minioClient));
+        // 3 tests will run to check different values of offset and length parameters
+        // when GetObject api returns part of the object as defined by the offset
+        // and length parameters. Tests will be reported as GetObject_Test3,
+        // GetObject_Test4 and GetObject_Test5.
+        functionalTestTasks.Add(FunctionalTest.GetObject_3_OffsetLength_Tests(minioClient));
 
-// #if NET6_0_OR_GREATER
-//         // Test async callback function to download an object
-//         functionalTestTasks.Add(FunctionalTest.GetObject_AsyncCallback_Test1(minioClient));
-// #endif
+#if NET6_0_OR_GREATER
+        // Test async callback function to download an object
+        functionalTestTasks.Add(FunctionalTest.GetObject_AsyncCallback_Test1(minioClient));
+#endif
 
-//         // Test File GetObject and PutObject functions
-//         functionalTestTasks.Add(FunctionalTest.FGetObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.FPutObject_Test2(minioClient));
+        // Test File GetObject and PutObject functions
+        functionalTestTasks.Add(FunctionalTest.FGetObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.FPutObject_Test2(minioClient));
 
-//         // Test SelectObjectContentAsync function
-//         functionalTestTasks.Add(FunctionalTest.SelectObjectContent_Test(minioClient));
+        // Test SelectObjectContentAsync function
+        functionalTestTasks.Add(FunctionalTest.SelectObjectContent_Test(minioClient));
 
-//         // Test ListObjectAsync function
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test3(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test4(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
+        // Test ListObjectAsync function
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test4(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
 
-//         // Test RemoveObjectAsync function
-//         functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test3(minioClient));
+        // Test RemoveObjectAsync function
+        functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.RemoveObjects_Test3(minioClient));
 
-//         // Test CopyObjectAsync function
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test3(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test4(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test5(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test6(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test7(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.CopyObject_Test8(minioClient));
+        // Test CopyObjectAsync function
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test4(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test5(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test6(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test7(minioClient));
+        functionalTestTasks.Add(FunctionalTest.CopyObject_Test8(minioClient));
 
-//         // Test SetPolicyAsync function
-//         functionalTestTasks.Add(FunctionalTest.SetBucketPolicy_Test1(minioClient));
+        // Test SetPolicyAsync function
+        functionalTestTasks.Add(FunctionalTest.SetBucketPolicy_Test1(minioClient));
 
-//         // Test S3Zip function
-//         functionalTestTasks.Add(FunctionalTest.GetObjectS3Zip_Test1(minioClient));
+        // Test S3Zip function
+        functionalTestTasks.Add(FunctionalTest.GetObjectS3Zip_Test1(minioClient));
 
-//         // Test Presigned Get/Put operations
-//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test3(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
-//         // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
+        // Test Presigned Get/Put operations
+        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PresignedGetObject_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
+        // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
 
-//         // Test incomplete uploads
-//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test2(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test3(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.RemoveIncompleteUpload_Test(minioClient));
+        // Test incomplete uploads
+        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.RemoveIncompleteUpload_Test(minioClient));
 
-//         // Test GetBucket policy
-//         functionalTestTasks.Add(FunctionalTest.GetBucketPolicy_Test1(minioClient));
+        // Test GetBucket policy
+        functionalTestTasks.Add(FunctionalTest.GetBucketPolicy_Test1(minioClient));
 
-//         // Test object versioning
-//         functionalTestTasks.Add(FunctionalTest.ObjectVersioningAsync_Test1(minioClient));
+        // Test object versioning
+        functionalTestTasks.Add(FunctionalTest.ObjectVersioningAsync_Test1(minioClient));
 
-//         // Test Object Lock Configuration
-//         functionalTestTasks.Add(FunctionalTest.ObjectLockConfigurationAsync_Test1(minioClient));
+        // Test Object Lock Configuration
+        functionalTestTasks.Add(FunctionalTest.ObjectLockConfigurationAsync_Test1(minioClient));
 
-//         // Test Bucket, Object Tags
-//         functionalTestTasks.Add(FunctionalTest.BucketTagsAsync_Test1(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.ObjectTagsAsync_Test1(minioClient));
+        // Test Bucket, Object Tags
+        functionalTestTasks.Add(FunctionalTest.BucketTagsAsync_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ObjectTagsAsync_Test1(minioClient));
 
-//         // Test Bucket Lifecycle configuration
+        // Test Bucket Lifecycle configuration
         functionalTestTasks.Add(FunctionalTest.BucketLifecycleAsync_Test1(minioClient));
         functionalTestTasks.Add(FunctionalTest.BucketLifecycleAsync_Test2(minioClient));
 
-//         // Test encryption
-//         if (isSecure)
-//         {
-// #pragma warning disable MA0039 // Do not write your own certificate validation method
-//             ServicePointManager.ServerCertificateValidationCallback +=
-//                 (sender, certificate, chain, sslPolicyErrors) => true;
-// #pragma warning restore MA0039 // Do not write your own certificate validation method
+        // Test encryption
+        if (isSecure)
+        {
+#pragma warning disable MA0039 // Do not write your own certificate validation method
+            ServicePointManager.ServerCertificateValidationCallback +=
+                (sender, certificate, chain, sslPolicyErrors) => true;
+#pragma warning restore MA0039 // Do not write your own certificate validation method
 
-//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test1(minioClient));
-//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test2(minioClient));
+            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test1(minioClient));
+            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test2(minioClient));
 
-//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test1(minioClient));
-//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test2(minioClient));
-//         }
+            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test1(minioClient));
+            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test2(minioClient));
+        }
 
-//         if (kmsEnabled is not null && string.Equals(kmsEnabled, "1", StringComparison.OrdinalIgnoreCase))
-//         {
-//             functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test3(minioClient));
-//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test3(minioClient));
-//             functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
-//         }
+        if (kmsEnabled is not null && string.Equals(kmsEnabled, "1", StringComparison.OrdinalIgnoreCase))
+        {
+            functionalTestTasks.Add(FunctionalTest.PutGetStatEncryptedObject_Test3(minioClient));
+            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test3(minioClient));
+            functionalTestTasks.Add(FunctionalTest.EncryptedCopyObject_Test4(minioClient));
+        }
 
         await functionalTestTasks.ForEachAsync().ConfigureAwait(false);
     }

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -78,12 +78,20 @@ public partial class MinioClient : IBucketOperations
                 await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
+            if (response.Exception is not null &&
+                response.Exception.GetType() == typeof(BucketNotFoundException))
+            {
+                    return false;
+            }
         }
         catch (InternalClientException ice)
         {
-            if ((ice.ServerResponse is not null && HttpStatusCode.NotFound.Equals(ice.ServerResponse.StatusCode))
-                || ice.ServerResponse is null)
+            if ((ice.ServerResponse is not null &&
+                HttpStatusCode.NotFound.Equals(ice.ServerResponse.StatusCode)) ||
+                ice.ServerResponse is null)
+            {
                 return false;
+            }
         }
         catch (Exception ex)
         {

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -76,22 +76,17 @@ public partial class MinioClient : IBucketOperations
             var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
             using var response =
                 await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
             if (response.Exception is not null &&
                 response.Exception.GetType() == typeof(BucketNotFoundException))
-            {
-                    return false;
-            }
+                return false;
         }
         catch (InternalClientException ice)
         {
             if ((ice.ServerResponse is not null &&
-                HttpStatusCode.NotFound.Equals(ice.ServerResponse.StatusCode)) ||
+                 HttpStatusCode.NotFound.Equals(ice.ServerResponse.StatusCode)) ||
                 ice.ServerResponse is null)
-            {
                 return false;
-            }
         }
         catch (Exception ex)
         {

--- a/Minio/DataModel/ILM/Duration.cs
+++ b/Minio/DataModel/ILM/Duration.cs
@@ -15,7 +15,6 @@
  */
 
 using System.Xml.Serialization;
-using Minio.Helper;
 
 namespace Minio.DataModel.ILM;
 
@@ -30,8 +29,7 @@ public abstract class Duration
 
     protected Duration(DateTime date)
     {
-        date = new DateTime(date.Year, date.Month, date.Day, 0, 0, 0);
-        Date = Utils.To8601String(date);
+        Date = date.AddDays(1).AddSeconds(-1).ToUniversalTime().Date.ToString("o");
     }
 
     protected Duration(double days)

--- a/Minio/DataModel/ILM/Duration.cs
+++ b/Minio/DataModel/ILM/Duration.cs
@@ -23,13 +23,14 @@ public abstract class Duration
 {
     protected Duration()
     {
-        Date = null;
+        ExpiryDate = null;
         Days = null;
     }
 
     protected Duration(DateTime date)
     {
-        Date = date.AddDays(1).AddSeconds(-1).ToUniversalTime().Date.ToString("o");
+        ExpiryDate = date.ToUniversalTime().Date.ToString("o")
+                     ?? date.AddDays(1).AddSeconds(-1).ToUniversalTime().Date.ToString("o");
     }
 
     protected Duration(double days)
@@ -38,7 +39,7 @@ public abstract class Duration
     }
 
     [XmlElement(ElementName = "Date", IsNullable = true)]
-    public string Date { get; set; }
+    public string ExpiryDate { get; set; }
 
     [XmlElement(ElementName = "Days", IsNullable = true)]
     public double? Days { get; set; }

--- a/Minio/DataModel/ILM/LifecycleConfiguration.cs
+++ b/Minio/DataModel/ILM/LifecycleConfiguration.cs
@@ -39,7 +39,7 @@ public class LifecycleConfiguration
 
     public LifecycleConfiguration(IList<LifecycleRule> rules)
     {
-        if (rules is null || rules.Count <= 0)
+        if (rules is null || rules.Count == 0)
             throw new ArgumentNullException(nameof(rules),
                 "Rules object cannot be empty. A finite set of Lifecycle Rules are needed for LifecycleConfiguration.");
 
@@ -73,7 +73,7 @@ public class LifecycleConfiguration
         catch (Exception ex)
         {
             Console.WriteLine(ex.ToString());
-            // throw ex;
+            throw;
         }
         finally
         {

--- a/Minio/DataModel/Result/ResponseResult.cs
+++ b/Minio/DataModel/Result/ResponseResult.cs
@@ -40,7 +40,7 @@ public sealed class ResponseResult : IDisposable
         Exception = exception;
     }
 
-    public Exception Exception { get; set;}
+    public Exception Exception { get; set; }
     public HttpRequestMessage Request { get; }
     public HttpResponseMessage Response { get; }
 

--- a/Minio/DataModel/Result/ResponseResult.cs
+++ b/Minio/DataModel/Result/ResponseResult.cs
@@ -40,7 +40,7 @@ public sealed class ResponseResult : IDisposable
         Exception = exception;
     }
 
-    private Exception Exception { get; }
+    public Exception Exception { get; set;}
     public HttpRequestMessage Request { get; }
     public HttpResponseMessage Response { get; }
 

--- a/Minio/Helper/OperationsHelper.cs
+++ b/Minio/Helper/OperationsHelper.cs
@@ -110,8 +110,7 @@ public partial class MinioClient : IMinioClient
         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
         using var response =
             await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
-                    cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
+                cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/Minio/MinioClientExtensions.cs
+++ b/Minio/MinioClientExtensions.cs
@@ -50,7 +50,6 @@ public static class MinioClientExtensions
     {
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
 
-        minioClient.Config.BaseUrl = endpoint;
         minioClient.Config.Endpoint = endpoint;
         minioClient.SetBaseURL(GetBaseUrl(endpoint));
         return minioClient;
@@ -64,8 +63,10 @@ public static class MinioClientExtensions
             throw new ArgumentException(
                 string.Format(CultureInfo.InvariantCulture, "Port {0} is not a number between 1 and 65535", port),
                 nameof(port));
+        endpoint = endpoint + ":" + port.ToString(CultureInfo.InvariantCulture);
         minioClient.Config.Endpoint = endpoint;
-        return minioClient.WithEndpoint(endpoint + ":" + port);
+        minioClient.SetBaseURL(GetBaseUrl(endpoint));
+        return minioClient;
     }
 
     public static IMinioClient WithEndpoint(this IMinioClient minioClient, Uri url)
@@ -73,9 +74,10 @@ public static class MinioClientExtensions
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
 
         if (url is null) throw new ArgumentNullException(nameof(url));
+        minioClient.SetBaseURL(url);
         minioClient.Config.Endpoint = url.AbsoluteUri;
 
-        return minioClient.WithEndpoint(url.AbsoluteUri);
+        return minioClient;
     }
 
     public static IMinioClient WithRegion(this IMinioClient minioClient, string region)
@@ -95,7 +97,7 @@ public static class MinioClientExtensions
     {
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
         // Set region to its default value if empty or null
-        minioClient.Config.Region = "us-east-1";
+        minioClient.Config.Region ??= "us-east-1";
         return minioClient;
     }
 

--- a/Minio/MinioClientExtensions.cs
+++ b/Minio/MinioClientExtensions.cs
@@ -51,6 +51,7 @@ public static class MinioClientExtensions
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
 
         minioClient.Config.BaseUrl = endpoint;
+        minioClient.Config.Endpoint = endpoint;
         minioClient.SetBaseURL(GetBaseUrl(endpoint));
         return minioClient;
     }
@@ -63,6 +64,7 @@ public static class MinioClientExtensions
             throw new ArgumentException(
                 string.Format(CultureInfo.InvariantCulture, "Port {0} is not a number between 1 and 65535", port),
                 nameof(port));
+        minioClient.Config.Endpoint = endpoint;
         return minioClient.WithEndpoint(endpoint + ":" + port);
     }
 
@@ -71,6 +73,7 @@ public static class MinioClientExtensions
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
 
         if (url is null) throw new ArgumentNullException(nameof(url));
+        minioClient.Config.Endpoint = url.AbsoluteUri;
 
         return minioClient.WithEndpoint(url.AbsoluteUri);
     }
@@ -120,15 +123,7 @@ public static class MinioClientExtensions
     public static IMinioClient WithSSL(this IMinioClient minioClient, bool secure = true)
     {
         if (minioClient is null) throw new ArgumentNullException(nameof(minioClient));
-
-        if (secure)
-        {
-            minioClient.Config.Secure = true;
-            if (string.IsNullOrEmpty(minioClient.Config.BaseUrl))
-                return minioClient;
-            //var secureUrl = RequestUtil.MakeTargetURL(minioClient.BaseUrl, minioClient.Secure);
-        }
-
+        minioClient.Config.Secure = secure;
         return minioClient;
     }
 

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Net.Http.Headers;
-using Microsoft.Win32;
 using Minio.Credentials;
 using Minio.DataModel;
 using Minio.DataModel.Args;
@@ -62,7 +60,7 @@ public static class RequestExtensions
                 cancellationToken = timeoutTokenSource.Token;
             }
 
-             responseResult = minioClient.ExecuteWithRetry(
+            responseResult = minioClient.ExecuteWithRetry(
                 async () => await minioClient.ExecuteTaskCoreAsync(errorHandlers, requestMessageBuilder,
                     isSts, cancellationToken).ConfigureAwait(false));
         }


### PR DESCRIPTION
Fixes the functional tests, part of the CI and merge process, failures.

The following issues are addressed :
 - The life cycle expiration date is supposed to be replaced to the next day's midnight before the request is sent to the s3 server and the existing code was not doing it.
 - WithSSl(secure=false) is ignored
 - 3 versions of WithEndpoint() methods set endpoint either incorrectly and/or they were inconsistent
 - BucketExistsAsync method exception handling and responseResult interpretation were not correct.