### PR TITLE
fixes incorrect versioning & lock config XML settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -378,4 +378,4 @@ dotnet_separate_import_directive_groups = false
 dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
 
 MA0051.maximum_lines_per_method = 150
-MA0051.maximum_statements_per_method = 60
+MA0051.maximum_statements_per_method = 70

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -592,8 +592,10 @@ public static class FunctionalTest
         ObjectLockConfiguration lockConfig = null;
         try
         {
-            var versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
-                .WithBucket(bucketName)).ConfigureAwait(false);
+            VersioningConfiguration versioningConfig = null;
+            versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
+                .WithBucket(bucketName)
+                .WithVersions(true)).ConfigureAwait(false);
             if (versioningConfig is not null &&
                 (versioningConfig.Status.Contains("Enabled", StringComparison.Ordinal) ||
                  versioningConfig.Status.Contains("Suspended", StringComparison.Ordinal)))
@@ -2216,18 +2218,18 @@ public static class FunctionalTest
         }
         catch (NotImplementedException ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             return;
         }
         catch (Exception ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.FAIL, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             throw;
         }
 
@@ -2246,16 +2248,17 @@ public static class FunctionalTest
         catch (NotImplementedException ex)
         {
             setLockNotImplemented = true;
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
         }
         catch (Exception ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), setObjectLockConfigurationSignature,
                 "Tests whether SetObjectLockConfigurationAsync passes", TestStatus.FAIL, DateTime.Now - startTime,
                 ex.Message, ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
             throw;
         }
 
@@ -2276,6 +2279,7 @@ public static class FunctionalTest
         }
         catch (NotImplementedException ex)
         {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
             getLockNotImplemented = true;
             new MintLogger(nameof(ObjectLockConfigurationAsync_Test1), getObjectLockConfigurationSignature,
                 "Tests whether GetObjectLockConfigurationAsync passes", TestStatus.NA, DateTime.Now - startTime,
@@ -2329,7 +2333,6 @@ public static class FunctionalTest
         }
         finally
         {
-            await Task.Delay(1500).ConfigureAwait(false);
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
@@ -2734,7 +2737,6 @@ public static class FunctionalTest
                 listenBucketNotificationsSignature,
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (NotImplementedException ex)
         {
@@ -2743,7 +2745,6 @@ public static class FunctionalTest
                 "Tests whether ListenBucketNotifications passes for small object",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();
-            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
         catch (Exception ex)
         {
@@ -2775,9 +2776,12 @@ public static class FunctionalTest
                     "Tests whether ListenBucketNotifications passes for small object",
                     TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                     ex.ToString(), args: args).Log();
-                await TearDown(minio, bucketName).ConfigureAwait(false);
                 throw;
             }
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
 

--- a/Minio/Credentials/AssumeRoleResponse.cs
+++ b/Minio/Credentials/AssumeRoleResponse.cs
@@ -21,7 +21,7 @@ using System.Xml.Serialization;
 namespace Minio.Credentials;
 
 [Serializable]
-[XmlRoot(ElementName = "AssumeRoleResponse", Namespace = "https://sts.amazonaws.com/doc/2011-06-15/")]
+[XmlRoot(ElementName = "AssumeRoleResponse", Namespace = "http://s3.amazonaws.com/doc/2006-03-01/")]
 public class AssumeRoleResponse
 {
     [XmlElement(ElementName = "AssumeRoleResult")]
@@ -33,9 +33,9 @@ public class AssumeRoleResponse
         using var ms = new MemoryStream();
         using var xmlWriter = XmlWriter.Create(ms, settings);
         var names = new XmlSerializerNamespaces();
-        names.Add(string.Empty, "https://sts.amazonaws.com/doc/2011-06-15/");
+        names.Add(string.Empty, "http://s3.amazonaws.com/doc/2006-03-01/");
 
-        var cs = new XmlSerializer(typeof(CertificateResponse));
+        var cs = new XmlSerializer(typeof(AssumeRoleResponse));
         cs.Serialize(xmlWriter, this, names);
 
         ms.Flush();

--- a/Minio/DataModel/Args/GetVersioningArgs.cs
+++ b/Minio/DataModel/Args/GetVersioningArgs.cs
@@ -23,6 +23,14 @@ public class GetVersioningArgs : BucketArgs<GetVersioningArgs>
         RequestMethod = HttpMethod.Get;
     }
 
+    internal bool Versions { get; private set; }
+
+    public GetVersioningArgs WithVersions(bool ver)
+    {
+        Versions = ver;
+        return this;
+    }
+
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
     {
         requestMessageBuilder.AddQueryParameter("versioning", "");

--- a/Minio/DataModel/ObjectLock/ObjectLockConfiguration.cs
+++ b/Minio/DataModel/ObjectLock/ObjectLockConfiguration.cs
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+using System.Xml;
 using System.Xml.Serialization;
 
 namespace Minio.DataModel.ObjectLock;
@@ -38,4 +39,21 @@ public class ObjectLockConfiguration
     [XmlElement("ObjectLockEnabled")] public string ObjectLockEnabled { get; set; }
 
     [XmlElement("Rule")] public ObjectLockRule Rule { get; set; }
+
+    public string ToXML()
+    {
+        var settings = new XmlWriterSettings { OmitXmlDeclaration = true };
+        using var ms = new MemoryStream();
+        using var xmlWriter = XmlWriter.Create(ms, settings);
+        var names = new XmlSerializerNamespaces();
+        names.Add(string.Empty, "http://s3.amazonaws.com/doc/2006-03-01/");
+
+        var cs = new XmlSerializer(typeof(ObjectLockConfiguration));
+        cs.Serialize(xmlWriter, this, names);
+
+        ms.Flush();
+        _ = ms.Seek(0, SeekOrigin.Begin);
+        using var streamReader = new StreamReader(ms);
+        return streamReader.ReadToEnd();
+    }
 }

--- a/Minio/DataModel/Response/GetVersioningResponse.cs
+++ b/Minio/DataModel/Response/GetVersioningResponse.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Net;
-using System.Text;
-using CommunityToolkit.HighPerformance;
 using Minio.Helper;
 
 namespace Minio.DataModel.Response;
@@ -30,8 +28,7 @@ internal class GetVersioningResponse : GenericResponse
             !HttpStatusCode.OK.Equals(statusCode))
             return;
 
-        using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();
-        VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(stream);
+        VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(responseContent);
     }
 
     internal VersioningConfiguration VersioningConfig { get; set; }

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -1065,21 +1065,14 @@ public static class Utils
         using var stringReader = new StringReader(xml);
         using var xmlReader = XmlReader.Create(stringReader, settings);
 
-        try
-        {
-            var serializer = new XmlSerializer(typeof(T));
-            return (T)serializer.Deserialize(xmlReader);
-        }
-        catch
-        {
-            throw;
-        }
+        var serializer = new XmlSerializer(typeof(T));
+        return (T)serializer.Deserialize(xmlReader);
     }
 
     private static string GetNamespace<T>()
     {
         return typeof(T).GetCustomAttributes(typeof(XmlRootAttribute), true)
-                .FirstOrDefault() is XmlRootAttribute xmlRootAttribute
+            .FirstOrDefault() is XmlRootAttribute xmlRootAttribute
             ? xmlRootAttribute.Namespace
             : null;
     }

--- a/Minio/Helper/Utils.cs
+++ b/Minio/Helper/Utils.cs
@@ -1070,18 +1070,17 @@ public static class Utils
             var serializer = new XmlSerializer(typeof(T));
             return (T)serializer.Deserialize(xmlReader);
         }
-        catch (InvalidOperationException)
+        catch
         {
-            return default;
+            throw;
         }
     }
 
     private static string GetNamespace<T>()
     {
-        if (typeof(T).GetCustomAttributes(typeof(XmlRootAttribute), true)
-                .FirstOrDefault() is XmlRootAttribute xmlRootAttribute)
-            return xmlRootAttribute.Namespace;
-
-        return null;
+        return typeof(T).GetCustomAttributes(typeof(XmlRootAttribute), true)
+                .FirstOrDefault() is XmlRootAttribute xmlRootAttribute
+            ? xmlRootAttribute.Namespace
+            : null;
     }
 }


### PR DESCRIPTION
This PR is created based on @voltuha's PR https://github.com/minio/minio-dotnet/pull/747.
The issue was the missing and incorrect name space and elements in the XML element definitions for `VersioningConfiguration` class. It also addresses a couple of issues in `AssumeRoleResponse` and in `ObjectLockConfiguration`.