### PR TITLE
adds build required OSPlatform calls

### DIFF
--- a/FileUploader/FileUpload.cs
+++ b/FileUploader/FileUpload.cs
@@ -32,7 +32,8 @@ public static class FileUpload
 {
     private static bool IsWindows()
     {
-        return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+        return System.OSPlatform.Windows;
+
     }
 
     private static async Task Main(string[] args)

--- a/FileUploader/FileUpload.cs
+++ b/FileUploader/FileUpload.cs
@@ -15,7 +15,6 @@
  */
 
 using System.Net;
-using System.Runtime.InteropServices;
 using Minio;
 using Minio.DataModel.Args;
 
@@ -32,8 +31,7 @@ public static class FileUpload
 {
     private static bool IsWindows()
     {
-        return System.OSPlatform.Windows;
-
+        return OperatingSystem.IsWindows();
     }
 
     private static async Task Main(string[] args)

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -17,7 +17,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using Minio.DataModel;
@@ -282,7 +281,6 @@ public static class Program
         File.Delete(smallFileName);
         File.Delete(bigFileName);
 
-        if (System.OSPlatform.Windows;) _ = Console.ReadLine();
-
+        if (OperatingSystem.IsWindows()) _ = Console.ReadLine();
     }
 }

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -282,6 +282,7 @@ public static class Program
         File.Delete(smallFileName);
         File.Delete(bigFileName);
 
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) _ = Console.ReadLine();
+        if (System.OSPlatform.Windows;) _ = Console.ReadLine();
+
     }
 }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -4826,7 +4826,7 @@ public static class FunctionalTest
                     {
                         expectedFileSize = objectSize - offsetToStartFrom;
                         var noOfCtrlChars = 1;
-                        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) noOfCtrlChars = 2;
+                        if (System.OSPlatform.Windows) noOfCtrlChars = 2;
 
                         expectedContent = string.Concat(line)
                             .Substring(offsetToStartFrom, expectedFileSize - noOfCtrlChars);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -20,7 +20,6 @@ using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
-using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
@@ -4817,7 +4816,10 @@ public static class FunctionalTest
 #else
                 await File.WriteAllLinesAsync(tempSource, line).ConfigureAwait(false);
 #endif
-                using (var filestream = File.Open(tempSource, FileMode.Open, FileAccess.Read, FileShare.Read))
+                FileStream filestream = null;
+                await
+                    using ((filestream = File.Open(tempSource, FileMode.Open, FileAccess.Read, FileShare.Read))
+                           .ConfigureAwait(false))
                 {
                     var objectSize = (int)filestream.Length;
                     var expectedFileSize = lengthToBeRead;
@@ -4826,7 +4828,7 @@ public static class FunctionalTest
                     {
                         expectedFileSize = objectSize - offsetToStartFrom;
                         var noOfCtrlChars = 1;
-                        if (System.OSPlatform.Windows) noOfCtrlChars = 2;
+                        if (OperatingSystem.IsWindows()) noOfCtrlChars = 2;
 
                         expectedContent = string.Concat(line)
                             .Substring(offsetToStartFrom, expectedFileSize - noOfCtrlChars);


### PR DESCRIPTION
This PR fixes the offending `RuntimeInformation.IsOSPlatform(OSPlatform.Windows)` calls as shown in the build logs below:
```
Error: /home/runner/work/minio-dotnet/minio-dotnet/FileUploader/FileUpload.cs(35,16): error MA0144: Use System.OperatingSystem to check the current OS (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md) [/home/runner/work/minio-dotnet/minio-dotnet/FileUploader/FileUploader.csproj]
Error: /home/runner/work/minio-dotnet/minio-dotnet/Minio.Functional.Tests/FunctionalTest.cs(4833,29): error MA0144: Use System.OperatingSystem to check the current OS (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md) [/home/runner/work/minio-dotnet/minio-dotnet/Minio.Functional.Tests/Minio.Functional.Tests.csproj::TargetFramework=net6.0]
Error: /home/runner/work/minio-dotnet/minio-dotnet/Minio.Examples/Program.cs(285,13): error MA0144: Use System.OperatingSystem to check the current OS (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md) [/home/runner/work/minio-dotnet/minio-dotnet/Minio.Examples/Minio.Examples.csproj]
  Minio.Tests -> /home/runner/work/minio-dotnet/minio-dotnet/Minio.Tests/bin/Release/net6.0/Minio.Tests.dll
  Successfully created package '/home/runner/work/minio-dotnet/minio-dotnet/artifacts/Minio.6.0.2.nupkg'.
  Successfully created package '/home/runner/work/minio-dotnet/minio-dotnet/artifacts/Minio.6.0.2.snupkg'.
Error: /home/runner/work/minio-dotnet/minio-dotnet/Minio.Functional.Tests/FunctionalTest.cs(4833,29): error MA0144: Use System.OperatingSystem to check the current OS (https://github.com/meziantou/Meziantou.Analyzer/blob/main/docs/Rules/MA0144.md) [/home/runner/work/minio-dotnet/minio-dotnet/Minio.Functional.Tests/Minio.Functional.Tests.csproj::TargetFramework=net7.0]
```
