### PR TITLE
Make response properties public

### DIFF
--- a/Minio/DataModel/Response/GenericResponse.cs
+++ b/Minio/DataModel/Response/GenericResponse.cs
@@ -26,6 +26,8 @@ public class GenericResponse
         ResponseStatusCode = statusCode;
     }
 
-    internal string ResponseContent { get; }
-    internal HttpStatusCode ResponseStatusCode { get; }
+    // These are very important for handling errors! 
+    // We should allow consumers to access them directly :)
+    public string ResponseContent { get; }
+    public HttpStatusCode ResponseStatusCode { get; }
 }

--- a/Minio/DataModel/Response/GenericResponse.cs
+++ b/Minio/DataModel/Response/GenericResponse.cs
@@ -26,8 +26,6 @@ public class GenericResponse
         ResponseStatusCode = statusCode;
     }
 
-    // These are very important for handling errors! 
-    // We should allow consumers to access them directly :)
     public string ResponseContent { get; }
     public HttpStatusCode ResponseStatusCode { get; }
 }


### PR DESCRIPTION
## Description

This PR makes two properties on `GenericResponse` public rather than internal. These properties are useful for error handling, as in many cases there is no other way to tell whether a request failed.