### PR TITLE
adds the missing NullForgiving operator comment

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -691,6 +691,7 @@ public static class FunctionalTest
         var xmlSerializer = new XmlSerializer(typeof(string));
         using var stringReader = new StringReader(xml);
 
+        // ! TODO:
         var obj = (string)xmlSerializer.Deserialize(stringReader)!;
         return JsonSerializer.Serialize(obj);
     }


### PR DESCRIPTION
Bumping `Nullable.Extended.Analyzer` from version `1.10.4539` to `1.14.6129` caused the build process to fail. 
That is because the Analyzer checks the usage of `NullForgiving operator` and require a `justification` for each use case. If it cannot find the justification, then it throws an exception during the build process.
The justification is a simple comment next the code and it is supposed to start with `// ! ` and gives some explanation about the use case.