### PR TITLE
docs: changed file uploader example to correct type

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ namespace FileUploader
         }
 
         // File uploader task.
-        private async static Task Run(MinioClient minio)
+        private async static Task Run(IMinioClient minio)
         {
             var bucketName = "mymusic";
             var location   = "us-east-1";


### PR DESCRIPTION
Just a simple update to the README since the `Build` method on `MinioClient` returns `IMinioClient` instead of `MinioClient`