### PR TITLE
Add GetPresignedUrl Functionality to Minio .NET Client

### DIFF
--- a/Docs/API.md
+++ b/Docs/API.md
@@ -2762,6 +2762,48 @@ catch(MinioException e)
 }
 ```
 
+<a name="getPresignedUrl"></a>
+### GetPresignedUrlAsync(GetPresignedUrlArgs args)
+
+`Task<string> GetPresignedUrlAsync(GetPresignedUrlArgs args)`
+
+Generates a presigned URL for HTTP operation using the giving HTTP method (GET, PUT, DELETE). Browsers/Mobile clients may point to this URL to upload objects directly to a bucket even if it is private. This presigned URL can have an associated expiration time in seconds after which it is no longer operational. The default expiry is set to 7 days.
+
+__Parameters__
+
+
+| Param    | Type                    | Description                                                                          |
+|:---------|:------------------------|:-------------------------------------------------------------------------------------|
+| ``args`` | _GetPresignedUrlArgs_   | GetPresignedUrlArgs arguments object with HTTP method, bucket, object names & expiry |
+
+| Return Type                                                 | Exceptions                                                         |
+|:------------------------------------------------------------|:-------------------------------------------------------------------|
+| ``Task<string>`` : string contains URL to upload the object | Listed Exceptions:                                                 |
+|                                                             | ``InvalidBucketNameException`` : upon invalid bucket name          |
+|                                                             | ``InvalidKeyException`` : upon an invalid access key or secret key |
+|                                                             | ``ConnectionException`` : upon connection error                    |
+|                                                             | ``InvalidExpiryRangeException`` : upon invalid expiry range.       |
+
+
+__Example__
+
+```cs
+try
+{
+    var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Put;
+    GetPresignedUrlArgs args = GetPresignedUrlArgs(httpMethod)
+                                      .WithBucket("mybucket")
+                                      .WithObject("myobject")
+                                      .WithExpiry(60 * 60 * 24);
+    String url = await minioClient.GetPresignedUrlAsync(args);
+    Console.WriteLine(url);
+}
+catch(MinioException e)
+{
+    Console.WriteLine("Error occurred: " + e);
+}
+```
+
 <a name="presignedPostPolicy"></a>
 ### PresignedPostPolicy(PresignedPostPolicyArgs args)
 

--- a/Minio.Examples/Cases/GetPresignedUrl.cs
+++ b/Minio.Examples/Cases/GetPresignedUrl.cs
@@ -1,0 +1,56 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using Minio.DataModel.Args;
+
+namespace Minio.Examples.Cases;
+
+public static class GetPresignedUrl
+{
+    public static async Task Run(IMinioClient client,
+        string bucketName = "my-bucket-name",
+        string objectName = "my-object-name")
+    {
+        if (client is null) throw new ArgumentNullException(nameof(client));
+
+        try
+        {
+            await GetPresignedUrlByRequest(client, 
+                GetPresignedUrlArgs.PresignedUrlHttpMethod.Get, bucketName, objectName).ConfigureAwait(false);
+            await GetPresignedUrlByRequest(client, 
+                GetPresignedUrlArgs.PresignedUrlHttpMethod.Put, bucketName, objectName).ConfigureAwait(false);
+            await GetPresignedUrlByRequest(client, 
+                GetPresignedUrlArgs.PresignedUrlHttpMethod.Delete, bucketName, objectName).ConfigureAwait(false);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Exception {e.Message}");
+        }
+    }
+
+    private static async Task GetPresignedUrlByRequest(IMinioClient client,
+        GetPresignedUrlArgs.PresignedUrlHttpMethod requestMethod,
+        string bucketName = "my-bucket-name",
+        string objectName = "my-object-name")
+    {
+        var args = new GetPresignedUrlArgs(requestMethod)
+            .WithBucket(bucketName)
+            .WithObject(objectName)
+            .WithExpiry(1000);
+        var presignedUrl = await client.GetPresignedUrlAsync(args).ConfigureAwait(false);
+        Console.WriteLine($"Presigned '{requestMethod}' URL: {presignedUrl}");
+    }
+}

--- a/Minio.Examples/Program.cs
+++ b/Minio.Examples/Program.cs
@@ -20,6 +20,7 @@ using System.Net;
 using System.Security.Cryptography;
 using System.Text;
 using Minio.DataModel;
+using Minio.DataModel.Args;
 using Minio.DataModel.Encryption;
 using Minio.DataModel.Notification;
 using Minio.DataModel.ObjectLock;
@@ -261,6 +262,9 @@ public static class Program
 
         // Get the presigned url for a PUT object request
         await PresignedPutObject.Run(minioClient, bucketName, objectName).ConfigureAwait(false);
+        
+        // Get the presigned url's of an object for HTTP methods
+        await GetPresignedUrl.Run(minioClient, bucketName, objectName).ConfigureAwait(false);
 
         // Delete the list of objects
         await RemoveObjects.Run(minioClient, bucketName, objectsList).ConfigureAwait(false);

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -45,280 +45,8 @@ using Minio.Helper;
 namespace Minio.Functional.Tests;
 
 [SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Keep private const lowercase")]
-public static class FunctionalTest
+public static partial class FunctionalTest
 {
-    private const int KB = 1024;
-    private const int MB = 1024 * 1024;
-    private const int GB = 1024 * 1024 * 1024;
-
-    private const string dataFile1B = "datafile-1-b";
-
-    private const string dataFile10KB = "datafile-10-kB";
-    private const string dataFile6MB = "datafile-6-MB";
-
-    private const string makeBucketSignature =
-        "Task MakeBucketAsync(string bucketName, string location = 'us-east-1', CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string listBucketsSignature =
-        "Task<ListAllMyBucketsResult> ListBucketsAsync(CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string bucketExistsSignature =
-        "Task<bool> BucketExistsAsync(string bucketName, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeBucketSignature =
-        "Task RemoveBucketAsync(string bucketName, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string listObjectsSignature =
-        "IObservable<Item> ListObjectsAsync(string bucketName, string prefix = null, bool recursive = false, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string putObjectSignature =
-        "Task PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getObjectSignature =
-        "Task GetObjectAsync(GetObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string listIncompleteUploadsSignature =
-        "IObservable<Upload> ListIncompleteUploads(ListIncompleteUploads args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string listenBucketNotificationsSignature =
-        "IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(ListenBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string listenNotificationsSignature =
-        "IObservable<MinioNotificationRaw> ListenNotifications(ListenBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string copyObjectSignature =
-        "Task<CopyObjectResult> CopyObjectAsync(CopyObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string statObjectSignature =
-        "Task<ObjectStat> StatObjectAsync(StatObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeObjectSignature1 =
-        "Task RemoveObjectAsync(RemoveObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeObjectSignature2 =
-        "Task<IObservable<DeleteError>> RemoveObjectsAsync(RemoveObjectsArgs, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeIncompleteUploadSignature =
-        "Task RemoveIncompleteUploadAsync(RemoveIncompleteUploadArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string presignedPutObjectSignature =
-        "Task<string> PresignedPutObjectAsync(PresignedPutObjectArgs args)";
-
-    private const string presignedGetObjectSignature =
-        "Task<string> PresignedGetObjectAsync(PresignedGetObjectArgs args)";
-
-    private const string presignedPostPolicySignature =
-        "Task<Dictionary<string, string>> PresignedPostPolicyAsync(PresignedPostPolicyArgs args)";
-
-    private const string getBucketPolicySignature =
-        "Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setBucketPolicySignature =
-        "Task SetPolicyAsync(SetPolicyArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getBucketNotificationSignature =
-        "Task<BucketNotification> GetBucketNotificationAsync(GetBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setBucketNotificationSignature =
-        "Task SetBucketNotificationAsync(SetBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeAllBucketsNotificationSignature =
-        "Task RemoveAllBucketNotificationsAsync(RemoveAllBucketNotifications args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setBucketEncryptionSignature =
-        "Task SetBucketEncryptionAsync(SetBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getBucketEncryptionSignature =
-        "Task<ServerSideEncryptionConfiguration> GetBucketEncryptionAsync(GetBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeBucketEncryptionSignature =
-        "Task RemoveBucketEncryptionAsync(RemoveBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string selectObjectSignature =
-        "Task<SelectResponseStream> SelectObjectContentAsync(SelectObjectContentArgs args,CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setObjectLegalHoldSignature =
-        "Task SetObjectLegalHoldAsync(SetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getObjectLegalHoldSignature =
-        "Task<bool> GetObjectLegalHoldAsync(GetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setObjectLockConfigurationSignature =
-        "Task SetObjectLockConfigurationAsync(SetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getObjectLockConfigurationSignature =
-        "Task<ObjectLockConfiguration> GetObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string deleteObjectLockConfigurationSignature =
-        "Task RemoveObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getBucketTagsSignature =
-        "Task<Tagging> GetBucketTagsAsync(GetBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setBucketTagsSignature =
-        "Task SetBucketTagsAsync(SetBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string deleteBucketTagsSignature =
-        "Task RemoveBucketTagsAsync(RemoveBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setVersioningSignature =
-        "Task SetVersioningAsync(SetVersioningArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getVersioningSignature =
-        "Task<VersioningConfiguration> GetVersioningAsync(GetVersioningArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string removeVersioningSignature =
-        "Task RemoveBucketTagsAsync(RemoveBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getObjectTagsSignature =
-        "Task<Tagging> GetObjectTagsAsync(GetObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setObjectTagsSignature =
-        "Task SetObjectTagsAsync(SetObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string deleteObjectTagsSignature =
-        "Task RemoveObjectTagsAsync(RemoveObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setObjectRetentionSignature =
-        "Task SetObjectRetentionAsync(SetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getObjectRetentionSignature =
-        "Task<ObjectRetentionConfiguration> GetObjectRetentionAsync(GetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string clearObjectRetentionSignature =
-        "Task ClearObjectRetentionAsync(ClearObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string getBucketLifecycleSignature =
-        "Task<LifecycleConfiguration> GetBucketLifecycleAsync(GetBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string setBucketLifecycleSignature =
-        "Task SetBucketLifecycleAsync(SetBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private const string deleteBucketLifecycleSignature =
-        "Task RemoveBucketLifecycleAsync(RemoveBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
-
-    private static readonly Random rnd = new();
-
-    private static readonly RandomStreamGenerator rsg = new(100 * MB);
-
-    private static string Bash(string cmd)
-    {
-        var Replacements = new Dictionary<string, string>
-            (StringComparer.Ordinal)
-            {
-                { "$", "\\$" },
-                { "(", "\\(" },
-                { ")", "\\)" },
-                { "{", "\\{" },
-                { "}", "\\}" },
-                { "[", "\\[" },
-                { "]", "\\]" },
-                { "@", "\\@" },
-                { "%", "\\%" },
-                { "&", "\\&" },
-                { "#", "\\#" },
-                { "+", "\\+" }
-            };
-
-        foreach (var toReplace in Replacements.Keys)
-            cmd = cmd.Replace(toReplace, Replacements[toReplace], StringComparison.Ordinal);
-        var cmdNoReturn = cmd + " >/dev/null 2>&1";
-
-        using var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "/bin/bash",
-                Arguments = $"-c \"{cmdNoReturn}\"",
-                UseShellExecute = false,
-                RedirectStandardOutput = true,
-                CreateNoWindow = true
-            }
-        };
-
-        _ = process.Start();
-        var result = process.StandardOutput.ReadLine();
-        process.WaitForExit();
-
-        return result;
-    }
-
-    // Create a file of given size from random byte array or optionally create a symbolic link
-    // to the dataFileName residing in MINT_DATA_DIR
-    private static string CreateFile(int size, string dataFileName = null)
-    {
-        var fileName = GetRandomName();
-
-        if (!IsMintEnv())
-        {
-            var data = new byte[size];
-            rnd.NextBytes(data);
-
-            File.WriteAllBytes(fileName, data);
-            return GetFilePath(fileName);
-        }
-
-        return GetFilePath(dataFileName);
-    }
-
-    public static string GetRandomObjectName(int length = 5)
-    {
-        // Server side does not allow the following characters in object names
-        // '-', '_', '.', '/', '*'
-#if NET6_0_OR_GREATER
-        var characters = "abcd+%$#@&{}[]()";
-#else
-        var characters = "abcdefgh+%$#@&";
-#endif
-        var result = new StringBuilder(length);
-
-        for (var i = 0; i < length; i++) result.Append(characters[rnd.Next(characters.Length)]);
-        return result.ToString();
-    }
-
-    // Generate a random string
-    public static string GetRandomName(int length = 5)
-    {
-        var characters = "0123456789abcdefghijklmnopqrstuvwxyz";
-        if (length > 50) length = 50;
-
-        var result = new StringBuilder(length);
-        for (var i = 0; i < length; i++) _ = result.Append(characters[rnd.Next(characters.Length)]);
-
-        return "minio-dotnet-example-" + result;
-    }
-
-    internal static void GenerateRandom500MB_File(string fileName)
-    {
-        using var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
-        var fileSize = 500L * 1024 * 1024;
-        var segments = fileSize / 10000;
-        var last_seg = fileSize % 10000;
-        using var br = new BinaryWriter(fs);
-
-        for (long i = 0; i < segments; i++)
-            br.Write(new byte[10000]);
-
-        br.Write(new byte[last_seg]);
-        br.Close();
-    }
-
-    // Return true if running in Mint mode
-    public static bool IsMintEnv()
-    {
-        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MINT_DATA_DIR"));
-    }
-
-    // Get full path of file
-    public static string GetFilePath(string fileName)
-    {
-        var dataDir = Environment.GetEnvironmentVariable("MINT_DATA_DIR");
-        if (!string.IsNullOrEmpty(dataDir)) return $"{dataDir}/{fileName}";
-
-        var path = Directory.GetCurrentDirectory();
-        return $"{path}/{fileName}";
-    }
-
     internal static Task RunCoreTests(IMinioClient minioClient)
     {
         ConcurrentBag<Task> coreTestsTasks = new()
@@ -340,6 +68,8 @@ public static class FunctionalTest
             // Test Presigned Get/Put operations
             PresignedGetObject_Test1(minioClient),
             PresignedPutObject_Test1(minioClient),
+            GetPresignedUrl_Get_Test1(minioClient),
+            GetPresignedUrl_Put_Delete_Test1(minioClient),
 
             // Test incomplete uploads
             ListIncompleteUpload_Test1(minioClient),
@@ -1319,6 +1049,13 @@ public static class FunctionalTest
         using var filestream = new FileStream(filePath, FileMode.Open, FileAccess.Read);
         using var stream = new StreamContent(filestream);
         await minio.WrapperPutAsync(url, stream).ConfigureAwait(false);
+    }
+
+    internal static async Task DeleteObjectAsync(IMinioClient minio, string url)
+    {
+        using var response = await minio.WrapperDeleteAsync(url).ConfigureAwait(false);
+        if (string.IsNullOrEmpty(Convert.ToString(response.Content)) || HttpStatusCode.OK != response.StatusCode)
+            throw new InvalidOperationException("Unable to delete via presigned URL" + nameof(response.Content));
     }
 
     internal static async Task PresignedPostPolicy_Test1(IMinioClient minio)
@@ -5940,6 +5677,367 @@ public static class FunctionalTest
         {
             new MintLogger("PresignedPutObject_Test2", presignedPutObjectSignature,
                 "Tests whether PresignedPutObject url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
+
+    #endregion
+
+    #region Get Presigned Url
+
+    internal static async Task GetPresignedUrl_Get_Test1(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        var expiresInt = 1000;
+        var downloadFile = GetRandomObjectName(10);
+
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "expiresInt", expiresInt.ToString(CultureInfo.InvariantCulture) }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
+            {
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length);
+
+                _ = await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            }
+
+            var statObjectArgs = new StatObjectArgs()
+                .WithBucket(bucketName)
+                .WithObject(objectName);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+
+            var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Get;
+            var preArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(expiresInt);
+            var presigned_url = await minio.GetPresignedUrlAsync(preArgs).ConfigureAwait(false);
+
+            await DownloadObjectAsync(minio, presigned_url, downloadFile).ConfigureAwait(false);
+            var writtenInfo = new FileInfo(downloadFile);
+            var file_read_size = writtenInfo.Length;
+            // Compare the size of the file downloaded using the generated
+            // presigned_url (expected value) and the actual object size on the server
+            Assert.AreEqual(file_read_size, stats.Size);
+            new MintLogger("GetPresignedUrl_Get_Test1", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket", TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetPresignedUrl_Get_Test1", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket", TestStatus.FAIL,
+                DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            File.Delete(downloadFile);
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task GetPresignedUrl_Get_Test2(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        var expiresInt = 0;
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "expiresInt", expiresInt.ToString(CultureInfo.InvariantCulture) }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
+            {
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length);
+
+                _ = await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            }
+
+            var statObjectArgs = new StatObjectArgs()
+                .WithBucket(bucketName)
+                .WithObject(objectName);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Get;
+            var preArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(0);
+            var presigned_url = await minio.GetPresignedUrlAsync(preArgs).ConfigureAwait(false);
+            throw new InvalidOperationException(
+                "GetPresignedUrlAsync expected to throw an InvalidExpiryRangeException.");
+        }
+        catch (InvalidExpiryRangeException)
+        {
+            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+        }
+        catch (InvalidOperationException ex)
+        {
+            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task GetPresignedUrl_Get_Test3(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        var expiresInt = 1000;
+        var reqDate = DateTime.UtcNow.AddSeconds(-50);
+        var downloadFile = GetRandomObjectName(10);
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "expiresInt", expiresInt.ToString(CultureInfo.InvariantCulture) },
+                {
+                    "reqParams",
+                    "response-content-type:application/json,response-content-disposition:attachment;filename=  MyDoc u m  e   nt.json ;"
+                },
+                { "reqDate", reqDate.ToString(CultureInfo.InvariantCulture) }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
+            {
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length);
+
+                _ = await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            }
+
+            var statObjectArgs = new StatObjectArgs()
+                .WithBucket(bucketName)
+                .WithObject(objectName);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var reqParams = new Dictionary<string, string>
+                (StringComparer.Ordinal)
+                {
+                    ["response-content-type"] = "application/json",
+                    ["response-content-disposition"] = "attachment;filename=  MyDoc u m  e   nt.json ;"
+                };
+            var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Get;
+            var preArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(1000)
+                .WithHeaders(reqParams)
+                .WithRequestDate(reqDate);
+            var presigned_url = await minio.GetPresignedUrlAsync(preArgs).ConfigureAwait(false);
+
+            using var response = await minio.WrapperGetAsync(presigned_url).ConfigureAwait(false);
+            if (response.StatusCode != HttpStatusCode.OK ||
+                string.IsNullOrEmpty(Convert.ToString(response.Content, CultureInfo.InvariantCulture)))
+                throw new InvalidOperationException("Unable to download via presigned URL " + nameof(response.Content));
+
+            Assert.IsTrue(response.Content.Headers.GetValues("Content-Type")
+                .Contains(reqParams["response-content-type"], StringComparer.Ordinal));
+            Assert.IsTrue(response.Content.Headers.GetValues("Content-Disposition")
+                .Contains(reqParams["response-content-disposition"], StringComparer.Ordinal));
+            Assert.IsTrue(response.Content.Headers.GetValues("Content-Length")
+                .Contains(stats.Size.ToString(CultureInfo.InvariantCulture), StringComparer.Ordinal));
+
+            using (var fs = new FileStream(downloadFile, FileMode.CreateNew))
+            {
+                await response.Content.CopyToAsync(fs).ConfigureAwait(false);
+            }
+
+            var writtenInfo = new FileInfo(downloadFile);
+            var file_read_size = writtenInfo.Length;
+
+            // Compare the size of the file downloaded with the generated
+            // presigned_url (expected) and the actual object size on the server
+            Assert.AreEqual(file_read_size, stats.Size);
+            new MintLogger("GetPresignedUrl_Get_Test3", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when override response headers sent",
+                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetPresignedUrl_Get_Test3", presignedGetObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when override response headers sent",
+                TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            File.Delete(downloadFile);
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+        }
+    }
+
+    internal static async Task GetPresignedUrl_Put_Delete_Test1(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        var expiresInt = 1000;
+        var fileName = CreateFile(10 * KB, dataFile10KB);
+
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "expiresInt", expiresInt.ToString(CultureInfo.InvariantCulture) }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            // Upload with presigned url
+            var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Put;
+            var presignedPutObjectArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(1000);
+            var presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            await UploadObjectAsync(minio, presigned_url, fileName).ConfigureAwait(false);
+            // Get stats for object from server
+            var statObjectArgs = new StatObjectArgs()
+                .WithBucket(bucketName)
+                .WithObject(objectName);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            // Compare with file used for upload
+            var writtenInfo = new FileInfo(fileName);
+            var file_written_size = writtenInfo.Length;
+            Assert.AreEqual(file_written_size, stats.Size);
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", presignedPutObjectSignature,
+                "Tests whether GetPresignedUrl url uploads object to bucket", TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
+
+            // Delete with presigned url
+            httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Delete;
+            presignedPutObjectArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(1000);
+            presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            await DeleteObjectAsync(minio, presigned_url).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", presignedPutObjectSignature,
+                "Tests whether GetPresignedUrl url uploads object to bucket", TestStatus.FAIL,
+                DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
+            throw;
+        }
+        finally
+        {
+            await TearDown(minio, bucketName).ConfigureAwait(false);
+            if (!IsMintEnv()) File.Delete(fileName);
+        }
+    }
+
+    internal static async Task GetPresignedUrl_Put_Delete_Test2(IMinioClient minio)
+    {
+        var startTime = DateTime.Now;
+        var bucketName = GetRandomName(15);
+        var objectName = GetRandomObjectName(10);
+        var expiresInt = 0;
+
+        var args = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "bucketName", bucketName },
+                { "objectName", objectName },
+                { "expiresInt", expiresInt.ToString(CultureInfo.InvariantCulture) }
+            };
+        try
+        {
+            await Setup_Test(minio, bucketName).ConfigureAwait(false);
+            using (var filestream = rsg.GenerateStreamFromSeed(1 * KB))
+            {
+                var putObjectArgs = new PutObjectArgs()
+                    .WithBucket(bucketName)
+                    .WithObject(objectName)
+                    .WithStreamData(filestream)
+                    .WithObjectSize(filestream.Length);
+
+                _ = await minio.PutObjectAsync(putObjectArgs).ConfigureAwait(false);
+            }
+
+            var statObjectArgs = new StatObjectArgs()
+                .WithBucket(bucketName)
+                .WithObject(objectName);
+            var stats = await minio.StatObjectAsync(statObjectArgs).ConfigureAwait(false);
+            var httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Put;
+            var presignedPutObjectArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(0);
+            var presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+
+            // Delete with presigned url
+            httpMethod = GetPresignedUrlArgs.PresignedUrlHttpMethod.Delete;
+            presignedPutObjectArgs = new GetPresignedUrlArgs(httpMethod)
+                .WithBucket(bucketName)
+                .WithObject(objectName)
+                .WithExpiry(1000);
+            presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
+            await DeleteObjectAsync(minio, presigned_url).ConfigureAwait(false);
+        }
+        catch (InvalidExpiryRangeException)
+        {
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
+                TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
+        }
+        catch (Exception ex)
+        {
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+                "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }

--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -5737,13 +5737,13 @@ public static partial class FunctionalTest
             // Compare the size of the file downloaded using the generated
             // presigned_url (expected value) and the actual object size on the server
             Assert.AreEqual(file_read_size, stats.Size);
-            new MintLogger("GetPresignedUrl_Get_Test1", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test1", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket", TestStatus.PASS,
                 DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger("GetPresignedUrl_Get_Test1", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test1", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket", TestStatus.FAIL,
                 DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
@@ -5797,20 +5797,20 @@ public static partial class FunctionalTest
         }
         catch (InvalidExpiryRangeException)
         {
-            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (InvalidOperationException ex)
         {
-            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
         }
         catch (Exception ex)
         {
-            new MintLogger("GetPresignedUrl_Get_Test2", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
@@ -5897,13 +5897,13 @@ public static partial class FunctionalTest
             // Compare the size of the file downloaded with the generated
             // presigned_url (expected) and the actual object size on the server
             Assert.AreEqual(file_read_size, stats.Size);
-            new MintLogger("GetPresignedUrl_Get_Test3", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test3", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when override response headers sent",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger("GetPresignedUrl_Get_Test3", presignedGetObjectSignature,
+            new MintLogger("GetPresignedUrl_Get_Test3", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when override response headers sent",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
@@ -5950,7 +5950,7 @@ public static partial class FunctionalTest
             var writtenInfo = new FileInfo(fileName);
             var file_written_size = writtenInfo.Length;
             Assert.AreEqual(file_written_size, stats.Size);
-            new MintLogger("GetPresignedUrl_Put_Delete_Test1", presignedPutObjectSignature,
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url uploads object to bucket", TestStatus.PASS,
                 DateTime.Now - startTime, args: args).Log();
 
@@ -5962,10 +5962,14 @@ public static partial class FunctionalTest
                 .WithExpiry(1000);
             presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
             await DeleteObjectAsync(minio, presigned_url).ConfigureAwait(false);
+
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", getPresignedUrlSignature,
+                "Tests whether GetPresignedUrl url deletes object from bucket", TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger("GetPresignedUrl_Put_Delete_Test1", presignedPutObjectSignature,
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url uploads object to bucket", TestStatus.FAIL,
                 DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;
@@ -6015,7 +6019,7 @@ public static partial class FunctionalTest
                 .WithObject(objectName)
                 .WithExpiry(0);
             var presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
-            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
 
@@ -6027,16 +6031,20 @@ public static partial class FunctionalTest
                 .WithExpiry(1000);
             presigned_url = await minio.GetPresignedUrlAsync(presignedPutObjectArgs).ConfigureAwait(false);
             await DeleteObjectAsync(minio, presigned_url).ConfigureAwait(false);
+
+            new MintLogger("GetPresignedUrl_Put_Delete_Test1", getPresignedUrlSignature,
+                "Tests whether GetPresignedUrl url deletes object from bucket", TestStatus.PASS,
+                DateTime.Now - startTime, args: args).Log();
         }
         catch (InvalidExpiryRangeException)
         {
-            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
         }
         catch (Exception ex)
         {
-            new MintLogger("GetPresignedUrl_Put_Delete_Test2", presignedPutObjectSignature,
+            new MintLogger("GetPresignedUrl_Put_Delete_Test2", getPresignedUrlSignature,
                 "Tests whether GetPresignedUrl url retrieves object from bucket when invalid expiry is set.",
                 TestStatus.FAIL, DateTime.Now - startTime, ex.Message, ex.ToString(), args: args).Log();
             throw;

--- a/Minio.Functional.Tests/FunctionalTests-setup.cs
+++ b/Minio.Functional.Tests/FunctionalTests-setup.cs
@@ -15,32 +15,9 @@
  * limitations under the License.
  */
 
-using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
-using System.Net;
-using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
-using System.Text.RegularExpressions;
-using System.Web;
-using System.Xml;
-using System.Xml.Serialization;
-using CommunityToolkit.HighPerformance;
-using ICSharpCode.SharpZipLib.Core;
-using ICSharpCode.SharpZipLib.Zip;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Minio.DataModel;
-using Minio.DataModel.Args;
-using Minio.DataModel.Encryption;
-using Minio.DataModel.ILM;
-using Minio.DataModel.Notification;
-using Minio.DataModel.ObjectLock;
-using Minio.DataModel.Select;
-using Minio.DataModel.Tags;
-using Minio.Exceptions;
-using Minio.Helper;
 
 namespace Minio.Functional.Tests;
 
@@ -107,6 +84,9 @@ public static partial class FunctionalTest
 
     private const string presignedGetObjectSignature =
         "Task<string> PresignedGetObjectAsync(PresignedGetObjectArgs args)";
+
+    private const string getPresignedUrlSignature =
+        "Task<string> GetPresignedUrlAsync(GetPresignedUrlArgs args)";
 
     private const string presignedPostPolicySignature =
         "Task<Dictionary<string, string>> PresignedPostPolicyAsync(PresignedPostPolicyArgs args)";

--- a/Minio.Functional.Tests/FunctionalTests-setup.cs
+++ b/Minio.Functional.Tests/FunctionalTests-setup.cs
@@ -1,0 +1,322 @@
+﻿/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage,
+ * (C) 2017-2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Web;
+using System.Xml;
+using System.Xml.Serialization;
+using CommunityToolkit.HighPerformance;
+using ICSharpCode.SharpZipLib.Core;
+using ICSharpCode.SharpZipLib.Zip;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Minio.DataModel;
+using Minio.DataModel.Args;
+using Minio.DataModel.Encryption;
+using Minio.DataModel.ILM;
+using Minio.DataModel.Notification;
+using Minio.DataModel.ObjectLock;
+using Minio.DataModel.Select;
+using Minio.DataModel.Tags;
+using Minio.Exceptions;
+using Minio.Helper;
+
+namespace Minio.Functional.Tests;
+
+[SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "Keep private const lowercase")]
+[SuppressMessage("Design", "MA0048:File name must match type name")]
+public static partial class FunctionalTest
+{
+    private const int KB = 1024;
+    private const int MB = 1024 * 1024;
+    private const int GB = 1024 * 1024 * 1024;
+
+    private const string dataFile1B = "datafile-1-b";
+
+    private const string dataFile10KB = "datafile-10-kB";
+    private const string dataFile6MB = "datafile-6-MB";
+
+    private const string makeBucketSignature =
+        "Task MakeBucketAsync(string bucketName, string location = 'us-east-1', CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string listBucketsSignature =
+        "Task<ListAllMyBucketsResult> ListBucketsAsync(CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string bucketExistsSignature =
+        "Task<bool> BucketExistsAsync(string bucketName, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeBucketSignature =
+        "Task RemoveBucketAsync(string bucketName, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string listObjectsSignature =
+        "IObservable<Item> ListObjectsAsync(string bucketName, string prefix = null, bool recursive = false, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string putObjectSignature =
+        "Task PutObjectAsync(PutObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getObjectSignature =
+        "Task GetObjectAsync(GetObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string listIncompleteUploadsSignature =
+        "IObservable<Upload> ListIncompleteUploads(ListIncompleteUploads args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string listenBucketNotificationsSignature =
+        "IObservable<MinioNotificationRaw> ListenBucketNotificationsAsync(ListenBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string listenNotificationsSignature =
+        "IObservable<MinioNotificationRaw> ListenNotifications(ListenBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string copyObjectSignature =
+        "Task<CopyObjectResult> CopyObjectAsync(CopyObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string statObjectSignature =
+        "Task<ObjectStat> StatObjectAsync(StatObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeObjectSignature1 =
+        "Task RemoveObjectAsync(RemoveObjectArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeObjectSignature2 =
+        "Task<IObservable<DeleteError>> RemoveObjectsAsync(RemoveObjectsArgs, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeIncompleteUploadSignature =
+        "Task RemoveIncompleteUploadAsync(RemoveIncompleteUploadArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string presignedPutObjectSignature =
+        "Task<string> PresignedPutObjectAsync(PresignedPutObjectArgs args)";
+
+    private const string presignedGetObjectSignature =
+        "Task<string> PresignedGetObjectAsync(PresignedGetObjectArgs args)";
+
+    private const string presignedPostPolicySignature =
+        "Task<Dictionary<string, string>> PresignedPostPolicyAsync(PresignedPostPolicyArgs args)";
+
+    private const string getBucketPolicySignature =
+        "Task<string> GetPolicyAsync(GetPolicyArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setBucketPolicySignature =
+        "Task SetPolicyAsync(SetPolicyArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getBucketNotificationSignature =
+        "Task<BucketNotification> GetBucketNotificationAsync(GetBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setBucketNotificationSignature =
+        "Task SetBucketNotificationAsync(SetBucketNotificationsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeAllBucketsNotificationSignature =
+        "Task RemoveAllBucketNotificationsAsync(RemoveAllBucketNotifications args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setBucketEncryptionSignature =
+        "Task SetBucketEncryptionAsync(SetBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getBucketEncryptionSignature =
+        "Task<ServerSideEncryptionConfiguration> GetBucketEncryptionAsync(GetBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeBucketEncryptionSignature =
+        "Task RemoveBucketEncryptionAsync(RemoveBucketEncryptionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string selectObjectSignature =
+        "Task<SelectResponseStream> SelectObjectContentAsync(SelectObjectContentArgs args,CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setObjectLegalHoldSignature =
+        "Task SetObjectLegalHoldAsync(SetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getObjectLegalHoldSignature =
+        "Task<bool> GetObjectLegalHoldAsync(GetObjectLegalHoldArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setObjectLockConfigurationSignature =
+        "Task SetObjectLockConfigurationAsync(SetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getObjectLockConfigurationSignature =
+        "Task<ObjectLockConfiguration> GetObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string deleteObjectLockConfigurationSignature =
+        "Task RemoveObjectLockConfigurationAsync(GetObjectLockConfigurationArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getBucketTagsSignature =
+        "Task<Tagging> GetBucketTagsAsync(GetBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setBucketTagsSignature =
+        "Task SetBucketTagsAsync(SetBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string deleteBucketTagsSignature =
+        "Task RemoveBucketTagsAsync(RemoveBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setVersioningSignature =
+        "Task SetVersioningAsync(SetVersioningArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getVersioningSignature =
+        "Task<VersioningConfiguration> GetVersioningAsync(GetVersioningArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string removeVersioningSignature =
+        "Task RemoveBucketTagsAsync(RemoveBucketTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getObjectTagsSignature =
+        "Task<Tagging> GetObjectTagsAsync(GetObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setObjectTagsSignature =
+        "Task SetObjectTagsAsync(SetObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string deleteObjectTagsSignature =
+        "Task RemoveObjectTagsAsync(RemoveObjectTagsArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setObjectRetentionSignature =
+        "Task SetObjectRetentionAsync(SetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getObjectRetentionSignature =
+        "Task<ObjectRetentionConfiguration> GetObjectRetentionAsync(GetObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string clearObjectRetentionSignature =
+        "Task ClearObjectRetentionAsync(ClearObjectRetentionArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string getBucketLifecycleSignature =
+        "Task<LifecycleConfiguration> GetBucketLifecycleAsync(GetBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string setBucketLifecycleSignature =
+        "Task SetBucketLifecycleAsync(SetBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private const string deleteBucketLifecycleSignature =
+        "Task RemoveBucketLifecycleAsync(RemoveBucketLifecycleArgs args, CancellationToken cancellationToken = default(CancellationToken))";
+
+    private static readonly Random rnd = new();
+
+    private static readonly RandomStreamGenerator rsg = new(100 * MB);
+
+    private static string Bash(string cmd)
+    {
+        var Replacements = new Dictionary<string, string>
+            (StringComparer.Ordinal)
+            {
+                { "$", "\\$" },
+                { "(", "\\(" },
+                { ")", "\\)" },
+                { "{", "\\{" },
+                { "}", "\\}" },
+                { "[", "\\[" },
+                { "]", "\\]" },
+                { "@", "\\@" },
+                { "%", "\\%" },
+                { "&", "\\&" },
+                { "#", "\\#" },
+                { "+", "\\+" }
+            };
+
+        foreach (var toReplace in Replacements.Keys)
+            cmd = cmd.Replace(toReplace, Replacements[toReplace], StringComparison.Ordinal);
+        var cmdNoReturn = cmd + " >/dev/null 2>&1";
+
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "/bin/bash",
+                Arguments = $"-c \"{cmdNoReturn}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true
+            }
+        };
+
+        _ = process.Start();
+        var result = process.StandardOutput.ReadLine();
+        process.WaitForExit();
+
+        return result;
+    }
+
+    // Create a file of given size from random byte array or optionally create a symbolic link
+    // to the dataFileName residing in MINT_DATA_DIR
+    private static string CreateFile(int size, string dataFileName = null)
+    {
+        var fileName = GetRandomName();
+
+        if (!IsMintEnv())
+        {
+            var data = new byte[size];
+            rnd.NextBytes(data);
+
+            File.WriteAllBytes(fileName, data);
+            return GetFilePath(fileName);
+        }
+
+        return GetFilePath(dataFileName);
+    }
+
+    public static string GetRandomObjectName(int length = 5)
+    {
+        // Server side does not allow the following characters in object names
+        // '-', '_', '.', '/', '*'
+#if NET6_0_OR_GREATER
+        var characters = "abcd+%$#@&{}[]()";
+#else
+        var characters = "abcdefgh+%$#@&";
+#endif
+        var result = new StringBuilder(length);
+
+        for (var i = 0; i < length; i++) result.Append(characters[rnd.Next(characters.Length)]);
+        return result.ToString();
+    }
+
+    // Generate a random string
+    public static string GetRandomName(int length = 5)
+    {
+        var characters = "0123456789abcdefghijklmnopqrstuvwxyz";
+        if (length > 50) length = 50;
+
+        var result = new StringBuilder(length);
+        for (var i = 0; i < length; i++) _ = result.Append(characters[rnd.Next(characters.Length)]);
+
+        return "minio-dotnet-example-" + result;
+    }
+
+    internal static void GenerateRandom500MB_File(string fileName)
+    {
+        using var fs = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None, 4096, true);
+        var fileSize = 500L * 1024 * 1024;
+        var segments = fileSize / 10000;
+        var last_seg = fileSize % 10000;
+        using var br = new BinaryWriter(fs);
+
+        for (long i = 0; i < segments; i++)
+            br.Write(new byte[10000]);
+
+        br.Write(new byte[last_seg]);
+        br.Close();
+    }
+
+    // Return true if running in Mint mode
+    public static bool IsMintEnv()
+    {
+        return !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MINT_DATA_DIR"));
+    }
+
+    // Get full path of file
+    public static string GetFilePath(string fileName)
+    {
+        var dataDir = Environment.GetEnvironmentVariable("MINT_DATA_DIR");
+        if (!string.IsNullOrEmpty(dataDir)) return $"{dataDir}/{fileName}";
+
+        var path = Directory.GetCurrentDirectory();
+        return $"{path}/{fileName}";
+    }
+}

--- a/Minio.Functional.Tests/Program.cs
+++ b/Minio.Functional.Tests/Program.cs
@@ -212,6 +212,11 @@ internal static class Program
         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test1(minioClient));
         functionalTestTasks.Add(FunctionalTest.PresignedPutObject_Test2(minioClient));
         // FunctionalTest.PresignedPostPolicy_Test1(minioClient).Wait();
+        functionalTestTasks.Add(FunctionalTest.GetPresignedUrl_Get_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetPresignedUrl_Get_Test2(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetPresignedUrl_Get_Test3(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetPresignedUrl_Put_Delete_Test1(minioClient));
+        functionalTestTasks.Add(FunctionalTest.GetPresignedUrl_Put_Delete_Test2(minioClient));
 
         // Test incomplete uploads
         functionalTestTasks.Add(FunctionalTest.ListIncompleteUpload_Test1(minioClient));

--- a/Minio/ApiEndpoints/IObjectOperations.cs
+++ b/Minio/ApiEndpoints/IObjectOperations.cs
@@ -293,6 +293,20 @@ public interface IObjectOperations
     /// <exception cref="ObjectNotFoundException">When object is not found</exception>
     /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
     Task<string> PresignedPutObjectAsync(PresignedPutObjectArgs args);
+    
+    /// <summary>
+    ///     Get Presigned Url -returns a presigned url of an object for HTTP method without credentials.URL can have a maximum expiry of
+    ///     upto 7 days or a minimum of 1 second.
+    /// </summary>
+    /// <param name="args">GetPresignedUrlArgs Arguments Object which encapsulates HTTP method, bucket, object names, expiry</param>
+    /// <returns></returns>
+    /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
+    /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+    /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
+    /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
+    /// <exception cref="ObjectNotFoundException">When object is not found</exception>
+    /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
+    Task<string> GetPresignedUrlAsync(GetPresignedUrlArgs args);
 
     /// <summary>
     ///     Tests the object's existence and returns metadata about existing objects.

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -275,6 +275,31 @@ public partial class MinioClient : IObjectOperations
     }
 
     /// <summary>
+    ///     Get Presigned Url -returns a presigned url of an object for HTTP method without credentials.URL can have a maximum expiry of
+    ///     upto 7 days or a minimum of 1 second.
+    /// </summary>
+    /// <param name="args">GetPresignedUrlArgs Arguments Object which encapsulates HTTP method, bucket, object names, expiry</param>
+    /// <returns></returns>
+    /// <exception cref="AuthorizationException">When access or secret key is invalid</exception>
+    /// <exception cref="InvalidBucketNameException">When bucket name is invalid</exception>
+    /// <exception cref="InvalidObjectNameException">When object name is invalid</exception>
+    /// <exception cref="BucketNotFoundException">When bucket is not found</exception>
+    /// <exception cref="ObjectNotFoundException">When object is not found</exception>
+    /// <exception cref="MalFormedXMLException">When configuration XML provided is invalid</exception>
+    public async Task<string> GetPresignedUrlAsync(GetPresignedUrlArgs args)
+    {
+        args?.Validate();
+        var requestMessageBuilder = await this.CreateRequest(args.RequestMethod, args.BucketName,
+            args.ObjectName,
+            args.Headers, // contentType
+            Convert.ToString(args.GetType(), CultureInfo.InvariantCulture), // metaData
+            Utils.ObjectToByteArray(args.RequestBody)).ConfigureAwait(false);
+        var authenticator = new V4Authenticator(Config.Secure, Config.AccessKey, Config.SecretKey, Config.Region,
+            Config.SessionToken);
+        return authenticator.PresignURL(requestMessageBuilder, args.Expiry, Config.Region, Config.SessionToken);
+    }
+
+    /// <summary>
     ///     Get the configuration object for Legal Hold Status
     /// </summary>
     /// <param name="args">

--- a/Minio/DataModel/Args/GetPresignedUrlArgs.cs
+++ b/Minio/DataModel/Args/GetPresignedUrlArgs.cs
@@ -19,11 +19,11 @@ using Minio.Helper;
 
 namespace Minio.DataModel.Args;
 
-public class PresignedGetObjectArgs : ObjectArgs<PresignedGetObjectArgs>
+public class GetPresignedUrlArgs : ObjectArgs<GetPresignedUrlArgs>
 {
-    public PresignedGetObjectArgs()
+    public GetPresignedUrlArgs(PresignedUrlHttpMethod requestMethod)
     {
-        RequestMethod = HttpMethod.Get;
+        RequestMethod = ToHttpMethod(requestMethod);
     }
 
     internal int Expiry { get; set; }
@@ -37,15 +37,33 @@ public class PresignedGetObjectArgs : ObjectArgs<PresignedGetObjectArgs>
                                                   Constants.DefaultExpiryTime);
     }
 
-    public PresignedGetObjectArgs WithExpiry(int expiry)
+    public GetPresignedUrlArgs WithExpiry(int expiry)
     {
         Expiry = expiry;
         return this;
     }
 
-    public PresignedGetObjectArgs WithRequestDate(DateTime? d)
+    public GetPresignedUrlArgs WithRequestDate(DateTime? d)
     {
         RequestDate = d;
         return this;
+    }
+    
+    public enum PresignedUrlHttpMethod
+    {
+        Get,
+        Put,
+        Delete
+    }
+    
+    private static HttpMethod ToHttpMethod(PresignedUrlHttpMethod method)
+    {
+        return method switch
+        {
+            PresignedUrlHttpMethod.Get => HttpMethod.Get,
+            PresignedUrlHttpMethod.Put => HttpMethod.Put,
+            PresignedUrlHttpMethod.Delete => HttpMethod.Delete,
+            _ => throw new ArgumentOutOfRangeException(nameof(method), method, null)
+        };
     }
 }

--- a/Minio/IMinioClient.cs
+++ b/Minio/IMinioClient.cs
@@ -30,5 +30,6 @@ public interface IMinioClient : IBucketOperations, IObjectOperations, IDisposabl
     void SetTraceOff();
     void SetTraceOn(IRequestLogger logger = null);
     Task<HttpResponseMessage> WrapperGetAsync(Uri uri);
+    Task<HttpResponseMessage> WrapperDeleteAsync(Uri uri);
     Task WrapperPutAsync(Uri uri, StreamContent strm);
 }

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -68,6 +68,14 @@ public partial class MinioClient : IMinioClient
     }
 
     /// <summary>
+    ///     Runs httpClient's DeleteAsync method
+    /// </summary>
+    public Task<HttpResponseMessage> WrapperDeleteAsync(Uri uri)
+    {
+        return Config.HttpClient.DeleteAsync(uri);
+    }
+
+    /// <summary>
     ///     Sets HTTP tracing On.Writes output to Console
     /// </summary>
     public void SetTraceOn(IRequestLogger requestLogger = null)

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -13,6 +13,9 @@ namespace Minio;
 
 public static class RequestExtensions
 {
+    /// <summary>
+    ///     Runs httpClient's GetObjectAsync method
+    /// </summary>
     [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
         Justification = "This is done in the interface. String is provided here for convenience")]
     public static Task<HttpResponseMessage> WrapperGetAsync(this IMinioClient minioClient, string url)
@@ -20,6 +23,18 @@ public static class RequestExtensions
         return minioClient is null
             ? throw new ArgumentNullException(nameof(minioClient))
             : minioClient.WrapperGetAsync(new Uri(url));
+    }
+
+    /// <summary>
+    ///     Runs httpClient's DeleteObjectAsync method
+    /// </summary>
+    [SuppressMessage("Design", "CA1054:URI-like parameters should not be strings",
+        Justification = "This is done in the interface. String is provided here for convenience")]
+    public static Task<HttpResponseMessage> WrapperDeleteAsync(this IMinioClient minioClient, string url)
+    {
+        return minioClient is null
+            ? throw new ArgumentNullException(nameof(minioClient))
+            : minioClient.WrapperDeleteAsync(new Uri(url));
     }
 
     /// <summary>


### PR DESCRIPTION
This PR introduces the GetPresignedUrl functionality to the Minio .NET client, aligning it with the existing capabilities of the Minio Python library, as detailed in the [official Python client API reference](https://min.io/docs/minio/linux/developers/python/API.html).
Key Features:

- Emulates Python Library Behavior: The GetPresignedUrl method is designed to closely emulate the behavior of the corresponding function in the Python Minio client. This includes generating presigned URLs for bucket objects, allowing temporary access to the objects in the Minio storage.
- Supported Operations: The functionality supports common HTTP methods (GET, PUT, DELETE, etc.) for presigned URLs, enabling users to share or access objects securely.
- Parameterization: The method supports various parameters such as expiry times, request parameters, and custom headers, giving users flexibility similar to that in the Python library.
- Extensive Testing: The implementation has been tested to ensure it matches the expected behavior and performance as seen in the Python library, covering edge cases and typical usage scenarios.

Rationale:

The addition of this functionality enhances the Minio .NET client's feature parity with the Python client, providing .NET developers with the tools necessary to generate presigned URLs directly within their applications, for GET, PUT and DELETE requests.

(Currently, object deletion by presigned url is not supported)

This PR is ready for review. Your feedback and suggestions are welcome!
