### PR TITLE
Fix objects with spaces in name not returned correctly fixes #1100

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -5335,6 +5335,50 @@ public static class FunctionalTest
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
+    
+    internal static async Task ListObjects_Test8(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var prefix = "minix+";
+        var objectName = prefix + GetRandomName(10);
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "prefix", prefix },
+                { "recursive", "false" }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            var tasks = new Task[2];
+            for (var i = 0; i < 2; i++)
+                tasks[i] = PutObject_Task(minio, bucketName, objectName + i, null, null, 0, null,
+                    rsg.GenerateStreamFromSeed(1));
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            await ListObjects_Test(minio, bucketName, prefix, 2, false).ConfigureAwait(false);
+            new MintLogger("ListObjects_Test8", listObjectsSignature,
+                "Tests whether ListObjects lists all objects matching a prefix with a plus non-recursive",
+                TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("ListObjects_Test8", listObjectsSignature,
+                "Tests whether ListObjects lists all objects matching a prefix with a plus non-recursive",
+                TestStatus.FAIL,
+                DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
 
     internal static async Task ListObjectVersions_Test1(IMinioClient minio)
     {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -5291,7 +5291,7 @@ public static class FunctionalTest
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
-    
+
     internal static async Task ListObjects_Test7(IMinioClient minio)
     {
         var startTime = DateTime.Now;
@@ -5318,13 +5318,15 @@ public static class FunctionalTest
 
             await ListObjects_Test(minio, bucketName, prefix, 2, false).ConfigureAwait(false);
             new MintLogger("ListObjects_Test7", listObjectsSignature,
-                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive", TestStatus.PASS,
+                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive",
+                TestStatus.PASS,
                 DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
             new MintLogger("ListObjects_Test7", listObjectsSignature,
-                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive", TestStatus.FAIL,
+                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive",
+                TestStatus.FAIL,
                 DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -5291,6 +5291,48 @@ public static class FunctionalTest
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
+    
+    internal static async Task ListObjects_Test7(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var prefix = "minix ";
+        var objectName = prefix + GetRandomName(10);
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "prefix", prefix },
+                { "recursive", "false" }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            var tasks = new Task[2];
+            for (var i = 0; i < 2; i++)
+                tasks[i] = PutObject_Task(minio, bucketName, objectName + i, null, null, 0, null,
+                    rsg.GenerateStreamFromSeed(1));
+
+            await Task.WhenAll(tasks).ConfigureAwait(false);
+
+            await ListObjects_Test(minio, bucketName, prefix, 2, false).ConfigureAwait(false);
+            new MintLogger("ListObjects_Test7", listObjectsSignature,
+                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive", TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("ListObjects_Test7", listObjectsSignature,
+                "Tests whether ListObjects lists all objects matching a prefix with a space non-recursive", TestStatus.FAIL,
+                DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
 
     internal static async Task ListObjectVersions_Test1(IMinioClient minio)
     {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -5335,7 +5335,7 @@ public static class FunctionalTest
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
-    
+
     internal static async Task ListObjects_Test8(IMinioClient minio)
     {
         var startTime = DateTime.Now;

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -177,6 +177,7 @@ internal static class Program
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test7(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test8(minioClient));
 
         // Test RemoveObjectAsync function
         functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -176,6 +176,7 @@ internal static class Program
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test4(minioClient));
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test5(minioClient));
         functionalTestTasks.Add(FunctionalTest.ListObjects_Test6(minioClient));
+        functionalTestTasks.Add(FunctionalTest.ListObjects_Test7(minioClient));
 
         // Test RemoveObjectAsync function
         functionalTestTasks.Add(FunctionalTest.RemoveObject_Test1(minioClient));

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -19,6 +19,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Reactive.Linq;
 using System.Runtime.CompilerServices;
+using System.Web;
 using System.Xml.Linq;
 using CommunityToolkit.HighPerformance;
 using Minio.ApiEndpoints;
@@ -271,7 +272,7 @@ public partial class MinioClient : IBucketOperations
 
                 var objectKey = t.Element(ns + "Key")?.Value;
                 if (objectKey != null)
-                    objectKey = Uri.UnescapeDataString(objectKey);
+                    objectKey = HttpUtility.UrlDecode(objectKey);
 
                 return new Item
                 {


### PR DESCRIPTION
The Uri.UnescapeDataString method has been replaced with the HttpUtility.UrlDecode method in the BucketOperations.cs file to correctly decode the item Key. Additionally, the ListObjects_Test7 function has been added to the functional tests to test whether ListObjects lists all objects matching a prefix with a space in a non-recursive manner.