### PR TITLE
A possible fix for random progress issue

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3517,6 +3517,7 @@ public static class FunctionalTest
                 stream, progress).ConfigureAwait(false);
             Console.WriteLine($"\n\n\n ===>>>   percentage = {percentage.ToString(CultureInfo.InvariantCulture)}");
             Console.WriteLine($" ===>>>   totalBytesTransferred = {totalBytesTransferred.ToString(CultureInfo.InvariantCulture)}\n\n\n");
+            Console.WriteLine($" ===>>>   objSize = {objSize}\n\n\n");
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == objSize);
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3515,10 +3515,6 @@ public static class FunctionalTest
             var stream = rsg.GenerateStreamFromSeed(objSize);
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
-            Console.WriteLine($"\n\n\n ===>>>   percentage = {percentage.ToString(CultureInfo.InvariantCulture)}");
-            Console.WriteLine(
-                $" ===>>>   totalBytesTransferred = {totalBytesTransferred.ToString(CultureInfo.InvariantCulture)}\n\n\n");
-            Console.WriteLine($" ===>>>   objSize = {objSize}\n\n\n");
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == objSize);
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3499,14 +3499,6 @@ public static class FunctionalTest
         {
             percentage = progressReport.Percentage;
             totalBytesTransferred = progressReport.TotalBytesTransferred;
-            // Console.WriteLine(
-            //    $"PutObject_Test9 - Percentage: {progressReport.Percentage}% TotalBytesTransferred: {progressReport.TotalBytesTransferred} bytes");
-            // if (progressReport.Percentage != 100)
-            // {
-            //     var topPosition = Console.CursorTop > 0 ? Console.CursorTop - 1 : Console.CursorTop;
-            //     Console.SetCursorPosition(0, topPosition);
-            // }
-            // else Console.WriteLine();
         });
         var args = new Dictionary<string, string>
             (StringComparer.Ordinal)
@@ -3523,6 +3515,12 @@ public static class FunctionalTest
             var stream = rsg.GenerateStreamFromSeed(objSize);
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
+            progress = new Progress<ProgressReport>(progressReport =>
+            {
+                percentage = progressReport.Percentage;
+                totalBytesTransferred = progressReport.TotalBytesTransferred;
+            });
+
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == objSize);
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3556,14 +3556,6 @@ public static class FunctionalTest
         {
             percentage = progressReport.Percentage;
             totalBytesTransferred = progressReport.TotalBytesTransferred;
-            // Console.WriteLine(
-            //    $"PutObject_Test10 - Percentage: {progressReport.Percentage}% TotalBytesTransferred: {progressReport.TotalBytesTransferred} bytes");
-            // if (progressReport.Percentage != 100)
-            // {
-            //     var topPosition = Console.CursorTop > 0 ? Console.CursorTop - 1 : Console.CursorTop;
-            //     Console.SetCursorPosition(0, topPosition);
-            // }
-            // else Console.WriteLine();
         });
         var args = new Dictionary<string, string>
             (StringComparer.Ordinal)
@@ -3578,6 +3570,11 @@ public static class FunctionalTest
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 rsg.GenerateStreamFromSeed(64 * MB), progress).ConfigureAwait(false);
+            progress = new Progress<ProgressReport>(progressReport =>
+            {
+                percentage = progressReport.Percentage;
+                totalBytesTransferred = progressReport.TotalBytesTransferred;
+            });
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == 64 * MB);
             new MintLogger(nameof(PutObject_Test10), putObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3515,12 +3515,8 @@ public static class FunctionalTest
             var stream = rsg.GenerateStreamFromSeed(objSize);
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
-            progress = new Progress<ProgressReport>(progressReport =>
-            {
-                percentage = progressReport.Percentage;
-                totalBytesTransferred = progressReport.TotalBytesTransferred;
-            });
-
+            Console.WriteLine($"\n\n\n ===>>>   percentage = {percentage.ToString(CultureInfo.InvariantCulture)}");
+            Console.WriteLine($" ===>>>   totalBytesTransferred = {totalBytesTransferred.ToString(CultureInfo.InvariantCulture)}\n\n\n");
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == objSize);
             new MintLogger(nameof(PutObject_Test9), putObjectSignature,
@@ -3568,11 +3564,6 @@ public static class FunctionalTest
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 rsg.GenerateStreamFromSeed(64 * MB), progress).ConfigureAwait(false);
-            progress = new Progress<ProgressReport>(progressReport =>
-            {
-                percentage = progressReport.Percentage;
-                totalBytesTransferred = progressReport.TotalBytesTransferred;
-            });
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == 64 * MB);
             new MintLogger(nameof(PutObject_Test10), putObjectSignature,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3516,7 +3516,8 @@ public static class FunctionalTest
             var statObj = await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
                 stream, progress).ConfigureAwait(false);
             Console.WriteLine($"\n\n\n ===>>>   percentage = {percentage.ToString(CultureInfo.InvariantCulture)}");
-            Console.WriteLine($" ===>>>   totalBytesTransferred = {totalBytesTransferred.ToString(CultureInfo.InvariantCulture)}\n\n\n");
+            Console.WriteLine(
+                $" ===>>>   totalBytesTransferred = {totalBytesTransferred.ToString(CultureInfo.InvariantCulture)}\n\n\n");
             Console.WriteLine($" ===>>>   objSize = {objSize}\n\n\n");
             Assert.IsTrue(percentage == 100);
             Assert.IsTrue(totalBytesTransferred == objSize);

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -843,8 +843,8 @@ public partial class MinioClient : IObjectOperations
         CancellationToken cancellationToken = default)
     {
         //Skipping validate as we need the case where stream sends 0 bytes
-        if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
-        {
+        // if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
+        // {
             var progressReport = new ProgressReport();
             var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
             using var response =
@@ -852,32 +852,33 @@ public partial class MinioClient : IObjectOperations
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
             var PutStatusCode = response.StatusCode;
-            Console.WriteLine($"\n\n\n ******   PutStatusCode = {PutStatusCode}   ******\n\n\n");
-            if (args.Progress is not null)
+            // if (args.Progress is not null)
 
-            {
-                Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
+            // {
+                // Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
                 var statArgs = new StatObjectArgs()
                     .WithBucket(args.BucketName)
                     .WithObject(args.ObjectName);
                 var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-                if (PutStatusCode == HttpStatusCode.OK)
+                if (PutStatusCode == HttpStatusCode.OK &&
+                    args.Progress is not null &&
+                    args.ObjectSize <= Constants.MinimumPUTPartSize)
                 {
-                    Console.WriteLine("\n\n\n ******   Inside HttpStatusCode.OK   ******\n\n\n");
+                    Console.WriteLine("\n\n\n ******   Inside PutStatusCode is HttpStatusCode.OK  ******\n\n\n");
                     progressReport.Percentage = 100;
                     progressReport.TotalBytesTransferred = stat.Size;
                 }
 
                 args.Progress.Report(progressReport);
-            }
+            // }
 
             return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
                 args.ObjectSize, args.ObjectName);
-        }
+        // }
 
         // The size should never be more than `Constants.MinimumPartSize`
         // Throws an exception
-        throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
+        // throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
     }
 
     /// <summary>

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -855,82 +855,14 @@ public partial class MinioClient : IObjectOperations
         if (args.Progress is not null &&
             response.StatusCode == HttpStatusCode.OK)
         {
-            // var statArgs = new StatObjectArgs()
-            //     .WithBucket(args.BucketName)
-            //     .WithObject(args.ObjectName);
-            // var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-            // if (response.StatusCode == HttpStatusCode.OK)
-            // {
-                progressReport.Percentage = 100;
-                progressReport.TotalBytesTransferred = args.ObjectSize;
-            // }
-
+            progressReport.Percentage = 100;
+            progressReport.TotalBytesTransferred = args.ObjectSize;
             args.Progress.Report(progressReport);
         }
 
         return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
             args.ObjectSize, args.ObjectName);
     }
-
-
-    // /// <summary>
-    // ///     Upload object part to bucket for particular uploadId
-    // /// </summary>
-    // /// <param name="args">
-    // ///     PutObjectArgs encapsulates bucket name, object name, upload id, part number, object data(body),
-    // ///     Headers, SSE Headers
-    // /// </param>
-    // /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-    // /// <returns></returns>
-    // /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
-    // /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
-    // /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
-    // /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
-    // /// <exception cref="ObjectDisposedException">The file stream has been disposed</exception>
-    // /// <exception cref="NotSupportedException">The file stream cannot be read from</exception>
-    // /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
-    // /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
-    // private async Task<PutObjectResponse> PutObjectSinglePartAsync(PutObjectArgs args,
-    //     CancellationToken cancellationToken = default)
-    // {
-    //     //Skipping validate as we need the case where stream sends 0 bytes
-    //     // if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
-    //     // {
-    //         var progressReport = new ProgressReport();
-    //         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
-    //         using var response =
-    //             await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
-    //                     cancellationToken: cancellationToken)
-    //                 .ConfigureAwait(false);
-    //         var PutStatusCode = response.StatusCode;
-    //         // if (args.Progress is not null)
-
-    //         // {
-    //             // Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
-    //             var statArgs = new StatObjectArgs()
-    //                 .WithBucket(args.BucketName)
-    //                 .WithObject(args.ObjectName);
-    //             var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-    //             if (PutStatusCode == HttpStatusCode.OK &&
-    //                 args.Progress is not null &&
-    //                 args.ObjectSize <= Constants.MinimumPUTPartSize)
-    //             {
-    //                 Console.WriteLine("\n\n\n ******   Inside PutStatusCode is HttpStatusCode.OK  ******\n\n\n");
-    //                 progressReport.Percentage = 100;
-    //                 progressReport.TotalBytesTransferred = stat.Size;
-    //             }
-
-    //             args.Progress.Report(progressReport);
-    //         // }
-
-    //         return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
-    //             args.ObjectSize, args.ObjectName);
-    //     // }
-
-    //     // The size should never be more than `Constants.MinimumPartSize`
-    //     // Throws an exception
-    //     // throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
-    // }
 
     /// <summary>
     ///     Upload object in multiple parts. Private Helper function

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -593,7 +593,7 @@ public partial class MinioClient : IObjectOperations
             args = args.WithRequestBody(bytes)
                 .WithStreamData(null)
                 .WithObjectSize(bytesRead);
-            return await PutObjectSinglePartAsync(args, cancellationToken, true).ConfigureAwait(false);
+            return await PutObjectSinglePartAsync(args, cancellationToken).ConfigureAwait(false);
         }
 
         // For all sizes greater than 5MiB do multipart.
@@ -830,10 +830,6 @@ public partial class MinioClient : IObjectOperations
     ///     Headers, SSE Headers
     /// </param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-    /// <param name="singleFile">
-    ///     This boolean parameter differentiates single part file upload and
-    ///     multi part file upload as this function is shared by both.
-    /// </param>
     /// <returns></returns>
     /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
     /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
@@ -844,35 +840,38 @@ public partial class MinioClient : IObjectOperations
     /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
     /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
     private async Task<PutObjectResponse> PutObjectSinglePartAsync(PutObjectArgs args,
-        CancellationToken cancellationToken = default,
-        bool singleFile = false)
+        CancellationToken cancellationToken = default)
     {
         //Skipping validate as we need the case where stream sends 0 bytes
-        var progressReport = new ProgressReport();
-        if (singleFile) args.Progress?.Report(progressReport);
-        var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
-        using var response =
-            await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
-                    cancellationToken: cancellationToken)
-                .ConfigureAwait(false);
-
-        if (singleFile && args.Progress is not null)
+        if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
         {
-            var statArgs = new StatObjectArgs()
-                .WithBucket(args.BucketName)
-                .WithObject(args.ObjectName);
-            var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-            if (response.StatusCode == HttpStatusCode.OK)
+            var progressReport = new ProgressReport();
+            var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
+            using var response =
+                await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
+                        cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            if (args.Progress is not null)
             {
-                progressReport.Percentage = 100;
-                progressReport.TotalBytesTransferred = stat.Size;
+                Console.WriteLine("\n\n\n ******   Inside   ******\n\n\n");
+                var statArgs = new StatObjectArgs()
+                    .WithBucket(args.BucketName)
+                    .WithObject(args.ObjectName);
+                var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    progressReport.Percentage = 100;
+                    progressReport.TotalBytesTransferred = stat.Size;
+                }
+
+                args.Progress.Report(progressReport);
             }
-
-            args.Progress.Report(progressReport);
+            return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
+                args.ObjectSize, args.ObjectName);
         }
-
-        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
-            args.ObjectSize, args.ObjectName);
+        // The size should never be more than `Constants.MinimumPartSize`
+        // Throws an exception
+        throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
     }
 
     /// <summary>

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -851,24 +851,30 @@ public partial class MinioClient : IObjectOperations
                 await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
+            var PutStatusCode = response.StatusCode;
+            Console.WriteLine($"\n\n\n ******   PutStatusCode = {PutStatusCode}   ******\n\n\n");
             if (args.Progress is not null)
+
             {
-                Console.WriteLine("\n\n\n ******   Inside   ******\n\n\n");
+                Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
                 var statArgs = new StatObjectArgs()
                     .WithBucket(args.BucketName)
                     .WithObject(args.ObjectName);
                 var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-                if (response.StatusCode == HttpStatusCode.OK)
+                if (PutStatusCode == HttpStatusCode.OK)
                 {
+                    Console.WriteLine("\n\n\n ******   Inside HttpStatusCode.OK   ******\n\n\n");
                     progressReport.Percentage = 100;
                     progressReport.TotalBytesTransferred = stat.Size;
                 }
 
                 args.Progress.Report(progressReport);
             }
+
             return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
                 args.ObjectSize, args.ObjectName);
         }
+
         // The size should never be more than `Constants.MinimumPartSize`
         // Throws an exception
         throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -822,6 +822,7 @@ public partial class MinioClient : IObjectOperations
                 .ConfigureAwait(false);
     }
 
+
     /// <summary>
     ///     Upload object part to bucket for particular uploadId
     /// </summary>
@@ -830,7 +831,7 @@ public partial class MinioClient : IObjectOperations
     ///     Headers, SSE Headers
     /// </param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
-    /// <returns></returns>
+    /// <returns>"PutObjectResponse"</returns>
     /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
     /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
     /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
@@ -843,43 +844,93 @@ public partial class MinioClient : IObjectOperations
         CancellationToken cancellationToken = default)
     {
         //Skipping validate as we need the case where stream sends 0 bytes
-        // if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
-        // {
-            var progressReport = new ProgressReport();
-            var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
-            using var response =
-                await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
-                        cancellationToken: cancellationToken)
-                    .ConfigureAwait(false);
-            var PutStatusCode = response.StatusCode;
-            // if (args.Progress is not null)
+        var progressReport = new ProgressReport();
+        args.Progress?.Report(progressReport);
+        var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
+        using var response =
+            await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
+                    cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
+        if (args.Progress is not null &&
+            response.StatusCode == HttpStatusCode.OK)
+        {
+            // var statArgs = new StatObjectArgs()
+            //     .WithBucket(args.BucketName)
+            //     .WithObject(args.ObjectName);
+            // var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
+            // if (response.StatusCode == HttpStatusCode.OK)
             // {
-                // Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
-                var statArgs = new StatObjectArgs()
-                    .WithBucket(args.BucketName)
-                    .WithObject(args.ObjectName);
-                var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-                if (PutStatusCode == HttpStatusCode.OK &&
-                    args.Progress is not null &&
-                    args.ObjectSize <= Constants.MinimumPUTPartSize)
-                {
-                    Console.WriteLine("\n\n\n ******   Inside PutStatusCode is HttpStatusCode.OK  ******\n\n\n");
-                    progressReport.Percentage = 100;
-                    progressReport.TotalBytesTransferred = stat.Size;
-                }
-
-                args.Progress.Report(progressReport);
+                progressReport.Percentage = 100;
+                progressReport.TotalBytesTransferred = args.ObjectSize;
             // }
 
-            return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
-                args.ObjectSize, args.ObjectName);
-        // }
+            args.Progress.Report(progressReport);
+        }
 
-        // The size should never be more than `Constants.MinimumPartSize`
-        // Throws an exception
-        // throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
+        return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
+            args.ObjectSize, args.ObjectName);
     }
+
+
+    // /// <summary>
+    // ///     Upload object part to bucket for particular uploadId
+    // /// </summary>
+    // /// <param name="args">
+    // ///     PutObjectArgs encapsulates bucket name, object name, upload id, part number, object data(body),
+    // ///     Headers, SSE Headers
+    // /// </param>
+    // /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    // /// <returns></returns>
+    // /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
+    // /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+    // /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
+    // /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
+    // /// <exception cref="ObjectDisposedException">The file stream has been disposed</exception>
+    // /// <exception cref="NotSupportedException">The file stream cannot be read from</exception>
+    // /// <exception cref="InvalidOperationException">The file stream is currently in a read operation</exception>
+    // /// <exception cref="AccessDeniedException">For encrypted PUT operation, Access is denied if the key is wrong</exception>
+    // private async Task<PutObjectResponse> PutObjectSinglePartAsync(PutObjectArgs args,
+    //     CancellationToken cancellationToken = default)
+    // {
+    //     //Skipping validate as we need the case where stream sends 0 bytes
+    //     // if (args.ObjectSize < Constants.MinimumPartSize && args.ObjectSize >= 0)
+    //     // {
+    //         var progressReport = new ProgressReport();
+    //         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
+    //         using var response =
+    //             await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
+    //                     cancellationToken: cancellationToken)
+    //                 .ConfigureAwait(false);
+    //         var PutStatusCode = response.StatusCode;
+    //         // if (args.Progress is not null)
+
+    //         // {
+    //             // Console.WriteLine("\n\n\n ******   Inside Progress is NOT Null   ******\n\n\n");
+    //             var statArgs = new StatObjectArgs()
+    //                 .WithBucket(args.BucketName)
+    //                 .WithObject(args.ObjectName);
+    //             var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
+    //             if (PutStatusCode == HttpStatusCode.OK &&
+    //                 args.Progress is not null &&
+    //                 args.ObjectSize <= Constants.MinimumPUTPartSize)
+    //             {
+    //                 Console.WriteLine("\n\n\n ******   Inside PutStatusCode is HttpStatusCode.OK  ******\n\n\n");
+    //                 progressReport.Percentage = 100;
+    //                 progressReport.TotalBytesTransferred = stat.Size;
+    //             }
+
+    //             args.Progress.Report(progressReport);
+    //         // }
+
+    //         return new PutObjectResponse(response.StatusCode, response.Content, response.Headers,
+    //             args.ObjectSize, args.ObjectName);
+    //     // }
+
+    //     // The size should never be more than `Constants.MinimumPartSize`
+    //     // Throws an exception
+    //     // throw new Exception($"Unexpected file size, {args.ObjectSize} cannot be > {Constants.MinimumPartSize}");
+    // }
 
     /// <summary>
     ///     Upload object in multiple parts. Private Helper function

--- a/Minio/DataModel/Args/PutObjectArgs.cs
+++ b/Minio/DataModel/Args/PutObjectArgs.cs
@@ -42,6 +42,7 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         PartNumber = args.PartNumber;
         SSE = args.SSE;
         UploadId = args.UploadId;
+        Progress = args.Progress;
     }
 
     internal string UploadId { get; private set; }


### PR DESCRIPTION
Progress' transferred data is not updated from time to time during the build functional tests and causes the transferred data/object size assertion in test is `PutObject_Test9` to fail.
This happens randomly and only during the build testing and I cannot reproduce this issue in my local environment.
That's why I created this PR to test if this fix is a correct workaround or not.
If the same problem keeps happening again, then I will revert the change back. 