### PR TITLE
Fix progress timing for `PutObject_Test9 ` test (fixes #1078)

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -1874,6 +1874,7 @@ try
     var ssec = new SSEC(aesEncryption.Key);
     var progress = new Progress<ProgressReport>(progressReport =>
     {
+        // Progress events are delivered asynchronously (see remark below)
         Console.WriteLine(
                 $"Percentage: {progressReport.Percentage}% TotalBytesTransferred: {progressReport.TotalBytesTransferred} bytes");
         if (progressReport.Percentage != 100)
@@ -1895,7 +1896,14 @@ catch(MinioException e)
     Console.WriteLine("Error occurred: " + e);
 }
 ```
-
+**Remark:** 
+Note that the default [Progress<T> class](https://learn.microsoft.com/en-us/dotnet/api/System.Progress-1) post progress
+updates to the SynchronizationContext when the instance was constructed
+([source](https://learn.microsoft.com/en-us/dotnet/api/system.progress-1#remarks)). This means that progress updates are
+sent asynchronous. If you do want to receive the events synchronous, then use the `Minio.Helper.SyncProgress<T>` instead,
+but make sure you understand the implications. Progress events are sent synchronous, so they may be invoked on an
+arbitrary thread (mostly a problem for UI applications) and performing long-running and/or blocking operations will
+degrade upload performance.
 
 <a name="statObject"></a>
 ### StatObjectAsync(StatObjectArgs args)

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -24,6 +24,7 @@ using Minio.DataModel.Encryption;
 using Minio.DataModel.Notification;
 using Minio.DataModel.ObjectLock;
 using Minio.Examples.Cases;
+using Minio.Helper;
 
 namespace Minio.Examples;
 
@@ -110,7 +111,7 @@ public static class Program
         var destBucketName = GetRandomName();
         var destObjectName = GetRandomName();
         var lockBucketName = GetRandomName();
-        var progress = new Progress<ProgressReport>(progressReport =>
+        var progress = new SyncProgress<ProgressReport>(progressReport =>
         {
             Console.WriteLine(
                 $"Percentage: {progressReport.Percentage}% TotalBytesTransferred: {progressReport.TotalBytesTransferred} bytes");

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3552,7 +3552,7 @@ public static class FunctionalTest
         var contentType = "binary/octet-stream";
         var percentage = 0;
         var totalBytesTransferred = 0L;
-        var progress = new Progress<ProgressReport>(progressReport =>
+        var progress = new SyncProgress<ProgressReport>(progressReport =>
         {
             percentage = progressReport.Percentage;
             totalBytesTransferred = progressReport.TotalBytesTransferred;

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -3495,7 +3495,7 @@ public static class FunctionalTest
         const string contentType = "application/octet-stream";
         var percentage = 0;
         var totalBytesTransferred = 0L;
-        var progress = new Progress<ProgressReport>(progressReport =>
+        var progress = new SyncProgress<ProgressReport>(progressReport =>
         {
             percentage = progressReport.Percentage;
             totalBytesTransferred = progressReport.TotalBytesTransferred;

--- a/Minio/Helper/SyncProgress.cs
+++ b/Minio/Helper/SyncProgress.cs
@@ -1,0 +1,29 @@
+﻿namespace Minio.Helper;
+
+/// <summary>
+/// SyncProgress is a thread-free alternative to <see cref="System.Progress&lt;T&gt;"/>
+/// and should be used if progress needs be determined in real-time.
+/// </summary>
+/// <typeparam name="T"></typeparam>
+/// <remarks>
+/// The upload process uses asynchronous tasks to perform the upload,
+/// so these events may be invoked on an arbitrary thread. Use the
+/// regular <see cref="System.Progress&lt;T&gt;"/> if you need progress
+/// to be reported on a fixed thread or provide your own thread
+/// synchronization. Doing synchronous calls to other threads from
+/// within this handler will degrade your upload performance.
+/// </remarks>
+public class SyncProgress<T> : IProgress<T>
+{
+    private readonly Action<T> handler;
+
+    public SyncProgress(Action<T> handler)
+    {
+        this.handler = handler;
+    }
+    
+    public void Report(T value)
+    {
+        handler(value);
+    }
+}

--- a/Minio/Helper/SyncProgress.cs
+++ b/Minio/Helper/SyncProgress.cs
@@ -1,17 +1,17 @@
 ﻿namespace Minio.Helper;
 
 /// <summary>
-/// SyncProgress is a thread-free alternative to <see cref="System.Progress&lt;T&gt;"/>
-/// and should be used if progress needs be determined in real-time.
+///     SyncProgress is a thread-free alternative to <see cref="System.Progress&lt;T&gt;" />
+///     and should be used if progress needs be determined in real-time.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 /// <remarks>
-/// The upload process uses asynchronous tasks to perform the upload,
-/// so these events may be invoked on an arbitrary thread. Use the
-/// regular <see cref="System.Progress&lt;T&gt;"/> if you need progress
-/// to be reported on a fixed thread or provide your own thread
-/// synchronization. Doing synchronous calls to other threads from
-/// within this handler will degrade your upload performance.
+///     The upload process uses asynchronous tasks to perform the upload,
+///     so these events may be invoked on an arbitrary thread. Use the
+///     regular <see cref="System.Progress&lt;T&gt;" /> if you need progress
+///     to be reported on a fixed thread or provide your own thread
+///     synchronization. Doing synchronous calls to other threads from
+///     within this handler will degrade your upload performance.
 /// </remarks>
 public class SyncProgress<T> : IProgress<T>
 {
@@ -21,7 +21,7 @@ public class SyncProgress<T> : IProgress<T>
     {
         this.handler = handler;
     }
-    
+
     public void Report(T value)
     {
         handler(value);


### PR DESCRIPTION
Fixes timing issue when running progress test. I have introduced a `SyncProgress` class that invokes progress updates synchronously and on the thread that is currently executing. Although not suitable for UI applications (that require UI updates to be done on the main-thread), it's perfectly fine for other situations.