### PR TITLE
fixes error messages for BucketExists and StatObject

### DIFF
--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -11,8 +11,8 @@
     <ProjectReference Include="..\Minio\Minio.csproj" />
   </ItemGroup>
 
-	<ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
-		<Reference Include="System.Web" />
-	</ItemGroup>
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('net4')) ">
+    <Reference Include="System.Web" />
+  </ItemGroup>
 
 </Project>

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -698,14 +698,12 @@ public partial class MinioClient : IObjectOperations
             (srcByteRangeSize > 0 &&
              args.SourceObject.CopyOperationConditions.byteRangeEnd >=
              args.SourceObjectInfo.Size))
-            throw new InvalidDataException(
-                $"Specified byte range ({
-                    args.SourceObject.CopyOperationConditions
-                        .byteRangeStart.ToString(CultureInfo.InvariantCulture)}-{
-                        args.SourceObject.CopyOperationConditions.byteRangeEnd
-                            .ToString(CultureInfo.InvariantCulture)
-                    }) does not fit within source object (size={
-                        args.SourceObjectInfo.Size.ToString(CultureInfo.InvariantCulture)})");
+            throw new InvalidDataException($"Specified byte range ({args.SourceObject
+                .CopyOperationConditions
+                .byteRangeStart.ToString(CultureInfo.InvariantCulture)}-{args.SourceObject
+                .CopyOperationConditions.byteRangeEnd.ToString(CultureInfo.InvariantCulture)
+            }) does not fit within source object (size={args.SourceObjectInfo.Size
+                .ToString(CultureInfo.InvariantCulture)})");
 
         if (copySize > Constants.MaxSingleCopyObjectSize ||
             (srcByteRangeSize > 0 &&

--- a/Minio/DataModel/Args/PutObjectArgs.cs
+++ b/Minio/DataModel/Args/PutObjectArgs.cs
@@ -151,7 +151,8 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
             }
 
         if (string.IsNullOrWhiteSpace(ContentType)) ContentType = "application/octet-stream";
-        if (!Headers.ContainsKey("Content-Type")) Headers["Content-Type"] = ContentType;
+        // if (!Headers.ContainsKey("Content-Type")) Headers["Content-Type"] = ContentType;
+        Headers["Content-Type"] = ContentType;
         return this;
     }
 

--- a/Minio/DataModel/Response/CopyObjectResponse.cs
+++ b/Minio/DataModel/Response/CopyObjectResponse.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Net;
-using System.Text;
-using CommunityToolkit.HighPerformance;
 using Minio.DataModel.Result;
 using Minio.Helper;
 
@@ -27,11 +25,10 @@ internal class CopyObjectResponse : GenericResponse
     public CopyObjectResponse(HttpStatusCode statusCode, string responseContent, Type reqType)
         : base(statusCode, responseContent)
     {
-        using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();
         if (reqType == typeof(CopyObjectResult))
-            CopyObjectRequestResult = Utils.DeserializeXml<CopyObjectResult>(stream);
+            CopyObjectRequestResult = Utils.DeserializeXml<CopyObjectResult>(responseContent);
         else
-            CopyPartRequestResult = Utils.DeserializeXml<CopyPartResult>(stream);
+            CopyPartRequestResult = Utils.DeserializeXml<CopyPartResult>(responseContent);
     }
 
     internal CopyObjectResult CopyObjectRequestResult { get; set; }

--- a/Minio/Exceptions/MinioException.cs
+++ b/Minio/Exceptions/MinioException.cs
@@ -69,11 +69,8 @@ public class MinioException : Exception
 
         var contentString = serverResponse.Content;
 
-        if (message is null)
-            return
-                $"MinIO API responded with status code={serverResponse.StatusCode}, response={serverResponse.ErrorMessage}, content={contentString}";
-
-        return
-            $"MinIO API responded with message={message}. Status code={serverResponse.StatusCode}, response={serverResponse.ErrorMessage}, content={contentString}";
+        return message is null
+            ? $"MinIO API responded with status code={serverResponse.StatusCode}, response={serverResponse.ErrorMessage}, content={contentString}"
+            : $"MinIO API responded with message={message}. Status code={serverResponse.StatusCode}, response={serverResponse.ErrorMessage}, content={contentString}";
     }
 }

--- a/Minio/Exceptions/PreconditionFailedException.cs
+++ b/Minio/Exceptions/PreconditionFailedException.cs
@@ -1,0 +1,27 @@
+using Minio.DataModel.Result;
+
+namespace Minio.Exceptions;
+
+[Serializable]
+public class PreconditionFailedException : MinioException
+{
+    public PreconditionFailedException()
+    {
+    }
+
+    public PreconditionFailedException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public PreconditionFailedException(ResponseResult serverResponse) : base(serverResponse)
+    {
+    }
+
+    public PreconditionFailedException(string message) : base(message)
+    {
+    }
+
+    public PreconditionFailedException(string message, ResponseResult serverResponse) : base(message, serverResponse)
+    {
+    }
+}


### PR DESCRIPTION
Fixes #953, #947, #945

Tested thee fix for the following error cases:
```
 - StatObjectAsync fails when object does not exist => ObjectNotFoundException
 - StatObjectAsync fails when bucket does not exist => BucketNotFoundException
 - BucketExistsAsync returns true/false