### PR TITLE
downgrades analyzers to address compiler version conflict temporarily

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -69,11 +69,11 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Roslynator.Analyzers" Version="4.6.4">
+        <PackageReference Include="Roslynator.Analyzers" Version="4.6.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.6.4">
+        <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.6.2">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>


### PR DESCRIPTION
This PR is to temporarily address the compiler mismatch issue the latest Roslynator analyzer version upgrade  caused by simply downgrading those 2 analyzer packages.
```
CSC : error CS9057: The analyzer assembly '.../.nuget/packages/roslynator.analyzers/4.6.4/analyzers/dotnet/cs/Roslynator.CSharp.Analyzers.dll' references version '4.6.0.0' of the compiler, which is newer than the currently running version '4.4.0.0'. [.../ersan/work/src/github.com/minio/minio-dotnet/Minio/Minio.csproj::TargetFramework=net6.0]
CSC : error CS9057: The analyzer assembly '.../.nuget/packages/roslynator.formatting.analyzers/4.6.4/analyzers/dotnet/cs/Roslynator.Formatting.Analyzers.dll' references version '4.6.0.0' of the compiler, which is newer than the currently running version '4.4.0.0'. [.../work/src/github.com/minio/minio-dotnet/Minio/Minio.csproj::TargetFramework=net6.0]
```