### PR TITLE
versioning configuration XML representation fix based on pr 747

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -378,4 +378,4 @@ dotnet_separate_import_directive_groups = false
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
 
 MA0051.maximum_lines_per_method = 150
-MA0051.maximum_statements_per_method = 60
+MA0051.maximum_statements_per_method = 70

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -593,7 +593,8 @@ public static class FunctionalTest
         try
         {
             var versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
-                .WithBucket(bucketName)).ConfigureAwait(false);
+                .WithBucket(bucketName)
+                .WithVersions(true)).ConfigureAwait(false);
             if (versioningConfig is not null &&
                 (versioningConfig.Status.Contains("Enabled", StringComparison.Ordinal) ||
                  versioningConfig.Status.Contains("Suspended", StringComparison.Ordinal)))
@@ -2216,18 +2217,18 @@ public static class FunctionalTest
         }
         catch (NotImplementedException ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             return;
         }
         catch (Exception ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.FAIL, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             throw;
         }
 
@@ -2246,16 +2247,17 @@ public static class FunctionalTest
         catch (NotImplementedException ex)
         {
             setLockNotImplemented = true;
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
         }
         catch (Exception ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.FAIL, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             throw;
         }
 
@@ -2276,6 +2278,7 @@ public static class FunctionalTest
         }
         catch (NotImplementedException ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             getLockNotImplemented = true;
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), getObjectLockConfigurationSignature,
                 "Tests whether GetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
@@ -2329,7 +2332,6 @@ public static class FunctionalTest
         }
         finally
         {
-            await Task.Delay(1500).ConfigureAwait(false);
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
@@ -2734,7 +2736,6 @@ public static class FunctionalTest
                 listenBucketNotificationsSignature,
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -2743,7 +2744,6 @@ public static class FunctionalTest
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -2775,9 +2775,12 @@ public static class FunctionalTest
                     "Tests whether ListenBucketNotifications passes for small object",
                     TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                     ex.ToString(), args: args).Log();
-                await TearDown(minio, bucketName).ConfigureAwait(false);
                 throw;
             }
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
 

--- a/Minio/Credentials/AssumeRoleResponse.cs
+++ b/Minio/Credentials/AssumeRoleResponse.cs
@@ -21,7 +21,7 @@ using System.Xml.Serialization;
 namespace Minio.Credentials;
 
 [Serializable]
-[XmlRoot(ElementName = "AssumeRoleResponse", Namespace = "https://sts.amazonaws.com/doc/2011-06-15/")]
+[XmlRoot(ElementName = "AssumeRoleResponse", Namespace = "http://s3.amazonaws.com/doc/2006-03-01/")]
 public class AssumeRoleResponse
 {
     [XmlElement(ElementName = "AssumeRoleResult")]
@@ -33,7 +33,7 @@ public class AssumeRoleResponse
         using var ms = new MemoryStream();
         using var xmlWriter = XmlWriter.Create(ms, settings);
         var names = new XmlSerializerNamespaces();
-        names.Add(string.Empty, "https://sts.amazonaws.com/doc/2011-06-15/");
+        names.Add(string.Empty, "http://s3.amazonaws.com/doc/2006-03-01/");
 
         var cs = new XmlSerializer(typeof(AssumeRoleResponse));
         cs.Serialize(xmlWriter, this, names);

--- a/Minio/Credentials/AssumeRoleResponse.cs
+++ b/Minio/Credentials/AssumeRoleResponse.cs
@@ -35,7 +35,7 @@ public class AssumeRoleResponse
         var names = new XmlSerializerNamespaces();
         names.Add(string.Empty, "https://sts.amazonaws.com/doc/2011-06-15/");
 
-        var cs = new XmlSerializer(typeof(CertificateResponse));
+        var cs = new XmlSerializer(typeof(AssumeRoleResponse));
         cs.Serialize(xmlWriter, this, names);
 
         ms.Flush();

--- a/Minio/DataModel/Args/GetVersioningArgs.cs
+++ b/Minio/DataModel/Args/GetVersioningArgs.cs
@@ -23,6 +23,14 @@ public class GetVersioningArgs : BucketArgs<GetVersioningArgs>
         RequestMethod = HttpMethod.Get;
     }
 
+    internal bool Versions { get; private set; }
+
+    public GetVersioningArgs WithVersions(bool ver)
+    {
+        Versions = ver;
+        return this;
+    }
+
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         requestMessageBuilder.AddQueryParameter("versioning", "");

--- a/Minio/DataModel/ObjectLock/ObjectLockConfiguration.cs
+++ b/Minio/DataModel/ObjectLock/ObjectLockConfiguration.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Minio.DataModel.ObjectLock;
@@ -38,4 +39,21 @@ public class ObjectLockConfiguration
     [XmlElement("ObjectLockEnabled")] public string ObjectLockEnabled { get; set; }
 
     [XmlElement("Rule")] public ObjectLockRule Rule { get; set; }
+
+    public string ToXML()
+    {
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true };
+        using var ms = new MemoryStream();
+        using var xmlWriter = XmlWriter.Create(ms, settings);
+        var names = new XmlSerializerNamespaces();
+        names.Add(string.Empty, "http://s3.amazonaws.com/doc/2006-03-01/");
+
+        var cs = new XmlSerializer(typeof(ObjectLockConfiguration));
+        cs.Serialize(xmlWriter, this, names);
+
+        ms.Flush();
+        _ = ms.Seek(0, SeekOrigin.Begin);
+        using var streamReader = new StreamReader(ms);
+        return streamReader.ReadToEnd();
+    }
 }

--- a/Minio/DataModel/Response/GetVersioningResponse.cs
+++ b/Minio/DataModel/Response/GetVersioningResponse.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Net;
-using System.Text;
-using CommunityToolkit.HighPerformance;
 using Minio.Helper;
 
 namespace Minio.DataModel.Response;
@@ -30,8 +28,7 @@ internal class GetVersioningResponse : GenericResponse
             !HttpStatusCode.OK.Equals(statusCode))
             return;
 
-        using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();
-        VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(stream);
+        VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(responseContent);
     }
 
     internal VersioningConfiguration VersioningConfig { get; set; }

--- a/Minio/DataModel/VersioningConfiguration.cs
+++ b/Minio/DataModel/VersioningConfiguration.cs
@@ -19,7 +19,7 @@ using System.Xml.Serialization;
 namespace Minio.DataModel;
 
 [Serializable]
-[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "http://s3.amazonaws.com/doc/2006-03-01/")]
+[XmlRoot(ElementName = "VersioningConfiguration")]
 public class VersioningConfiguration
 {
     public VersioningConfiguration()

--- a/Minio/DataModel/VersioningConfiguration.cs
+++ b/Minio/DataModel/VersioningConfiguration.cs
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Minio.DataModel;
 
 [Serializable]
-[XmlRoot(ElementName = "VersioningConfiguration")]
+[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "https://s3.amazonaws.com/doc/2011-06-15/")]
 public class VersioningConfiguration
 {
     public VersioningConfiguration()
@@ -30,10 +31,7 @@ public class VersioningConfiguration
 
     public VersioningConfiguration(bool enableVersioning = true)
     {
-        if (enableVersioning)
-            Status = "Enabled";
-        else
-            Status = "Suspended";
+        Status = enableVersioning ? "Enabled" : "Suspended";
     }
 
     public VersioningConfiguration(VersioningConfiguration vc)
@@ -44,7 +42,26 @@ public class VersioningConfiguration
         MfaDelete = vc.MfaDelete;
     }
 
-    [XmlElement] public string Status { get; set; }
+    [XmlElement(ElementName = "Status")]
+    public string Status { get; set; }
 
+    [XmlElement(ElementName = "MfaDelete")]
     public string MfaDelete { get; set; }
+
+    public string ToXML()
+    {
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true };
+        using var ms = new MemoryStream();
+        using var xmlWriter = XmlWriter.Create(ms, settings);
+        var names = new XmlSerializerNamespaces();
+        names.Add(string.Empty, "https://sts.amazonaws.com/doc/2011-06-15/");
+
+        var cs = new XmlSerializer(typeof(VersioningConfiguration));
+        cs.Serialize(xmlWriter, this, names);
+
+        ms.Flush();
+        _ = ms.Seek(0, SeekOrigin.Begin);
+        using var streamReader = new StreamReader(ms);
+        return streamReader.ReadToEnd();
+    }
 }

--- a/Minio/DataModel/VersioningConfiguration.cs
+++ b/Minio/DataModel/VersioningConfiguration.cs
@@ -21,7 +21,6 @@ namespace Minio.DataModel;
 
 [Serializable]
 [XmlRoot(ElementName = "VersioningConfiguration", Namespace = "http://s3.amazonaws.com/doc/2006-03-01/")]
-
 public class VersioningConfiguration
 {
     public VersioningConfiguration()

--- a/Minio/DataModel/VersioningConfiguration.cs
+++ b/Minio/DataModel/VersioningConfiguration.cs
@@ -20,7 +20,7 @@ using System.Xml.Serialization;
 namespace Minio.DataModel;
 
 [Serializable]
-[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "https://s3.amazonaws.com/doc/2011-06-15/")]
+[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "https://sts.amazonaws.com/doc/2011-06-15/")]
 public class VersioningConfiguration
 {
     public VersioningConfiguration()
@@ -42,8 +42,7 @@ public class VersioningConfiguration
         MfaDelete = vc.MfaDelete;
     }
 
-    [XmlElement(ElementName = "Status")]
-    public string Status { get; set; }
+    [XmlElement(ElementName = "Status")] public string Status { get; set; }
 
     [XmlElement(ElementName = "MfaDelete")]
     public string MfaDelete { get; set; }

--- a/Minio/DataModel/VersioningConfiguration.cs
+++ b/Minio/DataModel/VersioningConfiguration.cs
@@ -20,7 +20,8 @@ using System.Xml.Serialization;
 namespace Minio.DataModel;
 
 [Serializable]
-[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "https://sts.amazonaws.com/doc/2011-06-15/")]
+[XmlRoot(ElementName = "VersioningConfiguration", Namespace = "http://s3.amazonaws.com/doc/2006-03-01/")]
+
 public class VersioningConfiguration
 {
     public VersioningConfiguration()
@@ -53,7 +54,7 @@ public class VersioningConfiguration
         using var ms = new MemoryStream();
         using var xmlWriter = XmlWriter.Create(ms, settings);
         var names = new XmlSerializerNamespaces();
-        names.Add(string.Empty, "https://sts.amazonaws.com/doc/2011-06-15/");
+        names.Add(string.Empty, "http://s3.amazonaws.com/doc/2006-03-01/");
 
         var cs = new XmlSerializer(typeof(VersioningConfiguration));
         cs.Serialize(xmlWriter, this, names);

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -1078,10 +1078,9 @@ public static class Utils
 
     private static string GetNamespace<T>()
     {
-        if (typeof(T).GetCustomAttributes(typeof(XmlRootAttribute), true)
-                .FirstOrDefault() is XmlRootAttribute xmlRootAttribute)
-            return xmlRootAttribute.Namespace;
-
-        return null;
+        return typeof(T).GetCustomAttributes(typeof(XmlRootAttribute), true)
+            .FirstOrDefault() is XmlRootAttribute xmlRootAttribute
+            ? xmlRootAttribute.Namespace
+            : null;
     }
 }


### PR DESCRIPTION
This PR is created based on @voltuha's PR #747.
The issue was the missing and incorrect name space in XML element definitions for `VersioningConfiguration` class .