### PR TITLE
Fix Prefix property and init of Tags collection in AndOperator (#782)

### DIFF
--- a/Minio/DataModel/ILM/AndOperator.cs
+++ b/Minio/DataModel/ILM/AndOperator.cs
@@ -54,8 +54,7 @@ public class AndOperator
             Tags.Add(new Tag(item.Key, item.Value));
     }
 
-    [XmlElement("Prefix")]
-    public string Prefix { get; set; }
+    [XmlElement("Prefix")] public string Prefix { get; set; }
 
     [XmlElement(ElementName = "Tag", IsNullable = false)]
     public Collection<Tag> Tags { get; set; }

--- a/Minio/DataModel/ILM/AndOperator.cs
+++ b/Minio/DataModel/ILM/AndOperator.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,7 +38,8 @@ public class AndOperator
     public AndOperator(string prefix, IList<Tag> tag)
     {
         Prefix = prefix;
-        if (tag?.Count > 0) Tags = new Collection<Tag>(tag);
+        if (tag?.Count > 0)
+            Tags = new Collection<Tag>(tag);
     }
 
     public AndOperator(string prefix, IDictionary<string, string> tags)
@@ -46,10 +47,15 @@ public class AndOperator
         Prefix = prefix;
         if (tags is null || tags.Count == 0)
             return;
-        foreach (var item in tags) Tags.Add(new Tag(item.Key, item.Value));
+
+        Tags = new Collection<Tag>();
+
+        foreach (var item in tags)
+            Tags.Add(new Tag(item.Key, item.Value));
     }
 
-    [XmlElement("Prefix")] internal string Prefix { get; set; }
+    [XmlElement("Prefix")]
+    public string Prefix { get; set; }
 
     [XmlElement(ElementName = "Tag", IsNullable = false)]
     public Collection<Tag> Tags { get; set; }


### PR DESCRIPTION
minio-dotnet DON'T generate the xml node `<Prefix/>` inside the <And> node because of `Prefix` property is marked as `internal` instead of `public`.
Resolve also missing initialization of `Tag` property when using the constructor with `IDictionary<string, string>` object for tags