### PR TITLE
Fixes the missing exception throw action when an api request is executed, like BucketExistsAsync, etc.

### DIFF
--- a/FileUploader/FileUploader.csproj
+++ b/FileUploader/FileUploader.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Examples/Minio.Examples.csproj
+++ b/Minio.Examples/Minio.Examples.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;</TargetFrameworks>
+    <TargetFrameworks>net8.0;</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -372,25 +372,28 @@ public static class FunctionalTest
 
             var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
             if (found)
-                throw(new Exception("BucketExistsAsync api failed to return false for a non-existing bucket"));
+                throw new Exception("BucketExistsAsync api failed to return false for a non-existing bucket");
 
             await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
             found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
 
             if (!found)
-                throw(new Exception("BucketExistsAsync api failed to return true for an existing bucket"));
+                throw new Exception("BucketExistsAsync api failed to return true for an existing bucket");
 
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature,
+                "Tests whether BucketExistsAsync api passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (NotImplementedException ex)
         {
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature,
+                "Tests whether BucketExistsAsync api passes",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature,
+                "Tests whether BucketExistsAsync api passes",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1469,8 +1469,13 @@ public static class FunctionalTest
 
             var listArgs = new ListIncompleteUploadsArgs()
                 .WithBucket(bucketName);
+            // Check if all incomplete upload objects are cleaned up
             await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
-                Assert.AreEqual(item.Key, objectName);
+                if (item.Key.Equals(objectName, StringComparison.Ordinal))
+                    new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
+                        "Tests whether RemoveIncompleteUpload passes.", TestStatus.FAIL, DateTime.Now - startTime,
+                        ex.Message,
+                        ex.ToString(), args: args).Log();
 
             new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
                 "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1470,10 +1470,8 @@ public static class FunctionalTest
             var listArgs = new ListIncompleteUploadsArgs()
                 .WithBucket(bucketName);
             await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
-                new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
-                    "Tests whether RemoveIncompleteUpload passes.", TestStatus.FAIL, DateTime.Now - startTime,
-                    ex.Message,
-                    ex.ToString(), args: args).Log();
+                Assert.Fail();
+
             new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
                 "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -539,8 +539,11 @@ public static class FunctionalTest
                 {
                     return string.Equals(x.Name, y.Name, StringComparison.Ordinal)
                         ? 0
-                        : x.Name is null ? -1 : y.Name is null ? 1
-                        : string.CompareOrdinal(x.Name, y.Name);
+                        : x.Name is null
+                            ? -1
+                            : y.Name is null
+                                ? 1
+                                : string.CompareOrdinal(x.Name, y.Name);
                 });
                 var indx = 0;
                 foreach (var bucket in bucketListStripped)
@@ -561,10 +564,7 @@ public static class FunctionalTest
         }
         finally
         {
-            foreach (var bucket in bucketListStripped)
-            {
-                await TearDown(minio, bucket.Name).ConfigureAwait(false);
-            }
+            foreach (var bucket in bucketListStripped) await TearDown(minio, bucket.Name).ConfigureAwait(false);
         }
     }
 
@@ -609,7 +609,7 @@ public static class FunctionalTest
             found = await minio.BucketExistsAsync(beArgs, source.Token).ConfigureAwait(false);
             if (!found) await source.CancelAsync().ConfigureAwait(false);
         }
-        catch (Exception ex) when(ex is TaskCanceledException)
+        catch (Exception ex) when (ex is TaskCanceledException)
         {
             // do nothing
             return;
@@ -631,9 +631,7 @@ public static class FunctionalTest
                 if (versioningConfig is not null &&
                     (versioningConfig.Status.Contains("Enabled", StringComparison.Ordinal) ||
                      versioningConfig.Status.Contains("Suspended", StringComparison.Ordinal)))
-                {
                     getVersions = true;
-                }
 
                 lockConfig = await minio.GetObjectLockConfigurationAsync(lockConfigurationArgs, source.Token)
                     .ConfigureAwait(false);
@@ -658,12 +656,10 @@ public static class FunctionalTest
             var objectNames = new List<string>();
             var listObjects = minio.ListObjectsEnumAsync(listObjectsArgs, source.Token);
             await foreach (var item in listObjects.WithCancellation(source.Token).ConfigureAwait(false))
-            {
                 if (getVersions)
                     objectNamesVersions.Add(new Tuple<string, string>(item.Key, item.VersionId));
                 else
                     objectNames.Add(item.Key);
-            }
 
             if (lockConfig?.ObjectLockEnabled.Equals(ObjectLockConfiguration.LockEnabled,
                     StringComparison.OrdinalIgnoreCase) == true)
@@ -1450,20 +1446,20 @@ public static class FunctionalTest
             {
                 var file_write_size = filestream.Length;
 
-            var putObjectArgs = new PutObjectArgs()
-                .WithBucket(bucketName)
-                .WithObject(objectName)
-                .WithStreamData(filestream)
-                .WithObjectSize(filestream.Length)
-                .WithContentType(contentType);
-            _ = await minio.PutObjectAsync(putObjectArgs, cts.Token).ConfigureAwait(false);
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length)
+                    .WithContentType(contentType);
+                _ = await minio.PutObjectAsync(putObjectArgs, cts.Token).ConfigureAwait(false);
 
-            new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
+                new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
                     "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,
                     args: args).Log();
             }
         }
-        catch (Exception ex) when(ex.GetType() == typeof(TaskCanceledException))
+        catch (Exception ex) when (ex.GetType() == typeof(TaskCanceledException))
         {
             var rmArgs = new RemoveIncompleteUploadArgs()
                 .WithBucket(bucketName)
@@ -1474,14 +1470,13 @@ public static class FunctionalTest
             var listArgs = new ListIncompleteUploadsArgs()
                 .WithBucket(bucketName);
             await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
-            {
                 new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
-                    "Tests whether RemoveIncompleteUpload passes.", TestStatus.FAIL, DateTime.Now - startTime, ex.Message,
+                    "Tests whether RemoveIncompleteUpload passes.", TestStatus.FAIL, DateTime.Now - startTime,
+                    ex.Message,
                     ex.ToString(), args: args).Log();
-            }
             new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
-                    "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,
-                    args: args).Log();
+                "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,
+                args: args).Log();
         }
         catch (Exception ex)
         {
@@ -6032,7 +6027,7 @@ public static class FunctionalTest
                     .WithContentType(contentType);
                 _ = await minio.PutObjectAsync(putObjectArgs, cts.Token).ConfigureAwait(false);
             }
-            catch (Exception ex) when(ex is TaskCanceledException)
+            catch (Exception ex) when (ex is TaskCanceledException)
             {
                 new MintLogger("ListIncompleteUpload_Test1", listIncompleteUploadsSignature,
                     "Tests whether ListIncompleteUpload passes", TestStatus.PASS, DateTime.Now - startTime).Log();
@@ -6082,7 +6077,7 @@ public static class FunctionalTest
                     "Tests whether ListIncompleteUpload passes when qualified by prefix", TestStatus.PASS,
                     DateTime.Now - startTime, args: args).Log();
             }
-            catch (Exception ex) when(ex is TaskCanceledException)
+            catch (Exception ex) when (ex is TaskCanceledException)
             {
                 var listArgs = new ListIncompleteUploadsArgs()
                     .WithBucket(bucketName)
@@ -6135,7 +6130,7 @@ public static class FunctionalTest
                     "Tests whether ListIncompleteUpload passes when qualified by prefix and recursive", TestStatus.PASS,
                     DateTime.Now - startTime, args: args).Log();
             }
-            catch (Exception ex) when(ex is TaskCanceledException)
+            catch (Exception ex) when (ex is TaskCanceledException)
             {
                 try
                 {

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -594,17 +594,17 @@ public static class FunctionalTest
     {
         var beArgs = new BucketExistsArgs()
             .WithBucket(bucketName);
-        var bktExists = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
-        if (!bktExists)
-            return;
         var getVersions = false;
-        // Get Versioning/Retention Info.
-        var lockConfigurationArgs =
-            new GetObjectLockConfigurationArgs()
-                .WithBucket(bucketName);
-        ObjectLockConfiguration lockConfig = null;
+        var lockConfig = new ObjectLockConfiguration();
         try
         {
+            var bktExists = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
+            if (!bktExists)
+                return;
+            // Get Versioning/Retention Info.
+            var lockConfigurationArgs =
+                new GetObjectLockConfigurationArgs()
+                    .WithBucket(bucketName);
             var versioningConfig = await minio.GetVersioningAsync(new GetVersioningArgs()
                 .WithBucket(bucketName)
                 .WithVersions(true)).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -371,21 +371,26 @@ public static class FunctionalTest
                 await minio.RemoveBucketAsync(rbArgs).ConfigureAwait(false);
 
             var found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
-            Assert.IsFalse(found);
+            if (found)
+                throw(new Exception("BucketExistsAsync api failed to return false for a non-existing bucket"));
+
             await minio.MakeBucketAsync(mbArgs).ConfigureAwait(false);
             found = await minio.BucketExistsAsync(beArgs).ConfigureAwait(false);
-            Assert.IsTrue(found);
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExists passes",
+
+            if (!found)
+                throw(new Exception("BucketExistsAsync api failed to return true for an existing bucket"));
+
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (NotImplementedException ex)
         {
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExists passes",
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
                 TestStatus.NA, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExists passes",
+            new MintLogger(nameof(BucketExists_Test), bucketExistsSignature, "Tests whether BucketExistsAsync api passes",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -1470,7 +1470,7 @@ public static class FunctionalTest
             var listArgs = new ListIncompleteUploadsArgs()
                 .WithBucket(bucketName);
             await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
-                Assert.Fail();
+                Assert.AreEqual(item.Key, objectName);
 
             new MintLogger("RemoveIncompleteUpload_Test", removeIncompleteUploadSignature,
                 "Tests whether RemoveIncompleteUpload passes.", TestStatus.PASS, DateTime.Now - startTime,
@@ -6130,19 +6130,12 @@ public static class FunctionalTest
             }
             catch (Exception ex) when (ex is TaskCanceledException)
             {
-                try
-                {
-                    var listArgs = new ListIncompleteUploadsArgs()
-                        .WithBucket(bucketName)
-                        .WithPrefix(prefix)
-                        .WithRecursive(true);
-                    await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
-                        Assert.AreEqual(item.Key, objectName);
-                }
-                catch
-                {
-                    Assert.Fail();
-                }
+                var listArgs = new ListIncompleteUploadsArgs()
+                    .WithBucket(bucketName)
+                    .WithPrefix(prefix)
+                    .WithRecursive(true);
+                await foreach (var item in minio.ListIncompleteUploadsEnumAsync(listArgs).ConfigureAwait(false))
+                    Assert.AreEqual(item.Key, objectName);
             }
         }
         catch (Exception ex)

--- a/Minio.Functional.Tests/Minio.Functional.Tests.csproj
+++ b/Minio.Functional.Tests/Minio.Functional.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -122,8 +122,8 @@ internal static class Program
         // "Listening for bucket notification is specific only to `minio`
         // server endpoints".
         await FunctionalTest.ListenBucketNotificationsAsync_Test1(minioClient).ConfigureAwait(false);
+        await FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient).ConfigureAwait(false);
         functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.ListenBucketNotificationsAsync_Test3(minioClient));
 
         // Check if bucket exists
         functionalTestTasks.Add(FunctionalTest.BucketExists_Test(minioClient));
@@ -145,14 +145,12 @@ internal static class Program
 
         // Test Putobject function
         functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
-        // functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
-//         functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
 
         // Test StatObject function
         functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -26,7 +26,7 @@ namespace Minio.Functional.Tests;
 internal static class Program
 {
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Needs to run all tests")]
-    public static async Task Main(string[] args)
+    public static async Task Main()
     {
         string endPoint = null;
         string accessKey = null;
@@ -107,6 +107,12 @@ internal static class Program
 
         ConcurrentBag<Task> functionalTestTasks = new();
 
+        // Test incomplete uploads
+        await FunctionalTest.ListIncompleteUpload_Test1(minioClient).ConfigureAwait(false);
+        await FunctionalTest.ListIncompleteUpload_Test2(minioClient).ConfigureAwait(false);
+        await FunctionalTest.ListIncompleteUpload_Test3(minioClient).ConfigureAwait(false);
+        await FunctionalTest.RemoveIncompleteUpload_Test(minioClient).ConfigureAwait(false);
+
         // Global Notification
         await FunctionalTest.ListenNotifications_Test1(minioClient).ConfigureAwait(false);
 
@@ -139,14 +145,14 @@ internal static class Program
 
         // Test Putobject function
         functionalTestTasks.Add(FunctionalTest.PutObject_Test1(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
+        // functionalTestTasks.Add(FunctionalTest.PutObject_Test2(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test3(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test4(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test5(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test7(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test8(minioClient));
         functionalTestTasks.Add(FunctionalTest.PutObject_Test9(minioClient));
-        functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
+//         functionalTestTasks.Add(FunctionalTest.PutObject_Test10(minioClient));
 
         // Test StatObject function
         functionalTestTasks.Add(FunctionalTest.StatObject_Test1(minioClient));
@@ -154,8 +160,8 @@ internal static class Program
         // Test GetObjectAsync function
         functionalTestTasks.Add(FunctionalTest.GetObject_Test1(minioClient));
         functionalTestTasks.Add(FunctionalTest.GetObject_Test2(minioClient));
-        functionalTestTasks.Add(FunctionalTest.GetObjectNegObjNotFound_Test3(minioClient));
-        functionalTestTasks.Add(FunctionalTest.GetObjectNegBcktNotFound_Test4(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetObjectNegObjNotFound_Test1andTest2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetObjectNegBcktNotFound_Test3(minioClient));
         // 3 tests will run to check different values of offset and length parameters
         // when GetObject api returns part of the object as defined by the offset
         // and length parameters. Tests will be reported as GetObject_Test3,
@@ -213,12 +219,6 @@ internal static class Program
         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
         // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
 
-        // Test incomplete uploads
-        //functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));
-        //functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test2(minioClient));
-        //functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test3(minioClient));
-        //functionalTestTasks.Add(FunctionalTest.RemoveIncompleteUpload_Test(minioClient));
-
         // Test GetBucket policy
         functionalTestTasks.Add(FunctionalTest.GetBucketPolicy_Test1(minioClient));
 
@@ -259,5 +259,7 @@ internal static class Program
         }
 
         await functionalTestTasks.ForEachAsync().ConfigureAwait(false);
+        await FunctionalTest.PutObject_Test2(minioClient).ConfigureAwait(false);
+        await FunctionalTest.PutObject_Test10(minioClient).ConfigureAwait(false);
     }
 }

--- a/Minio.Functional.Tests/RandomStreamGenerator.cs
+++ b/Minio.Functional.Tests/RandomStreamGenerator.cs
@@ -21,27 +21,27 @@ namespace Minio.Functional.Tests;
 
 internal sealed class RandomStreamGenerator
 {
-    private readonly Random _random = new();
-    private readonly Memory<byte> _seedBuffer;
+    private readonly Random random = new();
+    private readonly Memory<byte> seedBuffer;
 
     public RandomStreamGenerator(int maxBufferSize)
     {
-        _seedBuffer = new byte[maxBufferSize];
+        seedBuffer = new byte[maxBufferSize];
 #if NETFRAMEWORK
         _random.NextBytes(_seedBuffer.Span.ToArray());
 #else
-        _random.NextBytes(_seedBuffer.Span);
+        random.NextBytes(seedBuffer.Span);
 #endif
     }
 
     public Stream GenerateStreamFromSeed(int size)
     {
-        var randomWindow = _random.Next(0, size);
+        var randomWindow = random.Next(0, size);
 
         Memory<byte> buffer = new byte[size];
 
-        _seedBuffer[randomWindow..size].CopyTo(buffer[..(size - randomWindow)]);
-        _seedBuffer[..randomWindow].CopyTo(buffer.Slice(size - randomWindow, randomWindow));
+        seedBuffer[randomWindow..size].CopyTo(buffer[..(size - randomWindow)]);
+        seedBuffer[..randomWindow].CopyTo(buffer.Slice(size - randomWindow, randomWindow));
 
         return buffer.AsStream();
     }

--- a/Minio.Tests/Minio.Tests.csproj
+++ b/Minio.Tests/Minio.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <IsPackable>False</IsPackable>
     <AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -43,8 +43,6 @@ namespace Minio;
 public partial class MinioClient : IBucketOperations
 {
     /// <summary>
-    ///
-    ///
     ///     List all the buckets for the current Endpoint URL
     /// </summary>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
@@ -61,8 +59,8 @@ public partial class MinioClient : IBucketOperations
         var bucketList = new ListAllMyBucketsResult();
         if (HttpStatusCode.OK == response.StatusCode)
         {
-            var stream = response.ContentBytes.AsStream();
-            await using (stream.ConfigureAwait(false))
+            var stream = response.ContentBytes.AsBytes().AsStream();
+            using (stream)
             {
                 bucketList = Utils.DeserializeXml<ListAllMyBucketsResult>(stream);
             }

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -43,6 +43,8 @@ namespace Minio;
 public partial class MinioClient : IBucketOperations
 {
     /// <summary>
+    ///
+    ///
     ///     List all the buckets for the current Endpoint URL
     /// </summary>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
@@ -60,11 +62,9 @@ public partial class MinioClient : IBucketOperations
         if (HttpStatusCode.OK == response.StatusCode)
         {
             var stream = response.ContentBytes.AsStream();
-            using (stream)
+            await using (stream.ConfigureAwait(false))
             {
-                {
-                    bucketList = Utils.DeserializeXml<ListAllMyBucketsResult>(stream);
-                }
+                bucketList = Utils.DeserializeXml<ListAllMyBucketsResult>(stream);
             }
         }
 
@@ -91,9 +91,7 @@ public partial class MinioClient : IBucketOperations
                 .ExecuteTaskAsync(requestMessageBuilder, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
 
-            if (response?.Exception is null && response.StatusCode == HttpStatusCode.OK)
-                return true;
-            return false;
+            return response?.Exception is null && response.StatusCode == HttpStatusCode.OK;
         }
         catch (Exception ex) when (ex.GetType() == typeof(BucketNotFoundException))
         {

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -82,21 +82,23 @@ public partial class MinioClient : IBucketOperations
     public async Task<bool> BucketExistsAsync(BucketExistsArgs args,
         CancellationToken cancellationToken = default)
     {
-        args?.Validate();
+        try
+        {
+            args?.Validate();
 
-        var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
-        using var response = await this
-            .ExecuteTaskAsync(requestMessageBuilder, cancellationToken: cancellationToken)
-            .ConfigureAwait(false);
+            var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
+            using var response = await this
+                .ExecuteTaskAsync(requestMessageBuilder, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
-        if (response?.Exception is null &&
-            response.StatusCode == HttpStatusCode.OK)
-            return true;
-        if (!response.ErrorMessage.Contains("Bucket NotFound") &&
-            response.Exception.GetType() != typeof(BucketNotFoundException))
-            throw response.Exception;
-
-        return false;
+            if (response?.Exception is null && response.StatusCode == HttpStatusCode.OK)
+                return true;
+            return false;
+        }
+        catch (Exception ex) when (ex.GetType() == typeof(BucketNotFoundException))
+        {
+            return false;
+        }
     }
 
     /// <summary>

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -232,7 +232,7 @@ public partial class MinioClient : IBucketOperations
                     $"HTTP status-code {responseResult.StatusCode:D}: {responseResult.StatusCode}", responseResult);
 
 #if NET2_0_OR_GREATER
-    var root = await XDocument.LoadAsync(modifiedStream, LoadOptions.None, ct).ConfigureAwait(false);
+    var root = await XDocument.LoadAsync(responseResult, LoadOptions.None, ct).ConfigureAwait(false);
 #else
             var root = XDocument.Load(responseResult.ContentStream);
 #endif

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -150,7 +150,6 @@ public partial class MinioClient : IObjectOperations
         {
             await foreach (var upload in ListIncompleteUploadsEnumAsync(listUploadArgs, cancellationToken)
                                .ConfigureAwait(false))
-            {
                 if (upload.Key.Equals(args.ObjectName, StringComparison.OrdinalIgnoreCase))
                 {
                     var rmArgs = new RemoveUploadArgs()
@@ -159,7 +158,6 @@ public partial class MinioClient : IObjectOperations
                         .WithUploadId(upload.UploadId);
                     await RemoveUploadAsync(rmArgs, cancellationToken).ConfigureAwait(false);
                 }
-            }
         }
         catch (Exception ex) when (ex.GetType() == typeof(BucketNotFoundException))
         {

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -150,6 +150,7 @@ public partial class MinioClient : IObjectOperations
         {
             await foreach (var upload in ListIncompleteUploadsEnumAsync(listUploadArgs, cancellationToken)
                                .ConfigureAwait(false))
+            {
                 if (upload.Key.Equals(args.ObjectName, StringComparison.OrdinalIgnoreCase))
                 {
                     var rmArgs = new RemoveUploadArgs()
@@ -158,6 +159,7 @@ public partial class MinioClient : IObjectOperations
                         .WithUploadId(upload.UploadId);
                     await RemoveUploadAsync(rmArgs, cancellationToken).ConfigureAwait(false);
                 }
+            }
         }
         catch (Exception ex) when (ex.GetType() == typeof(BucketNotFoundException))
         {

--- a/Minio/BucketRegionCache.cs
+++ b/Minio/BucketRegionCache.cs
@@ -98,7 +98,7 @@ public sealed class BucketRegionCache
             var requestBuilder = new HttpRequestMessageBuilder(HttpMethod.Get, requestUrl, path);
             requestBuilder.AddQueryParameter("location", "");
             using var response =
-                await client.ExecuteTaskAsync(client.ResponseErrorHandlers, requestBuilder).ConfigureAwait(false);
+                await client.ExecuteTaskAsync(requestBuilder).ConfigureAwait(false);
 
             if (response is not null && HttpStatusCode.OK == response.StatusCode)
             {

--- a/Minio/Credentials/AssumeRoleBaseProvider.cs
+++ b/Minio/Credentials/AssumeRoleBaseProvider.cs
@@ -63,7 +63,7 @@ public abstract class AssumeRoleBaseProvider<T> : IClientProvider
             ResponseResult responseMessage = null;
             try
             {
-                responseMessage = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder).ConfigureAwait(false);
+                responseMessage = await Client.ExecuteTaskAsync(requestBuilder).ConfigureAwait(false);
             }
             finally
             {

--- a/Minio/Credentials/AssumeRoleProvider.cs
+++ b/Minio/Credentials/AssumeRoleProvider.cs
@@ -68,7 +68,7 @@ public class AssumeRoleProvider : AssumeRoleBaseProvider<AssumeRoleProvider>
             ResponseResult responseResult = null;
             try
             {
-                responseResult = await Client.ExecuteTaskAsync(NoErrorHandlers, requestBuilder, true)
+                responseResult = await Client.ExecuteTaskAsync(requestBuilder, isSts: true)
                     .ConfigureAwait(false);
 
                 AssumeRoleResponse assumeRoleResp = null;

--- a/Minio/Credentials/CertificateIdentityProvider.cs
+++ b/Minio/Credentials/CertificateIdentityProvider.cs
@@ -16,6 +16,11 @@
  */
 
 
+#if (NET472_OR_GREATER || NET6_0_OR_GREATER)
+using System.Security.Authentication;
+#else
+using System.Net;
+#endif
 using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -24,11 +29,6 @@ using CommunityToolkit.HighPerformance;
 using Minio.DataModel;
 using Minio.Exceptions;
 using Minio.Helper;
-#if (NET472_OR_GREATER || NET6_0_OR_GREATER)
-using System.Security.Authentication;
-#else
-using System.Net;
-#endif
 
 /*
  * Certificate Identity Credential provider.

--- a/Minio/Credentials/IAMAWSProvider.cs
+++ b/Minio/Credentials/IAMAWSProvider.cs
@@ -19,7 +19,6 @@ using System.Net;
 using System.Text.Json;
 using Minio.DataModel;
 using Minio.Exceptions;
-using Minio.Handlers;
 using Minio.Helper;
 
 /*
@@ -152,19 +151,12 @@ public class IAMAWSProvider : IClientProvider
         requestBuilder.AddQueryParameter("location", "");
 
         using var response =
-            await Client.ExecuteTaskAsync(Enumerable.Empty<IApiResponseErrorHandler>(), requestBuilder)
+            await Client.ExecuteTaskAsync(requestBuilder)
                 .ConfigureAwait(false);
         if (string.IsNullOrWhiteSpace(response.Content) ||
             HttpStatusCode.OK != response.StatusCode)
             throw new CredentialsProviderException("IAMAWSProvider",
                 "Credential Get operation failed with HTTP Status code: " + response.StatusCode);
-        /*
-JsonConvert.DefaultSettings = () => new JsonSerializerSettings
-{
-   MissingMemberHandling = MissingMemberHandling.Error,
-   ContractResolver = new CamelCasePropertyNamesContractResolver(),
-   Error = null
-};*/
 
         var credentials = JsonSerializer.Deserialize<ECSCredentials>(response.Content);
         if (credentials.Code?.Equals("success", StringComparison.OrdinalIgnoreCase) == false)
@@ -183,7 +175,7 @@ JsonConvert.DefaultSettings = () => new JsonSerializerSettings
         requestBuilder.AddQueryParameter("location", "");
 
         using var response =
-            await Client.ExecuteTaskAsync(Enumerable.Empty<IApiResponseErrorHandler>(), requestBuilder)
+            await Client.ExecuteTaskAsync(requestBuilder)
                 .ConfigureAwait(false);
 
         if (string.IsNullOrWhiteSpace(response.Content) ||

--- a/Minio/DataModel/Args/PutObjectArgs.cs
+++ b/Minio/DataModel/Args/PutObjectArgs.cs
@@ -67,9 +67,6 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
                                                 " should be set.");
 
         if (!string.IsNullOrWhiteSpace(FileName)) Utils.ValidateFile(FileName);
-        // Check object size when using stream data
-        if (ObjectStreamData is not null && ObjectSize == 0)
-            throw new InvalidOperationException($"{nameof(ObjectSize)} must be set");
         Populate();
     }
 

--- a/Minio/DataModel/Args/SelectObjectContentArgs.cs
+++ b/Minio/DataModel/Args/SelectObjectContentArgs.cs
@@ -22,25 +22,25 @@ namespace Minio.DataModel.Args;
 
 public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
 {
-    private readonly SelectObjectOptions SelectOptions;
+    private readonly SelectObjectOptions selectOptions;
 
     public SelectObjectContentArgs()
     {
         RequestMethod = HttpMethod.Post;
-        SelectOptions = new SelectObjectOptions();
+        selectOptions = new SelectObjectOptions();
     }
 
     internal override void Validate()
     {
         base.Validate();
-        if (string.IsNullOrEmpty(SelectOptions.Expression))
-            throw new InvalidOperationException("The Expression " + nameof(SelectOptions.Expression) +
+        if (string.IsNullOrEmpty(selectOptions.Expression))
+            throw new InvalidOperationException("The Expression " + nameof(selectOptions.Expression) +
                                                 " for Select Object Content cannot be empty.");
 
-        if (SelectOptions.InputSerialization is null || SelectOptions.OutputSerialization is null)
+        if (selectOptions.InputSerialization is null || selectOptions.OutputSerialization is null)
             throw new InvalidOperationException(
                 "The Input/Output serialization members for SelectObjectContentArgs should be initialized " +
-                nameof(SelectOptions.InputSerialization) + " " + nameof(SelectOptions.OutputSerialization));
+                nameof(selectOptions.InputSerialization) + " " + nameof(selectOptions.OutputSerialization));
     }
 
     internal override HttpRequestMessageBuilder BuildRequest(HttpRequestMessageBuilder requestMessageBuilder)
@@ -50,7 +50,7 @@ public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
 
         if (RequestBody.IsEmpty)
         {
-            RequestBody = Encoding.UTF8.GetBytes(SelectOptions.MarshalXML());
+            RequestBody = Encoding.UTF8.GetBytes(selectOptions.MarshalXML());
             requestMessageBuilder.SetBody(RequestBody);
         }
 
@@ -62,31 +62,31 @@ public class SelectObjectContentArgs : EncryptionArgs<SelectObjectContentArgs>
 
     public SelectObjectContentArgs WithExpressionType(QueryExpressionType e)
     {
-        SelectOptions.ExpressionType = e;
+        selectOptions.ExpressionType = e;
         return this;
     }
 
     public SelectObjectContentArgs WithQueryExpression(string expr)
     {
-        SelectOptions.Expression = expr;
+        selectOptions.Expression = expr;
         return this;
     }
 
     public SelectObjectContentArgs WithInputSerialization(SelectObjectInputSerialization serialization)
     {
-        SelectOptions.InputSerialization = serialization;
+        selectOptions.InputSerialization = serialization;
         return this;
     }
 
     public SelectObjectContentArgs WithOutputSerialization(SelectObjectOutputSerialization serialization)
     {
-        SelectOptions.OutputSerialization = serialization;
+        selectOptions.OutputSerialization = serialization;
         return this;
     }
 
     public SelectObjectContentArgs WithRequestProgress(RequestProgress requestProgress)
     {
-        SelectOptions.RequestProgress = requestProgress;
+        selectOptions.RequestProgress = requestProgress;
         return this;
     }
 }

--- a/Minio/DataModel/Response/GetVersioningResponse.cs
+++ b/Minio/DataModel/Response/GetVersioningResponse.cs
@@ -24,8 +24,7 @@ internal class GetVersioningResponse : GenericResponse
     internal GetVersioningResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        if (string.IsNullOrEmpty(responseContent) ||
-            HttpStatusCode.OK != statusCode)
+        if (string.IsNullOrEmpty(responseContent) || HttpStatusCode.OK != statusCode)
             return;
 
         VersioningConfig = Utils.DeserializeXml<VersioningConfiguration>(responseContent);

--- a/Minio/DataModel/Response/NewMultipartUploadResponse.cs
+++ b/Minio/DataModel/Response/NewMultipartUploadResponse.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Net;
-using System.Text;
-using CommunityToolkit.HighPerformance;
 using Minio.DataModel.Result;
 using Minio.Helper;
 

--- a/Minio/DataModel/Response/NewMultipartUploadResponse.cs
+++ b/Minio/DataModel/Response/NewMultipartUploadResponse.cs
@@ -27,8 +27,7 @@ internal class NewMultipartUploadResponse : GenericResponse
     internal NewMultipartUploadResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();
-        var newUpload = Utils.DeserializeXml<InitiateMultipartUploadResult>(stream);
+        var newUpload = Utils.DeserializeXml<InitiateMultipartUploadResult>(responseContent);
 
         UploadId = newUpload.UploadId;
     }

--- a/Minio/DataModel/Response/RemoveObjectsResponse.cs
+++ b/Minio/DataModel/Response/RemoveObjectsResponse.cs
@@ -15,8 +15,6 @@
  */
 
 using System.Net;
-using System.Text;
-using CommunityToolkit.HighPerformance;
 using Minio.DataModel.Result;
 using Minio.Helper;
 
@@ -27,8 +25,7 @@ internal class RemoveObjectsResponse : GenericResponse
     internal RemoveObjectsResponse(HttpStatusCode statusCode, string responseContent)
         : base(statusCode, responseContent)
     {
-        using var stream = Encoding.UTF8.GetBytes(responseContent).AsMemory().AsStream();
-        DeletedObjectsResult = Utils.DeserializeXml<DeleteObjectsResult>(stream);
+        DeletedObjectsResult = Utils.DeserializeXml<DeleteObjectsResult>(responseContent);
     }
 
     internal DeleteObjectsResult DeletedObjectsResult { get; }

--- a/Minio/Exceptions/BucketNotFoundException.cs
+++ b/Minio/Exceptions/BucketNotFoundException.cs
@@ -41,7 +41,8 @@ public class BucketNotFoundException : MinioException
     {
     }
 
-    public BucketNotFoundException(Exception innerException, string message="Bucket NotFound") : base(message, innerException)
+    public BucketNotFoundException(Exception innerException, string message = "Bucket NotFound") : base(message,
+        innerException)
     {
     }
 

--- a/Minio/Exceptions/BucketNotFoundException.cs
+++ b/Minio/Exceptions/BucketNotFoundException.cs
@@ -24,7 +24,7 @@ public class BucketNotFoundException : MinioException
 {
     private readonly string bucketName;
 
-    public BucketNotFoundException(string bucketName, string message) : base(message)
+    public BucketNotFoundException(string bucketName, string message = "Bucket NotFound") : base(message)
     {
         this.bucketName = bucketName;
     }
@@ -33,11 +33,7 @@ public class BucketNotFoundException : MinioException
     {
     }
 
-    public BucketNotFoundException(string message) : base(message)
-    {
-    }
-
-    public BucketNotFoundException(string message, ResponseResult serverResponse) : base(message, serverResponse)
+    public BucketNotFoundException(string message = "Bucket NotFound") : base(message)
     {
     }
 
@@ -45,7 +41,15 @@ public class BucketNotFoundException : MinioException
     {
     }
 
+    public BucketNotFoundException(Exception innerException, string message="Bucket NotFound") : base(message, innerException)
+    {
+    }
+
     public BucketNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public BucketNotFoundException(string message, ResponseResult serverResponse) : base(message, serverResponse)
     {
     }
 

--- a/Minio/Exceptions/MinioException.cs
+++ b/Minio/Exceptions/MinioException.cs
@@ -30,7 +30,7 @@ public class MinioException : Exception
     {
     }
 
-    public MinioException(ResponseResult serverResponse) : this(null, serverResponse)
+    public MinioException(ResponseResult serverResponse) : this(message: null, serverResponse)
     {
     }
 

--- a/Minio/Exceptions/MinioException.cs
+++ b/Minio/Exceptions/MinioException.cs
@@ -30,7 +30,7 @@ public class MinioException : Exception
     {
     }
 
-    public MinioException(ResponseResult serverResponse) : this(message: null, serverResponse)
+    public MinioException(ResponseResult serverResponse) : this(null, serverResponse)
     {
     }
 

--- a/Minio/Exceptions/ObjectNotFoundException.cs
+++ b/Minio/Exceptions/ObjectNotFoundException.cs
@@ -23,7 +23,7 @@ public class ObjectNotFoundException : MinioException
 {
     private readonly string objectName;
 
-    public ObjectNotFoundException(string objectName, string message) : base(message)
+    public ObjectNotFoundException(string objectName, string message = "Object NotFound") : base(message)
     {
         this.objectName = objectName;
     }
@@ -32,11 +32,11 @@ public class ObjectNotFoundException : MinioException
     {
     }
 
-    public ObjectNotFoundException(string message) : base(message)
+    public ObjectNotFoundException(string message = "Object NotFound") : base(message)
     {
     }
 
-    public ObjectNotFoundException(string message, ResponseResult serverResponse) : base(message, serverResponse)
+    public ObjectNotFoundException(ResponseResult serverResponse, string message = "Object NotFound")  : base(message, serverResponse)
     {
     }
 
@@ -44,7 +44,15 @@ public class ObjectNotFoundException : MinioException
     {
     }
 
+    public ObjectNotFoundException(Exception innerException, string message = "Object NotFound") : base(message, innerException)
+    {
+    }
+
     public ObjectNotFoundException(string message, Exception innerException) : base(message, innerException)
+    {
+    }
+
+    public ObjectNotFoundException(string message, ResponseResult serverResponse) : base(message, serverResponse)
     {
     }
 

--- a/Minio/Exceptions/ObjectNotFoundException.cs
+++ b/Minio/Exceptions/ObjectNotFoundException.cs
@@ -36,7 +36,8 @@ public class ObjectNotFoundException : MinioException
     {
     }
 
-    public ObjectNotFoundException(ResponseResult serverResponse, string message = "Object NotFound")  : base(message, serverResponse)
+    public ObjectNotFoundException(ResponseResult serverResponse, string message = "Object NotFound") : base(message,
+        serverResponse)
     {
     }
 
@@ -44,7 +45,8 @@ public class ObjectNotFoundException : MinioException
     {
     }
 
-    public ObjectNotFoundException(Exception innerException, string message = "Object NotFound") : base(message, innerException)
+    public ObjectNotFoundException(Exception innerException, string message = "Object NotFound") : base(message,
+        innerException)
     {
     }
 

--- a/Minio/Handlers/DefaultErrorHandler.cs
+++ b/Minio/Handlers/DefaultErrorHandler.cs
@@ -9,7 +9,8 @@ public class DefaultErrorHandler : IApiResponseErrorHandler
     {
         if (response is null) throw new ArgumentNullException(nameof(response));
 
-        if (response.StatusCode is < HttpStatusCode.OK or >= HttpStatusCode.BadRequest)
+        if (response.StatusCode is < HttpStatusCode.OK or >= HttpStatusCode.BadRequest ||
+            response.Exception is not null)
             MinioClient.ParseError(response);
     }
 }

--- a/Minio/Handlers/IApiResponseErrorHandler.cs
+++ b/Minio/Handlers/IApiResponseErrorHandler.cs
@@ -2,7 +2,10 @@
 
 namespace Minio.Handlers;
 
+#pragma warning disable 0067
 public interface IApiResponseErrorHandler
+#pragma warning disable 0067
+
 {
-    void Handle(ResponseResult response);
+    void Handle(ResponseResult responseResult);
 }

--- a/Minio/Helper/OperationsHelper.cs
+++ b/Minio/Helper/OperationsHelper.cs
@@ -109,7 +109,7 @@ public partial class MinioClient : IMinioClient
     {
         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
         using var response =
-            await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
+            await this.ExecuteTaskAsync(requestMessageBuilder,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -133,7 +133,7 @@ public partial class MinioClient : IMinioClient
     {
         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);
         using var response =
-            await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
+            await this.ExecuteTaskAsync(requestMessageBuilder,
                     cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
         var removeObjectsResponse = new RemoveObjectsResponse(response.StatusCode, response.Content);

--- a/Minio/Helper/OperationsUtil.cs
+++ b/Minio/Helper/OperationsUtil.cs
@@ -18,7 +18,7 @@ namespace Minio.Helper;
 
 public static class OperationsUtil
 {
-    private static readonly List<string> SupportedHeaders = new()
+    private static readonly List<string> supportedHeaders = new()
     {
         "cache-control",
         "content-encoding",
@@ -28,7 +28,7 @@ public static class OperationsUtil
         "x-minio-extract"
     };
 
-    private static readonly List<string> SSEHeaders = new()
+    private static readonly List<string> sSEHeaders = new()
     {
         "X-Amz-Server-Side-Encryption-Customer-Algorithm",
         "X-Amz-Server-Side-Encryption-Customer-Key",
@@ -41,12 +41,12 @@ public static class OperationsUtil
     internal static bool IsSupportedHeader(string hdr, IEqualityComparer<string> comparer = null)
     {
         comparer ??= StringComparer.OrdinalIgnoreCase;
-        return SupportedHeaders.Contains(hdr, comparer);
+        return supportedHeaders.Contains(hdr, comparer);
     }
 
     internal static bool IsSSEHeader(string hdr, IEqualityComparer<string> comparer = null)
     {
         comparer ??= StringComparer.OrdinalIgnoreCase;
-        return SSEHeaders.Contains(hdr, comparer);
+        return sSEHeaders.Contains(hdr, comparer);
     }
 }

--- a/Minio/HttpRequestMessageBuilder.cs
+++ b/Minio/HttpRequestMessageBuilder.cs
@@ -76,6 +76,8 @@ internal class HttpRequestMessageBuilder
                     switch (key)
                     {
                         case "content-type":
+                        {
+                            val ??= "application/octet-stream";
                             try
                             {
                                 request.Content.Headers.ContentType = new MediaTypeHeaderValue(val);
@@ -86,6 +88,7 @@ internal class HttpRequestMessageBuilder
                             }
 
                             break;
+                        }
 
                         case "content-length":
                             request.Content.Headers.ContentLength = Convert.ToInt32(val, CultureInfo.InvariantCulture);

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -2,7 +2,7 @@
 	<PropertyGroup>
 		<AssemblyName>Minio</AssemblyName>
 		<RootNamespace>Minio</RootNamespace>
-		<TargetFrameworks>net6.0;net8.0;netstandard2.0</TargetFrameworks>
+		<TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
 		<AssemblyOriginatorKeyFile>..\Minio.snk</AssemblyOriginatorKeyFile>
 		<SignAssembly>true</SignAssembly>
 		<PublicSign Condition="'$(OS)' != 'Windows_NT'">true</PublicSign>

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -123,24 +123,20 @@ public partial class MinioClient : IMinioClient
             throw new ArgumentNullException(nameof(response));
         var statusCodeStrs = new[]
         {
-            nameof(HttpStatusCode.Forbidden),
-            nameof(HttpStatusCode.BadRequest),
-            nameof(HttpStatusCode.NotFound),
-            nameof(HttpStatusCode.MethodNotAllowed),
-            nameof(HttpStatusCode.NotImplemented)
+            nameof(HttpStatusCode.Forbidden), nameof(HttpStatusCode.BadRequest), nameof(HttpStatusCode.NotFound),
+            nameof(HttpStatusCode.MethodNotAllowed), nameof(HttpStatusCode.NotImplemented)
         };
 
         if (response.Exception != null && !string.IsNullOrEmpty(response.ErrorMessage))
         {
             foreach (var exception in statusCodeStrs)
-            {
-                if (((response.ErrorMessage?.Contains(exception, StringComparison.InvariantCulture)) ?? false) ||
-                    (response.ErrorMessage?.Contains(response.StatusCode.ToString(), StringComparison.InvariantCulture) ?? false))
+                if ((response.ErrorMessage?.Contains(exception, StringComparison.InvariantCulture) ?? false) ||
+                    (response.ErrorMessage?.Contains(response.StatusCode.ToString(),
+                        StringComparison.InvariantCulture) ?? false))
                 {
                     ParseWellKnownErrorNoContent(response);
                     break;
                 }
-            }
         }
         else if (statusCodeStrs.Contains(response.StatusCode.ToString(), StringComparer.Ordinal))
         {
@@ -275,9 +271,11 @@ public partial class MinioClient : IMinioClient
 
         if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("MalformedXML", StringComparison.OrdinalIgnoreCase))
-            throw new MalFormedXMLException(errResponse.Resource, errResponse.BucketName, errResponse.Message, errResponse.Key);
+            throw new MalFormedXMLException(errResponse.Resource, errResponse.BucketName, errResponse.Message,
+                errResponse.Key);
 
-        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotImplemented), StringComparison.OrdinalIgnoreCase)
+        if (response.StatusCode.ToString()
+                .Contains(nameof(HttpStatusCode.NotImplemented), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("NotImplemented", StringComparison.OrdinalIgnoreCase))
         {
 #pragma warning disable MA0025 // Implement the functionality instead of throwing NotImplementedException
@@ -308,7 +306,8 @@ public partial class MinioClient : IMinioClient
         if (response.StatusCode == HttpStatusCode.PreconditionFailed
             && errResponse.Code.Equals("PreconditionFailed", StringComparison.OrdinalIgnoreCase))
             throw new PreconditionFailedException("At least one of the pre-conditions you " +
-                                "specified did not hold for object: \"" + errResponse.Resource + "\"");
+                                                  "specified did not hold for object: \"" + errResponse.Resource +
+                                                  "\"");
 
         throw new UnexpectedMinioException(errResponse.Message) { Response = errResponse, XmlError = response.Content };
     }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -119,22 +119,28 @@ public partial class MinioClient : IMinioClient
 
     private static void ParseErrorNoContent(ResponseResult response)
     {
+        if (response is null)
+            throw new ArgumentNullException(nameof(response));
         var statusCodeStrs = new[]
         {
-            nameof(HttpStatusCode.Forbidden), nameof(HttpStatusCode.BadRequest), nameof(HttpStatusCode.NotFound),
-            nameof(HttpStatusCode.MethodNotAllowed), nameof(HttpStatusCode.NotImplemented)
+            nameof(HttpStatusCode.Forbidden),
+            nameof(HttpStatusCode.BadRequest),
+            nameof(HttpStatusCode.NotFound),
+            nameof(HttpStatusCode.MethodNotAllowed),
+            nameof(HttpStatusCode.NotImplemented)
         };
 
-        if (response?.Exception != null)
+        if (response.Exception != null && !string.IsNullOrEmpty(response.ErrorMessage))
         {
             foreach (var exception in statusCodeStrs)
-                if ((bool)response?.ErrorMessage.Contains(exception, StringComparison.InvariantCulture) ||
-                    (bool)response?.ErrorMessage.Contains(response.StatusCode.ToString(),
-                        StringComparison.InvariantCulture))
+            {
+                if (((response.ErrorMessage?.Contains(exception, StringComparison.InvariantCulture)) ?? false) ||
+                    (response.ErrorMessage?.Contains(response.StatusCode.ToString(), StringComparison.InvariantCulture) ?? false))
                 {
                     ParseWellKnownErrorNoContent(response);
                     break;
                 }
+            }
         }
         else if (statusCodeStrs.Contains(response.StatusCode.ToString(), StringComparer.Ordinal))
         {
@@ -174,8 +180,8 @@ public partial class MinioClient : IMinioClient
         // zero, one or two segments
         var resourceSplits = pathAndQuery.Split(separator, 2, StringSplitOptions.RemoveEmptyEntries);
 
-        if (HttpStatusCode.NotFound == response.StatusCode || response.Exception.ToString()
-                .Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase))
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.Ordinal) ||
+            response.Exception.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.Ordinal))
         {
             var pathLength = resourceSplits.Length;
             var isAWS = host.EndsWith("s3.amazonaws.com", StringComparison.OrdinalIgnoreCase);
@@ -185,7 +191,7 @@ public partial class MinioClient : IMinioClient
             {
                 var objectName = resourceSplits[1];
                 errorResponse.Code = "NoSuchKey";
-                error = new ObjectNotFoundException(objectName, "Object NotFound.");
+                error = new ObjectNotFoundException(objectName);
             }
             else if (pathLength == 1)
             {
@@ -194,13 +200,13 @@ public partial class MinioClient : IMinioClient
                 if (isAWS && isVirtual)
                 {
                     errorResponse.Code = "NoSuchKey";
-                    error = new ObjectNotFoundException(resource, "Object NotFound.");
+                    error = new ObjectNotFoundException(resource);
                 }
                 else
                 {
                     errorResponse.Code = "NoSuchBucket";
                     BucketRegionCache.Instance.Remove(resource);
-                    error = new BucketNotFoundException(resource, "Bucket NotFound.");
+                    error = new BucketNotFoundException(resource);
                 }
             }
             else
@@ -240,13 +246,13 @@ public partial class MinioClient : IMinioClient
         if (response is null)
             throw new ArgumentNullException(nameof(response));
 
-        if (response.StatusCode == HttpStatusCode.NotFound
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && response.Request.RequestUri.PathAndQuery.EndsWith("?location", StringComparison.OrdinalIgnoreCase)
             && response.Request.Method.Equals(HttpMethod.Get))
         {
             var bucketName = response.Request.RequestUri.PathAndQuery.Split('?')[0];
             BucketRegionCache.Instance.Remove(bucketName);
-            throw new BucketNotFoundException(bucketName, "NotFound.");
+            throw new BucketNotFoundException(bucketName);
         }
 
         var errResponse = Utils.DeserializeXml<ErrorResponse>(response.Content);
@@ -257,22 +263,21 @@ public partial class MinioClient : IMinioClient
             throw new AuthorizationException(errResponse.Resource, errResponse.BucketName, errResponse.Message);
 
         // Handle XML response for Bucket Policy not found case
-        if (response.StatusCode == HttpStatusCode.NotFound
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && response.Request.RequestUri.PathAndQuery.EndsWith("?policy", StringComparison.OrdinalIgnoreCase)
             && response.Request.Method.Equals(HttpMethod.Get)
             && string.Equals(errResponse.Code, "NoSuchBucketPolicy", StringComparison.OrdinalIgnoreCase))
             throw new ErrorResponseException(errResponse, response) { XmlError = response.Content };
 
-        if (response.StatusCode == HttpStatusCode.NotFound
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && string.Equals(errResponse.Code, "NoSuchBucket", StringComparison.OrdinalIgnoreCase))
-            throw new BucketNotFoundException(errResponse.BucketName, "NotFound.");
+            throw new BucketNotFoundException(errResponse.BucketName);
 
-        if (response.StatusCode == HttpStatusCode.BadRequest
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("MalformedXML", StringComparison.OrdinalIgnoreCase))
-            throw new MalFormedXMLException(errResponse.Resource, errResponse.BucketName, errResponse.Message,
-                errResponse.Key);
+            throw new MalFormedXMLException(errResponse.Resource, errResponse.BucketName, errResponse.Message, errResponse.Key);
 
-        if (response.StatusCode == HttpStatusCode.NotImplemented
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotImplemented), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("NotImplemented", StringComparison.OrdinalIgnoreCase))
         {
 #pragma warning disable MA0025 // Implement the functionality instead of throwing NotImplementedException
@@ -288,24 +293,22 @@ public partial class MinioClient : IMinioClient
                 throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
         }
 
-        if (response.StatusCode == HttpStatusCode.NotFound
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("ObjectLockConfigurationNotFoundError", StringComparison.OrdinalIgnoreCase))
             throw new MissingObjectLockConfigurationException(errResponse.BucketName, errResponse.Message);
 
-        if (response.StatusCode == HttpStatusCode.NotFound
+        if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.OrdinalIgnoreCase)
             && errResponse.Code.Equals("ReplicationConfigurationNotFoundError", StringComparison.OrdinalIgnoreCase))
             throw new MissingBucketReplicationConfigurationException(errResponse.BucketName, errResponse.Message);
 
         if (response.StatusCode == HttpStatusCode.Conflict
             && errResponse.Code.Equals("BucketAlreadyOwnedByYou", StringComparison.OrdinalIgnoreCase))
-            throw new ArgumentException("Bucket already owned by you: " + errResponse.BucketName,
-                nameof(response));
+            throw new ArgumentException("Bucket already owned by you: " + errResponse.BucketName, nameof(response));
 
         if (response.StatusCode == HttpStatusCode.PreconditionFailed
             && errResponse.Code.Equals("PreconditionFailed", StringComparison.OrdinalIgnoreCase))
             throw new PreconditionFailedException("At least one of the pre-conditions you " +
-                                                  "specified did not hold for object: \"" + errResponse.Resource +
-                                                  "\"");
+                                "specified did not hold for object: \"" + errResponse.Resource + "\"");
 
         throw new UnexpectedMinioException(errResponse.Message) { Response = errResponse, XmlError = response.Content };
     }

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -143,6 +143,9 @@ public static class RequestExtensions
         {
             if (ex.Message.Equals("ThrowBucketNotFoundException", StringComparison.Ordinal))
                 throw new BucketNotFoundException();
+
+            if (responseResult is not null) responseResult.Exception = ex;
+            else return new ResponseResult(request, ex);
             throw;
         }
     }

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -143,16 +143,7 @@ public static class RequestExtensions
         {
             if (ex.Message.Equals("ThrowBucketNotFoundException", StringComparison.Ordinal))
                 throw new BucketNotFoundException();
-
-            if (responseResult is not null)
-            {
-                responseResult.Exception = ex;
-                throw;
-            }
-
-            responseResult = new ResponseResult(request, ex);
-
-            return responseResult;
+            throw;
         }
     }
 

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -64,7 +64,7 @@ public static class RequestExtensions
                 requestMessageBuilder,
                 isSts, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
         if ((responseResult is not null &&
-             responseResult.Exception?.GetType().Equals(ignoreExceptionType) == false) ||
+            !Equals(responseResult.Exception?.GetType(), ignoreExceptionType)) ||
             responseResult.StatusCode != HttpStatusCode.OK)
         {
             var handler = new DefaultErrorHandler();

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -63,8 +63,8 @@ public static class RequestExtensions
             async Task<ResponseResult> () => await minioClient.ExecuteTaskCoreAsync(
                 requestMessageBuilder,
                 isSts, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
-        if (responseResult is not null &&
-            responseResult.Exception?.GetType().Equals(ignoreExceptionType) == false ||
+        if ((responseResult is not null &&
+             responseResult.Exception?.GetType().Equals(ignoreExceptionType) == false) ||
             responseResult.StatusCode != HttpStatusCode.OK)
         {
             var handler = new DefaultErrorHandler();

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -64,7 +64,7 @@ public static class RequestExtensions
                 requestMessageBuilder,
                 isSts, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
         if ((responseResult is not null &&
-            !Equals(responseResult.Exception?.GetType(), ignoreExceptionType)) ||
+             !Equals(responseResult.Exception?.GetType(), ignoreExceptionType)) ||
             responseResult.StatusCode != HttpStatusCode.OK)
         {
             var handler = new DefaultErrorHandler();

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -145,7 +145,10 @@ public static class RequestExtensions
                 throw new BucketNotFoundException();
 
             if (responseResult is not null)
+            {
                 responseResult.Exception = ex;
+                throw;
+            }
             else
                 responseResult = new ResponseResult(request, ex);
             return responseResult;

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using System.Net;
-using System.Web;
 using Minio.Credentials;
 using Minio.DataModel;
 using Minio.DataModel.Args;
@@ -38,18 +37,19 @@ public static class RequestExtensions
     ///     Actual doer that executes the request on the server
     /// </summary>
     /// <param name="minioClient"></param>
-    /// <param name="errorHandlers">List of handlers to override default handling</param>
     /// <param name="requestMessageBuilder">The build of HttpRequestMessageBuilder </param>
+    /// <param name="ignoreExceptionType">any type of Exception; if an exception type is going to be ignored</param>
     /// <param name="isSts">boolean; if true role credentials, otherwise IAM user</param>
     /// <param name="cancellationToken">Optional cancellation token to cancel the operation</param>
     /// <returns>ResponseResult</returns>
-    internal static Task<ResponseResult> ExecuteTaskAsync(this IMinioClient minioClient,
-        IEnumerable<IApiResponseErrorHandler> errorHandlers,
+    internal static async Task<ResponseResult> ExecuteTaskAsync(this IMinioClient minioClient,
         HttpRequestMessageBuilder requestMessageBuilder,
+        Type ignoreExceptionType = null,
         bool isSts = false,
         CancellationToken cancellationToken = default)
     {
-        Task<ResponseResult> responseResult;
+        var startTime = DateTime.Now;
+        var responseResult = new ResponseResult(requestMessageBuilder.Request, response: null);
         try
         {
             if (minioClient.Config.RequestTimeout > 0)
@@ -61,21 +61,32 @@ public static class RequestExtensions
                 cancellationToken = timeoutTokenSource.Token;
             }
 
-            responseResult = minioClient.ExecuteWithRetry(
-                async () => await minioClient.ExecuteTaskCoreAsync(errorHandlers, requestMessageBuilder,
-                    isSts, cancellationToken).ConfigureAwait(false));
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"\n\n   *** ExecuteTaskAsync::Threw an exception => {ex.Message}");
-            throw;
-        }
+            responseResult = await minioClient.ExecuteWithRetry(
+                async Task<ResponseResult> () => await minioClient.ExecuteTaskCoreAsync(
+                    requestMessageBuilder,
+                    isSts, cancellationToken).ConfigureAwait(false)).ConfigureAwait(false);
+            if (responseResult is not null &&
+                (responseResult.Exception?.GetType().Equals(ignoreExceptionType) == false ||
+                 responseResult.StatusCode != HttpStatusCode.OK))
+            {
+                var handler = new DefaultErrorHandler();
+                handler.Handle(responseResult);
+            }
 
-        return responseResult;
+            return responseResult;
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            responseResult.Exception ??= ignoreExceptionType is not null &&
+                                         ex.GetType() == ignoreExceptionType
+                ? null
+                : ex;
+            return responseResult;
+        }
     }
 
     private static async Task<ResponseResult> ExecuteTaskCoreAsync(this IMinioClient minioClient,
-        IEnumerable<IApiResponseErrorHandler> errorHandlers,
+        // IEnumerable<IApiResponseErrorHandler> errorHandlers,
         HttpRequestMessageBuilder requestMessageBuilder,
         bool isSts = false,
         CancellationToken cancellationToken = default)
@@ -89,73 +100,32 @@ public static class RequestExtensions
             v4Authenticator.Authenticate(requestMessageBuilder, isSts));
 
         var request = requestMessageBuilder.Request;
-
-        var responseResult = new ResponseResult(request, response: null);
+        var responseResult = new ResponseResult(request, new HttpResponseMessage());
         try
         {
             var response = await minioClient.Config.HttpClient.SendAsync(request,
-                    HttpCompletionOption.ResponseHeadersRead, cancellationToken)
-                .ConfigureAwait(false);
+                HttpCompletionOption.ResponseHeadersRead,
+                cancellationToken).ConfigureAwait(false);
+
             responseResult = new ResponseResult(request, response);
             if (requestMessageBuilder.ResponseWriter is not null)
                 await requestMessageBuilder.ResponseWriter(responseResult.ContentStream, cancellationToken)
                     .ConfigureAwait(false);
-
-            var path = request.RequestUri.LocalPath.TrimStart('/').TrimEnd('/')
-                .Split('/', StringSplitOptions.RemoveEmptyEntries);
-            if (responseResult.Response.StatusCode == HttpStatusCode.NotFound)
-            {
-                if (request.Method == HttpMethod.Get)
-                {
-                    var q = HttpUtility.ParseQueryString(request.RequestUri.Query);
-                    if (q.Get("object-lock") != null)
-                    {
-                        responseResult.Exception = new MissingObjectLockConfigurationException();
-                        return responseResult;
-                    }
-                }
-
-                if (request.Method == HttpMethod.Head)
-                {
-                    if (responseResult.Exception is BucketNotFoundException || path.Length == 1)
-                        responseResult.Exception = new BucketNotFoundException();
-
-                    if (path.Length > 1)
-                    {
-                        var found = await minioClient
-                            .BucketExistsAsync(new BucketExistsArgs().WithBucket(path[0]), cancellationToken)
-                            .ConfigureAwait(false);
-                        responseResult.Exception = !found
-                            ? new Exception("ThrowBucketNotFoundException")
-                            : new ObjectNotFoundException();
-                        throw responseResult.Exception;
-                    }
-                }
-
-                return responseResult;
-            }
-
-            minioClient.HandleIfErrorResponse(responseResult, errorHandlers, startTime);
-            return responseResult;
         }
-        catch (Exception ex) when (ex is not (OperationCanceledException or
-                                       ObjectNotFoundException))
+        catch (Exception ex)
         {
-            if (ex.Message.Equals("ThrowBucketNotFoundException", StringComparison.Ordinal))
-                throw new BucketNotFoundException();
-
-            if (responseResult is not null) responseResult.Exception = ex;
-            else return new ResponseResult(request, ex);
-            throw;
+            responseResult.Exception = ex;
         }
+
+        return responseResult;
     }
 
-    private static Task<ResponseResult> ExecuteWithRetry(this IMinioClient minioClient,
+    private static async Task<ResponseResult> ExecuteWithRetry(this IMinioClient minioClient,
         Func<Task<ResponseResult>> executeRequestCallback)
     {
         return minioClient.Config.RetryPolicyHandler is null
-            ? executeRequestCallback()
-            : minioClient.Config.RetryPolicyHandler.Handle(executeRequestCallback);
+            ? await executeRequestCallback().ConfigureAwait(false)
+            : await minioClient.Config.RetryPolicyHandler.Handle(executeRequestCallback).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -309,7 +279,7 @@ public static class RequestExtensions
             messageBuilder.AddOrUpdateHeaderParameter("Content-Type", contentType);
         }
 
-        if (headerMap is not null)
+        if (headerMap?.Count > 0)
         {
             if (headerMap.TryGetValue(messageBuilder.ContentTypeKey, out var value) && !string.IsNullOrEmpty(value))
                 headerMap[messageBuilder.ContentTypeKey] = contentType;
@@ -365,9 +335,11 @@ public static class RequestExtensions
     /// <param name="response"></param>
     /// <param name="handlers"></param>
     /// <param name="startTime"></param>
+    /// <param name="ignoreExceptionType"></param>
     private static void HandleIfErrorResponse(this IMinioClient minioClient, ResponseResult response,
         IEnumerable<IApiResponseErrorHandler> handlers,
-        DateTime startTime)
+        DateTime startTime,
+        Type ignoreExceptionType = null)
     {
         // Logs Response if HTTP tracing is enabled
         if (minioClient.Config.TraceHttp)
@@ -377,13 +349,20 @@ public static class RequestExtensions
         }
 
         if (response.Exception is not null)
-            throw response.Exception;
-
-        if (handlers.Any())
-            // Run through handlers passed to take up error handling
-            foreach (var handler in handlers)
-                handler.Handle(response);
-        else
-            minioClient.DefaultErrorHandler.Handle(response);
+        {
+            if (response.Exception?.GetType() == ignoreExceptionType)
+            {
+                response.Exception = null;
+            }
+            else
+            {
+                if (handlers.Any())
+                    // Run through handlers passed to take up error handling
+                    foreach (var handler in handlers)
+                        handler.Handle(response);
+                else
+                    minioClient.DefaultErrorHandler.Handle(response);
+            }
+        }
     }
 }

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -149,8 +149,9 @@ public static class RequestExtensions
                 responseResult.Exception = ex;
                 throw;
             }
-            else
-                responseResult = new ResponseResult(request, ex);
+
+            responseResult = new ResponseResult(request, ex);
+
             return responseResult;
         }
     }

--- a/SimpleTest/SimpleTest.csproj
+++ b/SimpleTest/SimpleTest.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #1118
and probably #1114, #1121, #1131 and #1132, ....
There may be some more issues filed for this very same issue.
If I find more, I'll add them here.
#1120 (The PR that tried to fix the issue)