### PR TITLE
Fixed error handling in `RequestExtensions`

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
  * (C) 2017-2021 MinIO, Inc.
  *
@@ -4139,9 +4139,9 @@ public static class FunctionalTest
             }
             catch (Exception ex)
             {
-                Assert.AreEqual(
+                Assert.IsTrue(ex.Message.StartsWith(
                     "MinIO API responded with message=At least one of the pre-conditions you specified did not hold",
-                    ex.Message);
+                    StringComparison.InvariantCulture));
             }
 
             new MintLogger("CopyObject_Test7", copyObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -365,9 +365,7 @@ public static class FunctionalTest
         try
         {
             if (await minio.BucketExistsAsync(beArgs).ConfigureAwait(false))
-            {
                 await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
-            }
 
             var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsFalse(found);
@@ -3527,8 +3525,8 @@ public static class FunctionalTest
             var stream = rsg.GenerateStreamFromSeed(objSize);
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
-            Assert.IsTrue(percentage == 100);
-            Assert.IsTrue(totalBytesTransferred == objSize);
+            Assert.IsTrue(percentage == 100, "Reported percentage after finished upload was not 100 percent.");
+            Assert.IsTrue(totalBytesTransferred == objSize, "Transfered object size does not match with the original object size.");
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,
                 "Tests whether PutObject with progress passes for small object", TestStatus.PASS,
                 DateTime.Now - startTime,
@@ -3582,8 +3580,8 @@ public static class FunctionalTest
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 rsg.GenerateStreamFromSeed(64 * MB), progress).ConfigureAwait(false);
-            Assert.IsTrue(percentage == 100);
-            Assert.IsTrue(totalBytesTransferred == 64 * MB);
+            Assert.IsTrue(percentage == 100, "Reported percentage after finished upload was not 100 percent.");
+            Assert.IsTrue(totalBytesTransferred == 64 * MB, "Transfered object size does not match with the original object size.");
             new MintLogger(nameof(PutObject_Test10), putObjectSignature,
                 "Tests whether multipart PutObject with progress passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3526,7 +3526,8 @@ public static class FunctionalTest
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
             Assert.IsTrue(percentage == 100, "Reported percentage after finished upload was not 100 percent.");
-            Assert.IsTrue(totalBytesTransferred == objSize, "Transfered object size does not match with the original object size.");
+            Assert.IsTrue(totalBytesTransferred == objSize,
+                "Transfered object size does not match with the original object size.");
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,
                 "Tests whether PutObject with progress passes for small object", TestStatus.PASS,
                 DateTime.Now - startTime,
@@ -3581,7 +3582,8 @@ public static class FunctionalTest
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 rsg.GenerateStreamFromSeed(64 * MB), progress).ConfigureAwait(false);
             Assert.IsTrue(percentage == 100, "Reported percentage after finished upload was not 100 percent.");
-            Assert.IsTrue(totalBytesTransferred == 64 * MB, "Transfered object size does not match with the original object size.");
+            Assert.IsTrue(totalBytesTransferred == 64 * MB,
+                "Transfered object size does not match with the original object size.");
             new MintLogger(nameof(PutObject_Test10), putObjectSignature,
                 "Tests whether multipart PutObject with progress passes", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -364,7 +364,11 @@ public static class FunctionalTest
 
         try
         {
-            await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            if (await minio.BucketExistsAsync(beArgs).ConfigureAwait(false))
+            {
+                await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
+            }
+
             var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             Assert.IsFalse(found);
             await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Minio.Credentials;
 using Minio.DataModel;
@@ -126,8 +126,6 @@ public static class RequestExtensions
                     request.Method == HttpMethod.Get)
                     responseResult.Exception = new MissingObjectLockConfigurationException();
             }
-
-            return responseResult;
         }
         catch (Exception ex) when (ex is not (OperationCanceledException or
                                        ObjectNotFoundException))
@@ -141,6 +139,9 @@ public static class RequestExtensions
                 responseResult = new ResponseResult(request, ex);
             return responseResult;
         }
+
+        minioClient.HandleIfErrorResponse(responseResult, errorHandlers, startTime);
+        return responseResult;
     }
 
     private static Task<ResponseResult> ExecuteWithRetry(this IMinioClient minioClient,
@@ -369,7 +370,7 @@ public static class RequestExtensions
             minioClient.LogRequest(response.Request, response, (now - startTime).TotalMilliseconds);
         }
 
-        if (response.Exception is null)
+        if (response.Exception is not null)
             throw response.Exception;
 
         if (handlers.Any())

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using Minio.Credentials;
 using Minio.DataModel;
@@ -107,10 +107,10 @@ public static class RequestExtensions
                 if (request.Method == HttpMethod.Head)
                 {
                     if (responseResult.Exception?.GetType().Equals(typeof(BucketNotFoundException)) == true ||
-                        path?.ToList().Count == 1)
+                        path.Length == 1)
                         responseResult.Exception = new BucketNotFoundException();
 
-                    if (path?.ToList().Count > 1)
+                    if (path.Length > 1)
                     {
                         var found = await minioClient
                             .BucketExistsAsync(new BucketExistsArgs().WithBucket(path.ToList()[0]), cancellationToken)


### PR DESCRIPTION
Response error handling was unintentionally removed in a previous commit. Added it back to the `ExecuteTaskCoreAsync` method. Fixed `NullReferenceException`-bug in the `HandleIfErrorResponse` method - `throw response.Exception;` does not make sense if the exception is null.

Fixes #1041 , #1020 , and probably #1027 