### PR TITLE
V5.0.0 patch release for a customer

### DIFF
--- a/Minio.Functional.Tests/FunctionalTest.cs
+++ b/Minio.Functional.Tests/FunctionalTest.cs
@@ -994,7 +994,6 @@ public static class FunctionalTest
         {
             var file_write_size = filestream.Length;
             var tempFileName = "tempfile-" + GetRandomName();
-            if (size == 0) size = filestream.Length;
             var putObjectArgs = new PutObjectArgs()
                 .WithBucket(bucketName)
                 .WithObject(objectName)
@@ -1047,7 +1046,7 @@ public static class FunctionalTest
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
-            await PutObject_Tester(minio, bucketName, objectName, null, null, 0, null,
+            await PutObject_Tester(minio, bucketName, objectName, null, null, 1 * KB, null,
                 rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
             new MintLogger(nameof(StatObject_Test1), statObjectSignature, "Tests whether StatObject passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -2687,7 +2686,7 @@ public static class FunctionalTest
             );
 
             await PutObject_Tester(minio, bucketName, objectName, null, contentType,
-                0, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
+                1 * KB, null, rsg.GenerateStreamFromSeed(1 * KB)).ConfigureAwait(false);
 
             // wait for notifications
             var eventDetected = false;
@@ -3230,13 +3229,13 @@ public static class FunctionalTest
         var bucketName = GetRandomName(15);
         var objectName = GetRandomObjectName(10);
         var contentType = "application/octet-stream";
-        var size = 1 * MB;
+        var size = 0;
         var args = new Dictionary<string, string>
         {
             { "bucketName", bucketName },
             { "objectName", objectName },
             { "contentType", contentType },
-            { "size", "1MB" }
+            { "size", "0" }
         };
         try
         {
@@ -3246,13 +3245,13 @@ public static class FunctionalTest
             Assert.AreEqual(size, resp.Size);
             Assert.AreEqual(objectName, objectName);
             new MintLogger(nameof(PutObject_Test1), putObjectSignature,
-                "Tests whether PutObject passes for small object", TestStatus.PASS, DateTime.Now - startTime,
+                "Tests whether PutObject passes for zero sized object", TestStatus.PASS, DateTime.Now - startTime,
                 args: args).Log();
         }
         catch (Exception ex)
         {
             new MintLogger(nameof(PutObject_Test1), putObjectSignature,
-                "Tests whether PutObject passes for small object", TestStatus.FAIL, DateTime.Now - startTime, "",
+                "Tests whether PutObject passes for zero sized object", TestStatus.FAIL, DateTime.Now - startTime, "",
                 ex.Message, ex.ToString(), args).Log();
             throw;
         }
@@ -3278,7 +3277,7 @@ public static class FunctionalTest
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
-            await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
+            await PutObject_Tester(minio, bucketName, objectName, null, contentType, 6 * MB, null,
                 rsg.GenerateStreamFromSeed(6 * MB)).ConfigureAwait(false);
             new MintLogger(nameof(PutObject_Test2), putObjectSignature, "Tests whether multipart PutObject passes",
                 TestStatus.PASS, DateTime.Now - startTime, args: args).Log();
@@ -3312,7 +3311,7 @@ public static class FunctionalTest
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
-            await PutObject_Tester(minio, bucketName, objectName, null, contentType, 0, null,
+            await PutObject_Tester(minio, bucketName, objectName, null, contentType, 1 * MB, null,
                 rsg.GenerateStreamFromSeed(1 * MB)).ConfigureAwait(false);
             new MintLogger(nameof(PutObject_Test3), putObjectSignature,
                 "Tests whether PutObject with custom content-type passes", TestStatus.PASS, DateTime.Now - startTime,
@@ -3355,7 +3354,7 @@ public static class FunctionalTest
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
             var statObject =
-                await PutObject_Tester(minio, bucketName, objectName, fileName, contentType, metaData: metaData)
+                await PutObject_Tester(minio, bucketName, objectName, fileName, contentType, 1, metaData)
                     .ConfigureAwait(false);
             Assert.IsTrue(statObject is not null);
             Assert.IsTrue(statObject.MetaData is not null);
@@ -3397,7 +3396,7 @@ public static class FunctionalTest
         try
         {
             await Setup_Test(minio, bucketName).ConfigureAwait(false);
-            await PutObject_Tester(minio, bucketName, objectName, null, null, 0, null, rsg.GenerateStreamFromSeed(1))
+            await PutObject_Tester(minio, bucketName, objectName, null, null, 1, null, rsg.GenerateStreamFromSeed(1))
                 .ConfigureAwait(false);
             new MintLogger(nameof(PutObject_Test5), putObjectSignature,
                 "Tests whether PutObject with no content-type passes for small object", TestStatus.PASS,

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1838,7 +1838,7 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
 
         if (!string.IsNullOrWhiteSpace(FileName)) Utils.ValidateFile(FileName);
         // Check object size when using stream data
-        if (ObjectStreamData is not null && ObjectSize == 0)
+        if (ObjectStreamData is not null && ObjectSize == -1)
             ObjectSize = ObjectStreamData.Length;
         Populate();
     }

--- a/Minio/DataModel/ObjectOperationsArgs.cs
+++ b/Minio/DataModel/ObjectOperationsArgs.cs
@@ -1839,7 +1839,7 @@ public class PutObjectArgs : ObjectWriteArgs<PutObjectArgs>
         if (!string.IsNullOrWhiteSpace(FileName)) Utils.ValidateFile(FileName);
         // Check object size when using stream data
         if (ObjectStreamData is not null && ObjectSize == 0)
-            throw new ArgumentException($"{nameof(ObjectSize)} must be set");
+            ObjectSize = ObjectStreamData.Length;
         Populate();
     }
 

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="System.Net.Http" Version="4.3.4"/>
 		<PackageReference Include="System.Net.Primitives" Version="4.3.1"/>
 		<PackageReference Include="System.ValueTuple" Version="4.5.0" />
-		<PackageReference Include="System.Text.Json" Version="7.0.2" />
+		<PackageReference Include="System.Text.Json" Version="8.0.5" />
 		<PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
 		<PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
 	</ItemGroup>

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -411,10 +411,7 @@ public partial class MinioClient : IMinioClient
     {
         var startTime = DateTime.Now;
         // Logs full url when HTTPtracing is enabled.
-        if (trace)
-        {
-            var fullUrl = requestMessageBuilder.RequestUri;
-        }
+        if (trace) _ = requestMessageBuilder.RequestUri;
 
         var v4Authenticator = new V4Authenticator(Secure,
             AccessKey, SecretKey, Region,

--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -410,8 +410,6 @@ public partial class MinioClient : IMinioClient
         CancellationToken cancellationToken = default)
     {
         var startTime = DateTime.Now;
-        // Logs full url when HTTPtracing is enabled.
-        if (trace) _ = requestMessageBuilder.RequestUri;
 
         var v4Authenticator = new V4Authenticator(Secure,
             AccessKey, SecretKey, Region,
@@ -728,5 +726,4 @@ public partial class MinioClient : IMinioClient
 
 internal delegate void ApiResponseErrorHandlingDelegate(ResponseResult response);
 
-public delegate Task<ResponseResult> RetryPolicyHandlingDelegate(
-    Func<Task<ResponseResult>> executeRequestCallback);
+public delegate Task<ResponseResult> RetryPolicyHandlingDelegate(Func<Task<ResponseResult>> executeRequestCallback);


### PR DESCRIPTION
A customer complained about PutObjectAsync api not supporting zero sized objects.
The customer uses version 5.0.0, so the patch fix is created on version 5.0.0.

