### PR TITLE
Adds a region and fixes the incorrect regexp pattern

### DIFF
--- a/Minio/AWSS3Endpoints.cs
+++ b/Minio/AWSS3Endpoints.cs
@@ -1,0 +1,83 @@
+/*
+ * MinIO .NET Library for Amazon S3 Compatible Cloud Storage, (C) 2017 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Concurrent;
+
+namespace Minio;
+
+/// <summary>
+///     Amazon AWS S3 endpoints for various regions.
+/// </summary>
+public sealed class AWSS3Endpoints
+{
+    private static readonly Lazy<AWSS3Endpoints> lazy = new(() => new AWSS3Endpoints());
+
+    private readonly ConcurrentDictionary<string, string> endpoints;
+
+    private AWSS3Endpoints()
+    {
+        endpoints = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+        // ap-northeast-1
+        _ = endpoints.TryAdd("ap-northeast-1", "s3-ap-northeast-1.amazonaws.com");
+        // ap-northeast-2
+        _ = endpoints.TryAdd("ap-northeast-2", "s3-ap-northeast-2.amazonaws.com");
+        // ap-south-1
+        _ = endpoints.TryAdd("ap-south-1", "s3-ap-south-1.amazonaws.com");
+        // ap-southeast-1
+        _ = endpoints.TryAdd("ap-southeast-1", "s3-ap-southeast-1.amazonaws.com");
+        // ap-southeast-2
+        _ = endpoints.TryAdd("ap-southeast-2", "s3-ap-southeast-2.amazonaws.com");
+        // eu-central-1
+        _ = endpoints.TryAdd("eu-central-1", "s3-eu-central-1.amazonaws.com");
+        // eu-west-1
+        _ = endpoints.TryAdd("eu-west-1", "s3-eu-west-1.amazonaws.com");
+        // eu-west-2
+        _ = endpoints.TryAdd("eu-west-2", "s3-eu-west-2.amazonaws.com");
+        // sa-east-1
+        _ = endpoints.TryAdd("sa-east-1", "s3-sa-east-1.amazonaws.com");
+        // us-west-1
+        _ = endpoints.TryAdd("us-west-1", "s3-us-west-1.amazonaws.com");
+        // us-west-2
+        _ = endpoints.TryAdd("us-west-2", "s3-us-west-2.amazonaws.com");
+        // us-east-1
+        _ = endpoints.TryAdd("us-east-1", "s3.amazonaws.com");
+        // us-east-2
+        _ = endpoints.TryAdd("us-east-2", "s3-us-east-2.amazonaws.com");
+        // ca-central-1
+        _ = endpoints.TryAdd("ca-central-1", "s3.ca-central-1.amazonaws.com");
+        // cn-north-1
+        _ = endpoints.TryAdd("cn-north-1", "s3.cn-north-1.amazonaws.com.cn");
+        // us-gov-west-1
+        _ = endpoints.TryAdd("us-gov-west-1", "s3.dualstack.us-gov-west-1.amazonaws.com");
+        
+
+    }
+
+    public static AWSS3Endpoints Instance => lazy.Value;
+
+    /// <summary>
+    ///     Gets Amazon S3 endpoint for the relevant region.
+    /// </summary>
+    /// <param name="region"></param>
+    /// <returns></returns>
+    public static string Endpoint(string region)
+    {
+        string endpoint = null;
+        if (region is not null) _ = Instance.endpoints.TryGetValue(region, out endpoint);
+        endpoint ??= "s3.amazonaws.com";
+        return endpoint;
+    }
+}

--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -125,12 +125,8 @@ public partial class MinioClient : IBucketOperations
     public async Task MakeBucketAsync(MakeBucketArgs args, CancellationToken cancellationToken = default)
     {
         args?.Validate();
-        if (string.IsNullOrEmpty(args.Location))
-            args.Location = Config.Region;
-
-        if (string.Equals(args.Location, "us-east-1", StringComparison.OrdinalIgnoreCase) &&
-            !string.IsNullOrEmpty(Config.Region))
-            args.Location = Config.Region;
+        if (string.IsNullOrEmpty(args.Location)) Config.Region = args.Location;
+        else args.Location = Config.Region = "us-east-1";
 
         args.IsBucketCreationRequest = true;
         var requestMessageBuilder = await this.CreateRequest(args).ConfigureAwait(false);

--- a/Minio/Helper/RequestUtil.cs
+++ b/Minio/Helper/RequestUtil.cs
@@ -51,8 +51,10 @@ internal static class RequestUtil
     {
         // For Amazon S3 endpoint, try to fetch location based endpoint.
         var host = endPoint;
-        if (S3utils.IsAmazonEndPoint(endPoint) && !string.IsNullOrEmpty(region))
-            host = $"s3.{region}.amazonaws.com";
+
+        if (S3utils.IsAmazonEndPoint(endPoint))
+            // Fetch new host based on the bucket location.
+            host = AWSS3Endpoints.Endpoint(region);
 
         if (!usePathStyle)
         {

--- a/Minio/Helper/S3utils.cs
+++ b/Minio/Helper/S3utils.cs
@@ -25,7 +25,7 @@ internal static class S3utils
     internal static bool IsAmazonEndPoint(string endpoint)
     {
         if (IsAmazonChinaEndPoint(endpoint)) return true;
-        var rgx = new Regex("^s3[.-]?(.*?)\\.amazonaws\\.com$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
+        var rgx = new Regex("[s|S]3[.|-]((.*?\\.|)|(.*?\\.*?\\.|)|)amazonaws.com", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
             TimeSpan.FromHours(1));
         var matches = rgx.Matches(endpoint);
         return matches.Count > 0;


### PR DESCRIPTION
Adds a new region/location, `us-gov-west-1`, for a customer.
Also fixes the incorrect regexp pattern used when deciding if an endpoint is an Amazon AWS or not.