### PR TITLE
Adds missing parts of the fix in PR #1110

### DIFF
--- a/Minio.Examples/Cases/ListenNotifications.cs
+++ b/Minio.Examples/Cases/ListenNotifications.cs
@@ -32,7 +32,7 @@ internal static class ListenNotifications
             Console.WriteLine();
             events ??= new List<EventType> { EventType.BucketCreatedAll };
             var args = new ListenBucketNotificationsArgs().WithEvents(events);
-            var observable = minio.ListenNotificationsAsync(events);
+            var observable = minio.ListenNotifications(args);
 
             subscription = observable.Subscribe(
                 notification => Console.WriteLine($"Notification: {notification.Json}"),

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2658,7 +2658,7 @@ public static class FunctionalTest
                 () => { }
             );
 
-            await Task.Delay(75).ConfigureAwait(false);
+            await Task.Delay(150).ConfigureAwait(false);
             // Trigger the event by creating a new bucket
             _ = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
 

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1041,11 +1041,11 @@ public static class FunctionalTest
     {
         // Create a new bucket
         await minio.MakeBucketAsync(new MakeBucketArgs().WithBucket(bucketName)).ConfigureAwait(false);
+        await Task.Delay(1000).ConfigureAwait(false);
 
         // Verify the bucket exists
-        var bucketExists = await minio.BucketExistsAsync(new BucketExistsArgs().WithBucket(bucketName))
+        return await minio.BucketExistsAsync(new BucketExistsArgs().WithBucket(bucketName))
             .ConfigureAwait(false);
-        return bucketExists;
     }
 
     internal static async Task StatObject_Test1(IMinioClient minio)
@@ -2657,13 +2657,12 @@ public static class FunctionalTest
                 _ => { },
                 () => { }
             );
-
-            await Task.Delay(150).ConfigureAwait(false);
             // Trigger the event by creating a new bucket
             _ = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
 
             var eventDetected = false;
             for (var attempt = 0; attempt < 20; attempt++)
+            {
                 if (received.Count > 0)
                 {
                     // Check if there is any unexpected error returned
@@ -2704,6 +2703,7 @@ public static class FunctionalTest
                         break;
                     }
                 }
+            }
 
             subscription.Dispose();
             if (!eventDetected)
@@ -2773,13 +2773,13 @@ public static class FunctionalTest
                 () => { }
             );
 
-
             _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType,
                 0, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
 
             // wait for notifications
             var eventDetected = false;
             for (var attempt = 0; attempt < 10; attempt++)
+            {
                 if (received.Count > 0)
                 {
                     // Check if there is any unexpected error returned
@@ -2827,8 +2827,9 @@ public static class FunctionalTest
                         break;
                     }
                 }
+            }
 
-            // subscription.Dispose();
+            subscription.Dispose();
             if (!eventDetected)
                 throw new UnexpectedMinioException("Failed to detect the expected bucket notification event.");
 

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2662,7 +2662,6 @@ public static class FunctionalTest
 
             var eventDetected = false;
             for (var attempt = 0; attempt < 20; attempt++)
-            {
                 if (received.Count > 0)
                 {
                     // Check if there is any unexpected error returned
@@ -2703,7 +2702,6 @@ public static class FunctionalTest
                         break;
                     }
                 }
-            }
 
             subscription.Dispose();
             if (!eventDetected)
@@ -2779,7 +2777,6 @@ public static class FunctionalTest
             // wait for notifications
             var eventDetected = false;
             for (var attempt = 0; attempt < 10; attempt++)
-            {
                 if (received.Count > 0)
                 {
                     // Check if there is any unexpected error returned
@@ -2827,7 +2824,6 @@ public static class FunctionalTest
                         break;
                     }
                 }
-            }
 
             subscription.Dispose();
             if (!eventDetected)

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2648,21 +2648,23 @@ public static class FunctionalTest
             var received = new List<MinioNotificationRaw>();
             var eventsList = new List<EventType> { EventType.BucketCreatedAll };
 
+            // No need to define a new "ListenNotificationArgs"
+            // "ListenBucketNotificationsArgs" is good here
             var listenArgs = new ListenBucketNotificationsArgs()
                 .WithEvents(eventsList);
             var events = minio.ListenNotifications(listenArgs);
             var eventDetected = false;
             using (var subscription = events.Subscribe(
-                received.Add,
-                _ => { },
-                () => { }))
+                       received.Add,
+                       _ => { },
+                       () => { }))
             {
                 await Task.Delay(200).ConfigureAwait(false);
                 // Trigger the event by creating a new bucket
                 _ = await CreateBucket_Tester(minio, bucketName).ConfigureAwait(false);
             }
+
             for (var attempt = 0; attempt < 20; attempt++)
-            {
                 // Check if there is a caught event
                 if (received.Count == 1)
                 {
@@ -2677,18 +2679,14 @@ public static class FunctionalTest
                         break;
                     }
                 }
-            }
+
             if (eventDetected)
-            {
                 new MintLogger(nameof(ListenNotifications_Test1),
-                                listenNotificationsSignature,
-                                "Tests whether ListenNotifications notifies user about \"BucketCreatedAll\" event",
-                                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
-            }
+                    listenNotificationsSignature,
+                    "Tests whether ListenNotifications notifies user about \"BucketCreatedAll\" event",
+                    TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
             else
-            {
-                throw new UnexpectedMinioException("Failed to detect the expected bucket notification event.");
-            }
+                throw new UnexpectedMinioException("Failed to detect the expected notification event, \"BucketCreatedAll\".");
         }
         catch (Exception ex)
         {
@@ -2737,15 +2735,15 @@ public static class FunctionalTest
                 .WithEvents(eventsList);
             var events = minio.ListenBucketNotificationsAsync(listenArgs);
             using (var subscription = events.Subscribe(
-                received.Add,
-                _ => { },
-                () => { } ))
+                       received.Add,
+                       _ => { },
+                       () => { }))
             {
                 _ = await PutObject_Tester(minio, bucketName, objectName, null, contentType,
-                0, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
+                    0, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
             }
+
             for (var attempt = 0; attempt < 20; attempt++)
-            {
                 // Check if there is a caught event
                 if (received.Count == 1)
                 {
@@ -2764,24 +2762,19 @@ public static class FunctionalTest
                         break;
                     }
                 }
-            }
             if (eventDetected)
-            {
                 new MintLogger(nameof(ListenBucketNotificationsAsync_Test1),
                     listenBucketNotificationsSignature,
                     "Tests whether ListenBucketNotifications passes for small object",
                     TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
-            }
             else
-            {
                 throw new UnexpectedMinioException("Failed to detect the expected bucket notification event.");
-            }
         }
         catch (NotImplementedException ex)
         {
             new MintLogger(nameof(ListenBucketNotificationsAsync_Test1),
                 listenBucketNotificationsSignature,
-                "Tests whether ListenBucketNotifications passes for small object",
+                "Tests whether ListenBucketNotifications generates notification for a newly created object.",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message,
                 ex.ToString(), args: args).Log();
         }
@@ -2805,14 +2798,14 @@ public static class FunctionalTest
                     // This is a PASS
                     new MintLogger(nameof(ListenBucketNotificationsAsync_Test1),
                         listenBucketNotificationsSignature,
-                        "Tests whether ListenBucketNotifications creates notification for an object",
+                        "Tests whether ListenBucketNotifications generates notification for a newly created object.",
                         TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
             }
             else
             {
                 new MintLogger(nameof(ListenBucketNotificationsAsync_Test1),
                     listenBucketNotificationsSignature,
-                    "Tests whether ListenBucketNotifications creates notification for an object",
+                    "Tests whether ListenBucketNotifications generates notification for a newly created object.",
                     TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
                     ex.ToString(), args: args).Log();
                 throw;

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -2686,7 +2686,8 @@ public static class FunctionalTest
                     "Tests whether ListenNotifications notifies user about \"BucketCreatedAll\" event",
                     TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
             else
-                throw new UnexpectedMinioException("Failed to detect the expected notification event, \"BucketCreatedAll\".");
+                throw new UnexpectedMinioException(
+                    "Failed to detect the expected notification event, \"BucketCreatedAll\".");
         }
         catch (Exception ex)
         {
@@ -2762,6 +2763,7 @@ public static class FunctionalTest
                         break;
                     }
                 }
+
             if (eventDetected)
                 new MintLogger(nameof(ListenBucketNotificationsAsync_Test1),
                     listenBucketNotificationsSignature,

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -108,7 +108,7 @@ internal static class Program
         ConcurrentBag<Task> functionalTestTasks = new();
 
         // Global Notification
-        await FunctionalTest.ListenNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
+        await FunctionalTest.ListenNotifications_Test1(minioClient).ConfigureAwait(false);
 
         // Try catch as 'finally' section needs to run in the Functional Tests
         // Bucket notification is a minio specific feature.

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -762,13 +762,12 @@ public partial class MinioClient : IBucketOperations
     /// <summary>
     ///     Subscribes to global change notifications (a Minio-only extension)
     /// </summary>
-    /// <param name="events">Events to listen for</param>
+    /// <param name="args">ListenBucketNotificationsArgs to listen events</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>An observable of JSON-based notification events</returns>
-    public IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
+    public IObservable<MinioNotificationRaw> ListenNotifications(ListenBucketNotificationsArgs args,
         CancellationToken cancellationToken = default)
     {
-        var args = new ListenBucketNotificationsArgs().WithEvents(events);
         return ListenBucketNotificationsAsync(args, cancellationToken);
     }
 

--- a/Minio/ApiEndpoints/IBucketOperations.cs
+++ b/Minio/ApiEndpoints/IBucketOperations.cs
@@ -379,7 +379,7 @@ public interface IBucketOperations
 
     Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default);
 
-    IObservable<MinioNotificationRaw> ListenNotificationsAsync(IList<EventType> events,
+    IObservable<MinioNotificationRaw> ListenNotifications(ListenBucketNotificationsArgs args,
         CancellationToken cancellationToken = default);
 
     IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(string bucketName, IList<EventType> events,

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -25,7 +25,7 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4" />
 		<PackageReference Include="System.Net.Primitives" Version="4.3.1" />
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="System.Text.Json" Version="8.0.3" />
+		<PackageReference Include="System.Text.Json" Version="8.0.4" />
         <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
         <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
 	</ItemGroup>


### PR DESCRIPTION
After PR #1110 is merged, the functional test case added in PR #1110 started failing sporadically but frequently.
This PR fixes the timing issue and there were bunch of unnecessary code that is removed.