### PR TITLE
Fixed two minor issues in `PresignedGetObjectAsync` and `PresignedPostPolicyAsync`

### DIFF
--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -219,14 +219,11 @@ public partial class MinioClient : IObjectOperations
 
         var authenticator = new V4Authenticator(Config.Secure, Config.AccessKey, Config.SecretKey,
             region, Config.SessionToken);
-
-        // Get base64 encoded policy.
-        var policyBase64 = args.Policy.Base64();
-
+        
         var t = DateTime.UtcNow;
         const string signV4Algorithm = "AWS4-HMAC-SHA256";
         var credential = authenticator.GetCredentialString(t, region);
-        var signature = authenticator.PresignPostSignature(region, t, policyBase64);
+
         args = args.WithDate(t)
             .WithAlgorithm(signV4Algorithm)
             .WithSessionToken(Config.SessionToken)
@@ -238,13 +235,19 @@ public partial class MinioClient : IObjectOperations
         // args.Policy.formData["key"] = "\\\"" + args.ObjectName + "\\\"";
 
         args.Policy.FormData["key"] = args.ObjectName;
-
-        args.Policy.FormData["policy"] = policyBase64;
+        
         args.Policy.FormData["x-amz-algorithm"] = signV4Algorithm;
         args.Policy.FormData["x-amz-credential"] = credential;
         args.Policy.FormData["x-amz-date"] = t.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
+
         if (!string.IsNullOrEmpty(Config.SessionToken))
             args.Policy.FormData["x-amz-security-token"] = Config.SessionToken;
+        
+        // Get base64 encoded policy.
+        var policyBase64 = args.Policy.Base64();
+        args.Policy.FormData["policy"] = policyBase64;
+        
+        var signature = authenticator.PresignPostSignature(region, t, policyBase64);
         args.Policy.FormData["x-amz-signature"] = signature;
 
         Config.Uri = RequestUtil.MakeTargetURL(Config.BaseUrl, Config.Secure, args.BucketName, region, false);

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -219,7 +219,7 @@ public partial class MinioClient : IObjectOperations
 
         var authenticator = new V4Authenticator(Config.Secure, Config.AccessKey, Config.SecretKey,
             region, Config.SessionToken);
-        
+
         var t = DateTime.UtcNow;
         const string signV4Algorithm = "AWS4-HMAC-SHA256";
         var credential = authenticator.GetCredentialString(t, region);
@@ -235,18 +235,18 @@ public partial class MinioClient : IObjectOperations
         // args.Policy.formData["key"] = "\\\"" + args.ObjectName + "\\\"";
 
         args.Policy.FormData["key"] = args.ObjectName;
-        
+
         args.Policy.FormData["x-amz-algorithm"] = signV4Algorithm;
         args.Policy.FormData["x-amz-credential"] = credential;
         args.Policy.FormData["x-amz-date"] = t.ToString("yyyyMMddTHHmmssZ", CultureInfo.InvariantCulture);
 
         if (!string.IsNullOrEmpty(Config.SessionToken))
             args.Policy.FormData["x-amz-security-token"] = Config.SessionToken;
-        
+
         // Get base64 encoded policy.
         var policyBase64 = args.Policy.Base64();
         args.Policy.FormData["policy"] = policyBase64;
-        
+
         var signature = authenticator.PresignPostSignature(region, t, policyBase64);
         args.Policy.FormData["x-amz-signature"] = signature;
 

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -8,6 +8,8 @@
 		<PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
 		<Description>MinIO .NET SDK for Amazon S3 Compatible Cloud Storage.</Description>
 		<Product>Minio</Product>
+		<PackageId>Minio-HeaderFix</PackageId>
+		<Version>6.0.5</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -8,8 +8,6 @@
 		<PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>
 		<Description>MinIO .NET SDK for Amazon S3 Compatible Cloud Storage.</Description>
 		<Product>Minio</Product>
-		<PackageId>Minio-HeaderFix</PackageId>
-		<Version>6.0.8</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -9,7 +9,7 @@
 		<Description>MinIO .NET SDK for Amazon S3 Compatible Cloud Storage.</Description>
 		<Product>Minio</Product>
 		<PackageId>Minio-HeaderFix</PackageId>
-		<Version>6.0.5</Version>
+		<Version>6.0.8</Version>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -467,10 +467,7 @@ internal class V4Authenticator
         foreach (var header in headers)
         {
             var headerName = header.Key.ToLowerInvariant();
-            if (string.Equals(header.Key, "versionId", StringComparison.Ordinal))
-            {
-                headerName = "versionId";
-            }
+            if (string.Equals(header.Key, "versionId", StringComparison.Ordinal)) headerName = "versionId";
             var headerValue = header.Value;
 
             if (!ignoredHeaders.Contains(headerName)) sortedHeaders.Add(headerName, headerValue);

--- a/Minio/V4Authenticator.cs
+++ b/Minio/V4Authenticator.cs
@@ -467,6 +467,10 @@ internal class V4Authenticator
         foreach (var header in headers)
         {
             var headerName = header.Key.ToLowerInvariant();
+            if (string.Equals(header.Key, "versionId", StringComparison.Ordinal))
+            {
+                headerName = "versionId";
+            }
             var headerValue = header.Value;
 
             if (!ignoredHeaders.Contains(headerName)) sortedHeaders.Add(headerName, headerValue);


### PR DESCRIPTION
Fixed two minor issues:

1. When using `PresignedGetObjectAsync`, specify `WithHeaders(new Dictionary<string, string> { { "versionId", version } })`, and the specific version file cannot be obtained.
2. When using `PresignedPostPolicyAsync`, the server returns the error `Access Denied. (Each form field that you specify in a form (except X-Amz-Date, X-Amz-Algorithm, X-Amz-Credential) must appear in the list of conditions.)`