### PR TITLE
Replace calls HttpStatusCode.Equals with direct comparison

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1313,7 +1313,7 @@ public static class FunctionalTest
         CancellationToken cancellationToken = default)
     {
         using var response = await minio.WrapperGetAsync(url).ConfigureAwait(false);
-        if (string.IsNullOrEmpty(Convert.ToString(response.Content)) || !HttpStatusCode.OK.Equals(response.StatusCode))
+        if (string.IsNullOrEmpty(Convert.ToString(response.Content)) || HttpStatusCode.OK != response.StatusCode)
             throw new InvalidOperationException("Unable to download via presigned URL" + nameof(response.Content));
 
         using var fs = new FileStream(filePath, FileMode.CreateNew);

--- a/Minio.Tests/NegativeTest.cs
+++ b/Minio.Tests/NegativeTest.cs
@@ -81,7 +81,7 @@ public class NegativeTest
             var ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
                 () => minio.StatObjectAsync(statObjArgs)).ConfigureAwait(false);
             for (var i = 0;
-                 i < tryCount && ex.ServerResponse?.StatusCode.Equals(HttpStatusCode.ServiceUnavailable) == true;
+                 i < tryCount && ex.ServerResponse?.StatusCode == HttpStatusCode.ServiceUnavailable;
                  ++i)
                 ex = await Assert.ThrowsExceptionAsync<InvalidObjectNameException>(
                     () => minio.StatObjectAsync(statObjArgs)).ConfigureAwait(false);

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -53,7 +53,7 @@ public partial class MinioClient : IBucketOperations
                 .ConfigureAwait(false);
 
         var bucketList = new ListAllMyBucketsResult();
-        if (HttpStatusCode.OK.Equals(response.StatusCode))
+        if (HttpStatusCode.OK == response.StatusCode)
         {
             using var stream = response.ContentBytes.AsStream();
             bucketList = Utils.DeserializeXml<ListAllMyBucketsResult>(stream);
@@ -84,7 +84,7 @@ public partial class MinioClient : IBucketOperations
         catch (InternalClientException ice)
         {
             return (ice.ServerResponse is null ||
-                    !HttpStatusCode.NotFound.Equals(ice.ServerResponse.StatusCode)) &&
+                    HttpStatusCode.NotFound != ice.ServerResponse.StatusCode) &&
                    ice.ServerResponse is not null;
         }
         catch (Exception ex)

--- a/Minio/BucketRegionCache.cs
+++ b/Minio/BucketRegionCache.cs
@@ -100,7 +100,7 @@ public sealed class BucketRegionCache
             using var response =
                 await client.ExecuteTaskAsync(client.ResponseErrorHandlers, requestBuilder).ConfigureAwait(false);
 
-            if (response is not null && HttpStatusCode.OK.Equals(response.StatusCode))
+            if (response is not null && HttpStatusCode.OK == response.StatusCode)
             {
                 var root = XDocument.Parse(response.Content);
                 location = root.Root.Value;

--- a/Minio/Credentials/AssumeRoleBaseProvider.cs
+++ b/Minio/Credentials/AssumeRoleBaseProvider.cs
@@ -142,7 +142,7 @@ public abstract class AssumeRoleBaseProvider<T> : IClientProvider
     internal virtual AccessCredentials ParseResponse(HttpResponseMessage response)
     {
         var content = Convert.ToString(response.Content, CultureInfo.InvariantCulture);
-        if (string.IsNullOrEmpty(content) || !HttpStatusCode.OK.Equals(response.StatusCode))
+        if (string.IsNullOrEmpty(content) || HttpStatusCode.OK != response.StatusCode)
             throw new ArgumentNullException(nameof(response), "Unable to generate credentials. Response error.");
 
         using var stream = Encoding.UTF8.GetBytes(content).AsMemory().AsStream();

--- a/Minio/Credentials/IAMAWSProvider.cs
+++ b/Minio/Credentials/IAMAWSProvider.cs
@@ -155,7 +155,7 @@ public class IAMAWSProvider : IClientProvider
             await Client.ExecuteTaskAsync(Enumerable.Empty<IApiResponseErrorHandler>(), requestBuilder)
                 .ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(response.Content) ||
-            !HttpStatusCode.OK.Equals(response.StatusCode))
+            HttpStatusCode.OK != response.StatusCode)
             throw new CredentialsProviderException("IAMAWSProvider",
                 "Credential Get operation failed with HTTP Status code: " + response.StatusCode);
         /*
@@ -187,7 +187,7 @@ JsonConvert.DefaultSettings = () => new JsonSerializerSettings
                 .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(response.Content) ||
-            !HttpStatusCode.OK.Equals(response.StatusCode))
+            HttpStatusCode.OK != response.StatusCode)
             throw new CredentialsProviderException("IAMAWSProvider",
                 "Credential Get operation failed with HTTP Status code: " + response.StatusCode);
 

--- a/Minio/Credentials/WebIdentityClientGrantsProvider.cs
+++ b/Minio/Credentials/WebIdentityClientGrantsProvider.cs
@@ -65,7 +65,7 @@ public abstract class WebIdentityClientGrantsProvider<T> : AssumeRoleBaseProvide
         // txtBlock.Text = readStream.ReadToEnd();
         var content = Convert.ToString(response.Content, CultureInfo.InvariantCulture);
         if (string.IsNullOrWhiteSpace(content) ||
-            !HttpStatusCode.OK.Equals(response.StatusCode))
+            HttpStatusCode.OK != response.StatusCode)
             throw new ArgumentNullException(nameof(response), "Unable to get credentials. Response error.");
 
         using var stream = Encoding.UTF8.GetBytes(content).AsMemory().AsStream();

--- a/Minio/DataModel/Response/GetBucketEncryptionResponse.cs
+++ b/Minio/DataModel/Response/GetBucketEncryptionResponse.cs
@@ -27,7 +27,7 @@ internal class GetBucketEncryptionResponse : GenericResponse
     internal GetBucketEncryptionResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) || !HttpStatusCode.OK.Equals(statusCode))
+        if (string.IsNullOrEmpty(responseContent) || HttpStatusCode.OK != statusCode)
         {
             BucketEncryptionConfiguration = null;
             return;

--- a/Minio/DataModel/Response/GetBucketLifecycleResponse.cs
+++ b/Minio/DataModel/Response/GetBucketLifecycleResponse.cs
@@ -28,7 +28,7 @@ internal class GetBucketLifecycleResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
         {
             BucketLifecycle = null;
             return;

--- a/Minio/DataModel/Response/GetBucketNotificationsResponse.cs
+++ b/Minio/DataModel/Response/GetBucketNotificationsResponse.cs
@@ -28,7 +28,7 @@ internal class GetBucketNotificationsResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
         {
             BucketNotificationConfiguration = new BucketNotification();
             return;

--- a/Minio/DataModel/Response/GetBucketReplicationResponse.cs
+++ b/Minio/DataModel/Response/GetBucketReplicationResponse.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020, 2021 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -28,7 +28,7 @@ internal class GetBucketReplicationResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
         {
             Config = null;
             return;

--- a/Minio/DataModel/Response/GetBucketTagsResponse.cs
+++ b/Minio/DataModel/Response/GetBucketTagsResponse.cs
@@ -28,7 +28,7 @@ internal class GetBucketTagsResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
         {
             BucketTags = null;
             return;

--- a/Minio/DataModel/Response/GetLegalHoldResponse.cs
+++ b/Minio/DataModel/Response/GetLegalHoldResponse.cs
@@ -27,7 +27,7 @@ public class GetLegalHoldResponse : GenericResponse
     public GetLegalHoldResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) || !HttpStatusCode.OK.Equals(statusCode))
+        if (string.IsNullOrEmpty(responseContent) || HttpStatusCode.OK != statusCode)
         {
             CurrentLegalHoldConfiguration = null;
             return;

--- a/Minio/DataModel/Response/GetObjectLockConfigurationResponse.cs
+++ b/Minio/DataModel/Response/GetObjectLockConfigurationResponse.cs
@@ -27,7 +27,7 @@ internal class GetObjectLockConfigurationResponse : GenericResponse
     internal GetObjectLockConfigurationResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) || !HttpStatusCode.OK.Equals(statusCode))
+        if (string.IsNullOrEmpty(responseContent) || HttpStatusCode.OK != statusCode)
         {
             LockConfiguration = null;
             return;

--- a/Minio/DataModel/Response/GetObjectTagsResponse.cs
+++ b/Minio/DataModel/Response/GetObjectTagsResponse.cs
@@ -28,7 +28,7 @@ internal class GetObjectTagsResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
         {
             ObjectTags = null;
             return;

--- a/Minio/DataModel/Response/GetObjectsListResponse.cs
+++ b/Minio/DataModel/Response/GetObjectsListResponse.cs
@@ -33,7 +33,7 @@ internal class GetObjectsListResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
             return;
 
         using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();

--- a/Minio/DataModel/Response/GetObjectsVersionsListResponse.cs
+++ b/Minio/DataModel/Response/GetObjectsVersionsListResponse.cs
@@ -33,7 +33,7 @@ internal class GetObjectsVersionsListResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
             return;
 
         using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();

--- a/Minio/DataModel/Response/GetPolicyResponse.cs
+++ b/Minio/DataModel/Response/GetPolicyResponse.cs
@@ -26,7 +26,7 @@ internal class GetPolicyResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
             return;
 
         Initialize().Wait();

--- a/Minio/DataModel/Response/GetRetentionResponse.cs
+++ b/Minio/DataModel/Response/GetRetentionResponse.cs
@@ -27,7 +27,7 @@ internal class GetRetentionResponse : GenericResponse
     public GetRetentionResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) && !HttpStatusCode.OK.Equals(statusCode))
+        if (string.IsNullOrEmpty(responseContent) && HttpStatusCode.OK != statusCode)
         {
             CurrentRetentionConfiguration = null;
             return;

--- a/Minio/DataModel/Response/GetVersioningResponse.cs
+++ b/Minio/DataModel/Response/GetVersioningResponse.cs
@@ -25,7 +25,7 @@ internal class GetVersioningResponse : GenericResponse
         : base(statusCode, responseContent)
     {
         if (string.IsNullOrEmpty(responseContent) ||
-            !HttpStatusCode.OK.Equals(statusCode))
+            HttpStatusCode.OK != statusCode)
             return;
 
         VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(responseContent);

--- a/Minio/DataModel/Response/ListBucketsResponse.cs
+++ b/Minio/DataModel/Response/ListBucketsResponse.cs
@@ -29,7 +29,7 @@ internal class ListBucketsResponse : GenericResponse
     internal ListBucketsResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) || !HttpStatusCode.OK.Equals(statusCode))
+        if (string.IsNullOrEmpty(responseContent) || HttpStatusCode.OK != statusCode)
             return;
 
         using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -102,9 +102,9 @@ public partial class MinioClient : IMinioClient
             throw new ConnectionException(
                 "Response is nil. Please report this issue https://github.com/minio/minio-dotnet/issues", response);
 
-        if (HttpStatusCode.Redirect.Equals(response.StatusCode) ||
-            HttpStatusCode.TemporaryRedirect.Equals(response.StatusCode) ||
-            HttpStatusCode.MovedPermanently.Equals(response.StatusCode))
+        if (HttpStatusCode.Redirect == response.StatusCode ||
+            HttpStatusCode.TemporaryRedirect == response.StatusCode ||
+            HttpStatusCode.MovedPermanently == response.StatusCode)
             throw new RedirectionException(
                 "Redirection detected. Please report this issue https://github.com/minio/minio-dotnet/issues");
 
@@ -119,11 +119,11 @@ public partial class MinioClient : IMinioClient
 
     private static void ParseErrorNoContent(ResponseResult response)
     {
-        if (HttpStatusCode.Forbidden.Equals(response.StatusCode)
-            || HttpStatusCode.BadRequest.Equals(response.StatusCode)
-            || HttpStatusCode.NotFound.Equals(response.StatusCode)
-            || HttpStatusCode.MethodNotAllowed.Equals(response.StatusCode)
-            || HttpStatusCode.NotImplemented.Equals(response.StatusCode))
+        if (HttpStatusCode.Forbidden == response.StatusCode
+            || HttpStatusCode.BadRequest == response.StatusCode
+            || HttpStatusCode.NotFound == response.StatusCode
+            || HttpStatusCode.MethodNotAllowed == response.StatusCode
+            || HttpStatusCode.NotImplemented == response.StatusCode)
             ParseWellKnownErrorNoContent(response);
 
 #pragma warning disable MA0099 // Use Explicit enum value instead of 0
@@ -158,7 +158,7 @@ public partial class MinioClient : IMinioClient
         // zero, one or two segments
         var resourceSplits = pathAndQuery.Split(separator, 2, StringSplitOptions.RemoveEmptyEntries);
 
-        if (HttpStatusCode.NotFound.Equals(response.StatusCode))
+        if (HttpStatusCode.NotFound == response.StatusCode)
         {
             var pathLength = resourceSplits.Length;
             var isAWS = host.EndsWith("s3.amazonaws.com", StringComparison.OrdinalIgnoreCase);
@@ -192,7 +192,7 @@ public partial class MinioClient : IMinioClient
                     response);
             }
         }
-        else if (HttpStatusCode.BadRequest.Equals(response.StatusCode))
+        else if (HttpStatusCode.BadRequest == response.StatusCode)
         {
             var pathLength = resourceSplits.Length;
 
@@ -208,7 +208,7 @@ public partial class MinioClient : IMinioClient
                     response);
             }
         }
-        else if (HttpStatusCode.Forbidden.Equals(response.StatusCode))
+        else if (HttpStatusCode.Forbidden == response.StatusCode)
         {
             errorResponse.Code = "Forbidden";
             error = new AccessDeniedException("Access denied on the resource: " + pathAndQuery);
@@ -223,7 +223,7 @@ public partial class MinioClient : IMinioClient
         if (response is null)
             throw new ArgumentNullException(nameof(response));
 
-        if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound
             && response.Request.RequestUri.PathAndQuery.EndsWith("?location", StringComparison.OrdinalIgnoreCase)
             && response.Request.Method.Equals(HttpMethod.Get))
         {
@@ -234,28 +234,28 @@ public partial class MinioClient : IMinioClient
 
         var errResponse = Utils.DeserializeXml<ErrorResponse>(response.Content);
 
-        if (response.StatusCode.Equals(HttpStatusCode.Forbidden)
+        if (response.StatusCode == HttpStatusCode.Forbidden
             && (errResponse.Code.Equals("SignatureDoesNotMatch", StringComparison.OrdinalIgnoreCase) ||
                 errResponse.Code.Equals("InvalidAccessKeyId", StringComparison.OrdinalIgnoreCase)))
             throw new AuthorizationException(errResponse.Resource, errResponse.BucketName, errResponse.Message);
 
         // Handle XML response for Bucket Policy not found case
-        if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound
             && response.Request.RequestUri.PathAndQuery.EndsWith("?policy", StringComparison.OrdinalIgnoreCase)
             && response.Request.Method.Equals(HttpMethod.Get)
             && string.Equals(errResponse.Code, "NoSuchBucketPolicy", StringComparison.OrdinalIgnoreCase))
             throw new ErrorResponseException(errResponse, response) { XmlError = response.Content };
 
-        if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound
             && string.Equals(errResponse.Code, "NoSuchBucket", StringComparison.OrdinalIgnoreCase))
             throw new BucketNotFoundException(errResponse.BucketName, "Not found.");
 
-        if (response.StatusCode.Equals(HttpStatusCode.BadRequest)
+        if (response.StatusCode == HttpStatusCode.BadRequest
             && errResponse.Code.Equals("MalformedXML", StringComparison.OrdinalIgnoreCase))
             throw new MalFormedXMLException(errResponse.Resource, errResponse.BucketName, errResponse.Message,
                 errResponse.Key);
 
-        if (response.StatusCode.Equals(HttpStatusCode.NotImplemented)
+        if (response.StatusCode == HttpStatusCode.NotImplemented
             && errResponse.Code.Equals("NotImplemented", StringComparison.OrdinalIgnoreCase))
         {
 #pragma warning disable MA0025 // Implement the functionality instead of throwing NotImplementedException
@@ -263,7 +263,7 @@ public partial class MinioClient : IMinioClient
         }
 #pragma warning restore MA0025 // Implement the functionality instead of throwing NotImplementedException
 
-        if (response.StatusCode.Equals(HttpStatusCode.BadRequest)
+        if (response.StatusCode == HttpStatusCode.BadRequest
             && errResponse.Code.Equals("InvalidRequest", StringComparison.OrdinalIgnoreCase))
         {
             _ = new Dictionary<string, string>(StringComparer.Ordinal) { { "legal-hold", "" } };
@@ -271,20 +271,20 @@ public partial class MinioClient : IMinioClient
                 throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
         }
 
-        if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound
             && errResponse.Code.Equals("ObjectLockConfigurationNotFoundError", StringComparison.OrdinalIgnoreCase))
             throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
 
-        if (response.StatusCode.Equals(HttpStatusCode.NotFound)
+        if (response.StatusCode == HttpStatusCode.NotFound
             && errResponse.Code.Equals("ReplicationConfigurationNotFoundError", StringComparison.OrdinalIgnoreCase))
             throw new MissingBucketReplicationConfigurationException(errResponse.BucketName, errResponse.Message);
 
-        if (response.StatusCode.Equals(HttpStatusCode.Conflict)
+        if (response.StatusCode == HttpStatusCode.Conflict
             && errResponse.Code.Equals("BucketAlreadyOwnedByYou", StringComparison.OrdinalIgnoreCase))
             throw new ArgumentException("Bucket already owned by you: " + errResponse.BucketName,
                 nameof(response));
 
-        if (response.StatusCode.Equals(HttpStatusCode.PreconditionFailed)
+        if (response.StatusCode == HttpStatusCode.PreconditionFailed
             && errResponse.Code.Equals("PreconditionFailed", StringComparison.OrdinalIgnoreCase))
             throw new PreconditionFailedException("At least one of the pre-conditions you " +
                                                   "specified did not hold for object: \"" + errResponse.Resource +


### PR DESCRIPTION

This change replaces the use of `HttpStatusCode.OK.Equals(statusCode)` in favor of using the equals operator directly.  Using the equals operator is around 26 - 3000 times faster depending on the processor.  I tested on a Raspberry Pi 4b and am AMD Ryzen Threadripper PRO 3955WX. Consider the following benchmark,

```cs
    public class Benchmarks
    {
        private HttpStatusCode _statusCode;

        [GlobalSetup]
        public void Setup()
        {
            Random random = new Random(420);

            var values = Enum.GetValues(typeof(HttpStatusCode)).Cast<HttpStatusCode>().ToArray();
            for (int i = 0; i < 10; i++)
            {
                random.Shuffle(values);
            }
        }

        [Benchmark]
        public bool EqualsMethod()
        {
            return _statusCode.Equals(HttpStatusCode.OK);
        }

        [Benchmark(Baseline = true)]
        public bool EqualsOperator()
        {
            return _statusCode == HttpStatusCode.OK;
        }
    }
```

The results on Raspberry Pi 4,

```
BenchmarkDotNet v0.13.12, Debian GNU/Linux 12 (bookworm)
Unknown processor
.NET SDK 8.0.101
  [Host]     : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD
  DefaultJob : .NET 8.0.1 (8.0.123.58001), Arm64 RyuJIT AdvSIMD


| Method         | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD |
|--------------- |-----------:|----------:|----------:|-----------:|------:|--------:|
| EqualsMethod   | 73.6396 ns | 0.4825 ns | 0.4277 ns | 73.5708 ns |     ? |       ? |
| EqualsOperator |  0.0197 ns | 0.0185 ns | 0.0164 ns |  0.0248 ns |     ? |       ? |
```

and the results on AMD Ryzen Threadripper PRO 3955WX,

```
BenchmarkDotNet v0.13.12, Windows 11 (10.0.22631.3085/23H2/2023Update/SunValley3)
AMD Ryzen Threadripper PRO 3955WX 16-Cores, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.200-preview.23624.5
  [Host]     : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2
  DefaultJob : .NET 8.0.1 (8.0.123.58001), X64 RyuJIT AVX2


| Method         | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD |
|--------------- |----------:|----------:|----------:|----------:|------:|--------:|
| EqualsMethod   | 8.3323 ns | 0.1652 ns | 0.1545 ns | 8.2500 ns |     ? |       ? |
| EqualsOperator | 0.0027 ns | 0.0036 ns | 0.0034 ns | 0.0018 ns |     ? |       ? |
```