### PR TITLE
Add support for listening to global events

### DIFF
--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -38,6 +38,9 @@ internal static class ListenNotifications
                 notification => Console.WriteLine($"Notification: {notification.Json}"),
                 ex => Console.WriteLine($"OnError: {ex}"),
                 () => Console.WriteLine("Stopped listening for bucket notifications\n"));
+
+            Console.WriteLine("Press any key to stop listening for notifications...");
+            Console.ReadLine();
         }
         catch (Exception e)
         {

--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -21,7 +21,7 @@ namespace Minio.Examples.Cases;
 
 internal static class ListenNotifications
 {
-    // Listen for notifications from a specified bucket (a Minio-only extension)
+    // Listen for gloabal notifications (a Minio-only extension)
     public static void Run(IMinioClient minio,
         List<EventType> events = null,
         string prefix = "",
@@ -31,11 +31,8 @@ internal static class ListenNotifications
         {
             Console.WriteLine("Running example for API: ListenNotifications");
             Console.WriteLine();
-            events ??= new List<EventType> { EventType.ObjectCreatedAll };
-            var args = new ListenBucketNotificationsArgs()
-                .WithPrefix(prefix)
-                .WithEvents(events)
-                .WithSuffix(suffix);
+            events ??= new List<EventType> { EventType.BucketCreatedAll };
+            var args = new ListenBucketNotificationsArgs().WithEvents(events);
             var observable = minio.ListenNotificationsAsync(events, prefix, suffix);
 
             var subscription = observable.Subscribe(

--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -23,9 +23,7 @@ internal static class ListenNotifications
 {
     // Listen for gloabal notifications (a Minio-only extension)
     public static void Run(IMinioClient minio,
-        List<EventType> events = null,
-        string prefix = "",
-        string suffix = "")
+        List<EventType> events = null)
     {
         try
         {
@@ -33,7 +31,7 @@ internal static class ListenNotifications
             Console.WriteLine();
             events ??= new List<EventType> { EventType.BucketCreatedAll };
             var args = new ListenBucketNotificationsArgs().WithEvents(events);
-            var observable = minio.ListenNotificationsAsync(events, prefix, suffix);
+            var observable = minio.ListenNotificationsAsync(events);
 
             var subscription = observable.Subscribe(
                 notification => Console.WriteLine($"Notification: {notification.Json}"),

--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -25,6 +25,7 @@ internal static class ListenNotifications
     public static void Run(IMinioClient minio,
         List<EventType> events = null)
     {
+        IDisposable subscription = null;
         try
         {
             Console.WriteLine("Running example for API: ListenNotifications");
@@ -33,16 +34,18 @@ internal static class ListenNotifications
             var args = new ListenBucketNotificationsArgs().WithEvents(events);
             var observable = minio.ListenNotificationsAsync(events);
 
-            var subscription = observable.Subscribe(
+            subscription = observable.Subscribe(
                 notification => Console.WriteLine($"Notification: {notification.Json}"),
                 ex => Console.WriteLine($"OnError: {ex}"),
                 () => Console.WriteLine("Stopped listening for bucket notifications\n"));
-
-            // subscription.Dispose();
         }
         catch (Exception e)
         {
             Console.WriteLine($"[Bucket]  Exception: {e}");
+        }
+        finally
+        {
+            subscription?.Dispose();
         }
     }
 }

--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -1,5 +1,5 @@
 /*
- * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2024 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -1,0 +1,53 @@
+/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2020 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Minio.DataModel.Args;
+using Minio.DataModel.Notification;
+
+namespace Minio.Examples.Cases;
+
+internal static class ListenNotifications
+{
+    // Listen for notifications from a specified bucket (a Minio-only extension)
+    public static void Run(IMinioClient minio,
+        List<EventType> events = null,
+        string prefix = "",
+        string suffix = "")
+    {
+        try
+        {
+            Console.WriteLine("Running example for API: ListenNotifications");
+            Console.WriteLine();
+            events ??= new List<EventType> { EventType.ObjectCreatedAll };
+            var args = new ListenBucketNotificationsArgs()
+                .WithPrefix(prefix)
+                .WithEvents(events)
+                .WithSuffix(suffix);
+            var observable = minio.ListenNotificationsAsync(events, prefix, suffix);
+
+            var subscription = observable.Subscribe(
+                notification => Console.WriteLine($"Notification: {notification.Json}"),
+                ex => Console.WriteLine($"OnError: {ex}"),
+                () => Console.WriteLine("Stopped listening for bucket notifications\n"));
+
+            // subscription.Dispose();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"[Bucket]  Exception: {e}");
+        }
+    }
+}

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -152,6 +152,9 @@ public static class Program
         // Start listening for bucket notifications
         ListenBucketNotifications.Run(minioClient, bucketName, new List<EventType> { EventType.ObjectCreatedAll });
 
+        // Start listening for global notifications
+        ListenNotifications.Run(minioClient, new List<EventType> { EventType.BucketCreatedAll });
+
         // Put an object to the new bucket
         await PutObject.Run(minioClient, bucketName, objectName, smallFileName, progress).ConfigureAwait(false);
 

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2647,8 +2647,6 @@ public static class FunctionalTest
             (StringComparer.Ordinal) { { "bucketName", bucketName } };
         try
         {
-            await Setup_Test(minio, bucketName).ConfigureAwait(false);
-
             var received = new List<MinioNotificationRaw>();
 
             var eventsList = new List<EventType> { EventType.BucketCreatedAll };
@@ -2663,10 +2661,10 @@ public static class FunctionalTest
             await Task.Delay(1000).ConfigureAwait(false);
 
             // Trigger the event by creating a new bucket
-            var isBucketCreated = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
+            var isBucketCreated1 = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
 
             var eventDetected = false;
-            for (var attempt = 0; attempt < 10; attempt++)
+            for (var attempt = 0; attempt < 20; attempt++)
             {
                 if (received.Count > 0)
                 {
@@ -2679,8 +2677,7 @@ public static class FunctionalTest
                         break;
                     }
                 }
-
-                await Task.Delay(1000).ConfigureAwait(false); // wait for 1 second before the next attempt
+                await Task.Delay(500).ConfigureAwait(false);  // Delay between attempts
             }
 
             subscription.Dispose();
@@ -2750,6 +2747,7 @@ public static class FunctionalTest
                 ex => { },
                 () => { }
             );
+
 
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType,
                 0, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
@@ -6002,7 +6000,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var contentType = "gzip";
         var args = new Dictionary<string, string>
-            (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
+             (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1043,7 +1043,8 @@ public static class FunctionalTest
         await minio.MakeBucketAsync(new MakeBucketArgs().WithBucket(bucketName)).ConfigureAwait(false);
 
         // Verify the bucket exists
-        var bucketExists = await minio.BucketExistsAsync(new BucketExistsArgs().WithBucket(bucketName)).ConfigureAwait(false);
+        var bucketExists = await minio.BucketExistsAsync(new BucketExistsArgs().WithBucket(bucketName))
+            .ConfigureAwait(false);
         Assert.IsTrue(bucketExists, $"Bucket {bucketName} was not created successfully.");
 
         return bucketExists;
@@ -2643,10 +2644,7 @@ public static class FunctionalTest
         var startTime = DateTime.Now;
         var bucketName = GetRandomName(15);
         var args = new Dictionary<string, string>
-            (StringComparer.Ordinal)
-            {
-                { "bucketName", bucketName },
-            };
+            (StringComparer.Ordinal) { { "bucketName", bucketName } };
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
@@ -2660,13 +2658,13 @@ public static class FunctionalTest
                 received.Add,
                 ex => Console.WriteLine($"OnError: {ex}"),
                 () => Console.WriteLine("Stopped listening for bucket notifications\n"));
-           
+
             // Ensure the subscription is established
             await Task.Delay(1000).ConfigureAwait(false);
 
             // Trigger the event by creating a new bucket
             var isBucketCreated = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
-        
+
             var eventDetected = false;
             for (var attempt = 0; attempt < 10; attempt++)
             {
@@ -2681,9 +2679,10 @@ public static class FunctionalTest
                         break;
                     }
                 }
+
                 await Task.Delay(1000).ConfigureAwait(false); // wait for 1 second before the next attempt
             }
-            
+
             subscription.Dispose();
             if (!eventDetected)
                 throw new UnexpectedMinioException("Failed to detect the expected bucket notification event.");
@@ -6003,7 +6002,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var contentType = "gzip";
         var args = new Dictionary<string, string>
-             (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
+            (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -83,6 +83,9 @@ public static class FunctionalTest
     private const string listenBucketNotificationsSignature =
         "IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(ListenBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
 
+    private const string listenNotificationsSignature =
+        "IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default(CancellationToken))";
+
     private const string copyObjectSignature =
         "Task<CopyObjectResult> CopyObjectAsync(CopyObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
 
@@ -1032,6 +1035,18 @@ public static class FunctionalTest
         }
 
         return statObject;
+    }
+
+    internal static async Task<bool> CreateBucket_Tester(IMinioClient minio, string bucketName)
+    {
+        // Create a new bucket
+        await minio.MakeBucketAsync(new MakeBucketArgs().WithBucket(bucketName)).ConfigureAwait(false);
+
+        // Verify the bucket exists
+        var bucketExists = await minio.BucketExistsAsync(new BucketExistsArgs().WithBucket(bucketName)).ConfigureAwait(false);
+        Assert.IsTrue(bucketExists, $"Bucket {bucketName} was not created successfully.");
+
+        return bucketExists;
     }
 
     internal static async Task StatObject_Test1(IMinioClient minio)
@@ -2620,6 +2635,88 @@ public static class FunctionalTest
             await TearDown(minio, bucketName).ConfigureAwait(false);
         }
     }
+
+    #region Global Notifications
+
+    internal static async Task ListenNotificationsAsync_Test1(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+
+            var received = new List<MinioNotificationRaw>();
+
+            var eventsList = new List<EventType> { EventType.BucketCreatedAll };
+
+            var events = minio.ListenNotificationsAsync(eventsList);
+            var subscription = events.Subscribe(
+                received.Add,
+                ex => Console.WriteLine($"OnError: {ex}"),
+                () => Console.WriteLine("Stopped listening for bucket notifications\n"));
+           
+            // Ensure the subscription is established
+            await Task.Delay(1000).ConfigureAwait(false);
+
+            // Trigger the event by creating a new bucket
+            var isBucketCreated = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
+        
+            var eventDetected = false;
+            for (var attempt = 0; attempt < 10; attempt++)
+            {
+                if (received.Count > 0)
+                {
+                    var notification = JsonSerializer.Deserialize<MinioNotification>(received[0].Json);
+
+                    if (notification.Records is not null)
+                    {
+                        Assert.AreEqual(1, notification.Records.Count);
+                        eventDetected = true;
+                        break;
+                    }
+                }
+                await Task.Delay(1000).ConfigureAwait(false); // wait for 1 second before the next attempt
+            }
+            
+            subscription.Dispose();
+            if (!eventDetected)
+                throw new UnexpectedMinioException("Failed to detect the expected bucket notification event.");
+
+            new MintLogger(nameof(ListenNotificationsAsync_Test1),
+                listenNotificationsSignature,
+                "Tests whether ListenNotifications passes",
+                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+        }
+        catch (NotImplementedException ex)
+        {
+            new MintLogger(nameof(ListenNotificationsAsync_Test1),
+                listenNotificationsSignature,
+                "Tests whether ListenNotifications passes",
+                TestStatus.NA, DateTime.Now - startTime, ex.Message,
+                ex.ToString(), args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger(nameof(ListenNotificationsAsync_Test1),
+                listenNotificationsSignature,
+                "Tests whether ListenNotifications passes",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
+                ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
+
+    #endregion
 
     #region Bucket Notifications
 
@@ -5906,7 +6003,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var contentType = "gzip";
         var args = new Dictionary<string, string>
-            (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
+             (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2677,7 +2677,8 @@ public static class FunctionalTest
                         break;
                     }
                 }
-                await Task.Delay(500).ConfigureAwait(false);  // Delay between attempts
+
+                await Task.Delay(500).ConfigureAwait(false); // Delay between attempts
             }
 
             subscription.Dispose();
@@ -6000,7 +6001,7 @@ public static class FunctionalTest
         var objectName = GetRandomObjectName(10);
         var contentType = "gzip";
         var args = new Dictionary<string, string>
-             (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
+            (StringComparer.Ordinal) { { "bucketName", bucketName }, { "recursive", "true" } };
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -107,6 +107,9 @@ internal static class Program
 
         ConcurrentBag<Task> functionalTestTasks = new();
 
+        // Global Notification
+        await FunctionalTest.ListenNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
+
         // Try catch as 'finally' section needs to run in the Functional Tests
         // Bucket notification is a minio specific feature.
         // If the following test is run against AWS, then the SDK throws

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -776,6 +776,8 @@ public partial class MinioClient : IBucketOperations
     /// </summary>
     /// <param name="bucketName">Bucket to get notifications from</param>
     /// <param name="events">Events to listen for</param>
+    /// <param name="prefix">Filter keys starting with this prefix</param>
+    /// <param name="suffix">Filter keys ending with this suffix</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
     public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -782,12 +782,16 @@ public partial class MinioClient : IBucketOperations
     public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(
         string bucketName,
         IList<EventType> events,
+        string prefix = "",
+        string suffix = "",
         CancellationToken cancellationToken = default)
     {
         var eventList = new List<EventType>(events);
         var args = new ListenBucketNotificationsArgs()
             .WithBucket(bucketName)
-            .WithEvents(eventList);
+            .WithEvents(eventList)
+            .WithPrefix(prefix)
+            .WithSuffix(suffix);
         return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -765,7 +765,8 @@ public partial class MinioClient : IBucketOperations
     /// <param name="events">Events to listen for</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
-    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default)
+    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
+        CancellationToken cancellationToken = default)
     {
         var args = new ListenBucketNotificationsArgs().WithEvents(events);
         return ListenBucketNotificationsAsync(args, cancellationToken);

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -765,11 +765,10 @@ public partial class MinioClient : IBucketOperations
     /// <param name="events">Events to listen for</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
-    public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(
-        IList<EventType> events,
-        CancellationToken cancellationToken = default)
+    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, string prefix = "", string suffix = "", CancellationToken cancellationToken = default)
     {
-        return ListenNotificationsAsync(events, cancellationToken);
+        var args = new ListenBucketNotificationsArgs().WithEvents(events);
+        return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 
     /// <summary>
@@ -858,11 +857,5 @@ public partial class MinioClient : IBucketOperations
             await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
-    }
-
-    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default)
-    {
-        var args = new ListenBucketNotificationsArgs().WithEvents(events);
-        return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 }

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -760,6 +760,23 @@ public partial class MinioClient : IBucketOperations
     }
 
     /// <summary>
+    ///     Subscribes to global change notifications (a Minio-only extension)
+    /// </summary>
+    /// <param name="events">Events to listen for</param>
+    /// <param name="prefix">Filter keys starting with this prefix</param>
+    /// <param name="suffix">Filter keys ending with this suffix</param>
+    /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
+    /// <returns>An observable of JSON-based notification events</returns>
+    public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(
+        IList<EventType> events,
+        string prefix = "",
+        string suffix = "",
+        CancellationToken cancellationToken = default)
+    {
+        return ListenNotificationsAsync(events, prefix, suffix, cancellationToken);
+    }
+
+    /// <summary>
     ///     Subscribes to bucket change notifications (a Minio-only extension)
     /// </summary>
     /// <param name="bucketName">Bucket to get notifications from</param>
@@ -847,5 +864,14 @@ public partial class MinioClient : IBucketOperations
             await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
+    }
+
+    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, string prefix = "", string suffix = "", CancellationToken cancellationToken = default)
+    {
+        var args = new ListenBucketNotificationsArgs()
+            .WithEvents(events)
+            .WithPrefix(prefix)
+            .WithSuffix(suffix);
+        return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 }

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -765,7 +765,7 @@ public partial class MinioClient : IBucketOperations
     /// <param name="events">Events to listen for</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
-    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, string prefix = "", string suffix = "", CancellationToken cancellationToken = default)
+    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default)
     {
         var args = new ListenBucketNotificationsArgs().WithEvents(events);
         return ListenBucketNotificationsAsync(args, cancellationToken);

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -763,17 +763,13 @@ public partial class MinioClient : IBucketOperations
     ///     Subscribes to global change notifications (a Minio-only extension)
     /// </summary>
     /// <param name="events">Events to listen for</param>
-    /// <param name="prefix">Filter keys starting with this prefix</param>
-    /// <param name="suffix">Filter keys ending with this suffix</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
     public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(
         IList<EventType> events,
-        string prefix = "",
-        string suffix = "",
         CancellationToken cancellationToken = default)
     {
-        return ListenNotificationsAsync(events, prefix, suffix, cancellationToken);
+        return ListenNotificationsAsync(events, cancellationToken);
     }
 
     /// <summary>
@@ -781,23 +777,17 @@ public partial class MinioClient : IBucketOperations
     /// </summary>
     /// <param name="bucketName">Bucket to get notifications from</param>
     /// <param name="events">Events to listen for</param>
-    /// <param name="prefix">Filter keys starting with this prefix</param>
-    /// <param name="suffix">Filter keys ending with this suffix</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
     public IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(
         string bucketName,
         IList<EventType> events,
-        string prefix = "",
-        string suffix = "",
         CancellationToken cancellationToken = default)
     {
         var eventList = new List<EventType>(events);
         var args = new ListenBucketNotificationsArgs()
             .WithBucket(bucketName)
-            .WithEvents(eventList)
-            .WithPrefix(prefix)
-            .WithSuffix(suffix);
+            .WithEvents(eventList);
         return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 
@@ -866,12 +856,9 @@ public partial class MinioClient : IBucketOperations
                 .ConfigureAwait(false);
     }
 
-    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, string prefix = "", string suffix = "", CancellationToken cancellationToken = default)
+    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default)
     {
-        var args = new ListenBucketNotificationsArgs()
-            .WithEvents(events)
-            .WithPrefix(prefix)
-            .WithSuffix(suffix);
+        var args = new ListenBucketNotificationsArgs().WithEvents(events);
         return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 }

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -379,6 +379,9 @@ public interface IBucketOperations
 
     Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default);
 
+    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
+        string prefix = "", string suffix = "", CancellationToken cancellationToken = default);
+
     IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(string bucketName, IList<EventType> events,
         string prefix = "", string suffix = "", CancellationToken cancellationToken = default);
 

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -379,7 +379,8 @@ public interface IBucketOperations
 
     Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default);
 
-    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default);
+    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
+        CancellationToken cancellationToken = default);
 
     IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(string bucketName, IList<EventType> events,
         string prefix = "", string suffix = "", CancellationToken cancellationToken = default);

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -379,8 +379,7 @@ public interface IBucketOperations
 
     Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default);
 
-    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
-        string prefix = "", string suffix = "", CancellationToken cancellationToken = default);
+    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events, CancellationToken cancellationToken = default);
 
     IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(string bucketName, IList<EventType> events,
         string prefix = "", string suffix = "", CancellationToken cancellationToken = default);

--- a/Minio/DataModel/Notification/EventType.cs
+++ b/Minio/DataModel/Notification/EventType.cs
@@ -43,6 +43,9 @@ public sealed class EventType
     public static readonly EventType ObjectRemovedDeleteMarkerCreated = new("s3:ObjectRemoved:DeleteMarkerCreated");
     public static readonly EventType ReducedRedundancyLostObject = new("s3:ReducedRedundancyLostObject");
 
+    public static readonly EventType BucketCreatedAll = new("s3:BucketCreated:*");
+    public static readonly EventType BucketRemovedAll = new("s3:BucketRemoved:*");
+
     private EventType()
     {
         Value = null;


### PR DESCRIPTION
This PR implements the following:

- Introduce two new types of EventType that represent global events ( s3:BucketCreated:* and s3:BucketRemoved:*)
- Add `ListenNotificationsAsync`  that uses `ListenBucketNotificationsAsync` to listen for global notifications without a bucket name set

Resolves [ #1109](https://github.com/minio/minio-dotnet/issues/1109)