### PR TITLE
Update README AddMinio() example

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ public static class Program
         // Add Minio using the custom endpoint and configure additional settings for default MinioClient initialization
         builder.Services.AddMinio(configureClient => configureClient
             .WithEndpoint(endpoint)
-            .WithCredentials(accessKey, secretKey));
+            .WithCredentials(accessKey, secretKey)
+	    .Build());
 
         // NOTE: SSL and Build are called by the build-in services already.
 


### PR DESCRIPTION
Correct the example invocation of `AddMinio(configureClient...` in the README.

Fixes https://github.com/minio/minio-dotnet/issues/904