### PR TITLE
docs(readme): fix missing brackets in readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ public class ExampleController : ControllerBase
     public async Task<IActionResult> GetUrl(string bucketID)
     {
         return Ok(await minioClient.PresignedGetObjectAsync(new PresignedGetObjectArgs()
-                .WithBucket(bucketID)
+                .WithBucket(bucketID))
             .ConfigureAwait(false));
     }
 }
@@ -82,7 +82,7 @@ public class ExampleFactoryController : ControllerBase
         var minioClient = minioClientFactory.CreateClient(); //Has optional argument to configure specifics
 
         return Ok(await minioClient.PresignedGetObjectAsync(new PresignedGetObjectArgs()
-                .WithBucket(bucketID)
+                .WithBucket(bucketID))
             .ConfigureAwait(false));
     }
 }


### PR DESCRIPTION
this mistake is also present [here](https://min.io/docs/minio/linux/developers/dotnet/minio-dotnet.html)