### PR TITLE
Adds support for newly bumped up Meziantou.Analyzer

### DIFF
--- a/Minio/DataModel/DeleteObjectsRequest.cs
+++ b/Minio/DataModel/DeleteObjectsRequest.cs
@@ -23,7 +23,7 @@ namespace Minio.DataModel;
 [XmlType(TypeName = "Delete")]
 public class DeleteObjectsRequest
 {
-    public DeleteObjectsRequest(Collection<DeleteObject> objectsList, bool quiet = true)
+    public DeleteObjectsRequest(ICollection<DeleteObject> objectsList, bool quiet = true)
     {
         Quiet = quiet;
         Objects = objectsList;
@@ -37,5 +37,5 @@ public class DeleteObjectsRequest
 
     [XmlElement("Quiet")] public bool Quiet { get; set; }
 
-    [XmlElement("Object")] public Collection<DeleteObject> Objects { get; set; }
+    [XmlElement("Object")] public ICollection<DeleteObject> Objects { get; set; }
 }

--- a/Minio/DataModel/Replication/AndOperator.cs
+++ b/Minio/DataModel/Replication/AndOperator.cs
@@ -44,7 +44,7 @@ public class AndOperator
         Tags = new Collection<Tag>(tagObj.TaggingSet.Tag);
     }
 
-    public AndOperator(string prefix, Collection<Tag> tag)
+    public AndOperator(string prefix, ICollection<Tag> tag)
     {
         Prefix = prefix;
         Tags = tag;
@@ -60,5 +60,5 @@ public class AndOperator
 
     [XmlElement("Prefix")] internal string Prefix { get; set; }
 
-    [XmlElement("Tag")] public Collection<Tag> Tags { get; set; }
+    [XmlElement("Tag")] public ICollection<Tag> Tags { get; set; }
 }

--- a/Minio/DataModel/Replication/ReplicationConfiguration.cs
+++ b/Minio/DataModel/Replication/ReplicationConfiguration.cs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Xml;
 using System.Xml.Serialization;
@@ -38,7 +37,7 @@ public class ReplicationConfiguration
     {
     }
 
-    public ReplicationConfiguration(string role, Collection<ReplicationRule> rules)
+    public ReplicationConfiguration(string role, ICollection<ReplicationRule> rules)
     {
         if (string.IsNullOrEmpty(role) || string.IsNullOrWhiteSpace(role))
             throw new ArgumentNullException(nameof(role), nameof(role) + " member cannot be empty.");
@@ -54,7 +53,7 @@ public class ReplicationConfiguration
 
     [XmlElement("Role")] public string Role { get; set; }
 
-    [XmlElement("Rule")] public Collection<ReplicationRule> Rules { get; set; }
+    [XmlElement("Rule")] public ICollection<ReplicationRule> Rules { get; set; }
 
     public string MarshalXML()
     {


### PR DESCRIPTION
Bumping Meziantou.Analyzer from 2.0.127 to 2.0.136 [PR #983](https://github.com/minio/minio-dotnet/pull/983) caused dotnet build to fail due to some code Analyzer complained about.
This PR is for these changes.
