### PR TITLE
replaces deprecated v3 of artifact actions with v4

### DIFF
--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -73,12 +73,12 @@ jobs:
             **/*.key
             **/*.crt
 
-      # Upload the Nuget packages
-      - name: Upload the Nuget packages output
-        uses: actions/upload-artifact@v4
-        with:
-          name: nuget-packages
-          path: ./artifacts/*
+      # # Upload the Nuget packages
+      # - name: Upload the Nuget packages output
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: nuget-packages
+      #     path: ./artifacts/*
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -63,7 +63,7 @@ jobs:
 
       # Upload the normal artifacts
       - name: Upload the build output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |
@@ -75,7 +75,7 @@ jobs:
 
       # Upload the Nuget packages
       - name: Upload the Nuget packages output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nuget-packages
           path: ./artifacts/*
@@ -123,7 +123,7 @@ jobs:
 
       # Download the build artifacts
       - name: Download the build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: .
@@ -150,7 +150,7 @@ jobs:
 
       # Download the build artifacts
       - name: Download the build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: .
@@ -191,7 +191,7 @@ jobs:
     steps:
       # Download the Nuget artifacts
       - name: Download the Nuget artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nuget-packages
           path: ./artifacts

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -74,6 +74,14 @@ jobs:
             **/*.crt
           overwrite: true
 
+      # Upload the Nuget packages
+      - name: Upload the Nuget packages output
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-packages
+          path: ./artifacts/*
+          overwrite: true
+
   format-check:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -61,21 +61,8 @@ jobs:
       - name: Create the Nuget package
         run: dotnet pack ${{ env.Minio_Project_Path }} --no-restore --no-build --configuration Release --output ./artifacts
 
-      # Artifact clean up
-      - name: Delete all artifacts
-        uses: actions/delete-artifact@v4
-        with:
-          name: build-artifacts
-          path: |
-            **/bin/Release/
-            **/obj/Release/
-            **/*.csproj
-            **/*.key
-            **/*.crt
-
       # Upload the normal artifacts
       - name: Upload the build output
-        if: ${{ !success() }}
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
@@ -85,6 +72,7 @@ jobs:
             **/*.csproj
             **/*.key
             **/*.crt
+        if: ${{ always() }}
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -64,6 +64,7 @@ jobs:
       # Upload the normal artifacts
       - name: Upload the build output
         uses: actions/upload-artifact@v4
+        if: ${{ always() }}
         with:
           name: build-artifacts
           path: |
@@ -72,7 +73,6 @@ jobs:
             **/*.csproj
             **/*.key
             **/*.crt
-        if: ${{ always() }}
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -63,10 +63,9 @@ jobs:
 
       # Empty 'artifacts' directory for windows upload
       - name: Remove 'artifact' directory
+        if: ${{ matrix.os == 'windows-latest' }}
         run: |
-          if [[ matrix.os == 'windows-latest' ]]; then
             sudo rm -rf './Minio/bin/Release' './Minio/obj/Release' './Minio/Minio.csproj' './Minio/*.key' './Minio/*.crt'
-          fi
 
       # Upload the normal artifacts
       - name: Upload the build output

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -61,8 +61,21 @@ jobs:
       - name: Create the Nuget package
         run: dotnet pack ${{ env.Minio_Project_Path }} --no-restore --no-build --configuration Release --output ./artifacts
 
+      # Artifact clean up
+      - name: Delete all artifacts
+        uses: actions/delete-artifact@v4
+        with:
+          name: build-artifacts
+          path: |
+            **/bin/Release/
+            **/obj/Release/
+            **/*.csproj
+            **/*.key
+            **/*.crt
+
       # Upload the normal artifacts
       - name: Upload the build output
+        if: ${{ !success() }}
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -61,10 +61,16 @@ jobs:
       - name: Create the Nuget package
         run: dotnet pack ${{ env.Minio_Project_Path }} --no-restore --no-build --configuration Release --output ./artifacts
 
+      # Empty 'artifacts' directory for windows upload
+      - name: Remove 'artifact' directory
+        run: |
+          if [[ matrix.os == 'windows-latest' ]]; then
+            sudo rm -rf './Minio/bin/Release' './Minio/obj/Release' './Minio/Minio.csproj' './Minio/*.key' './Minio/*.crt'
+          fi
+
       # Upload the normal artifacts
       - name: Upload the build output
         uses: actions/upload-artifact@v4
-        if: ${{ always() }}
         with:
           name: build-artifacts
           path: |

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -61,12 +61,6 @@ jobs:
       - name: Create the Nuget package
         run: dotnet pack ${{ env.Minio_Project_Path }} --no-restore --no-build --configuration Release --output ./artifacts
 
-      # Empty 'artifacts' directory for windows upload
-      - name: Remove 'artifact' directory
-        if: ${{ matrix.os == 'windows-latest' }}
-        run: |
-            rm -rf './Minio/bin/Release' './Minio/obj/Release' './Minio/Minio.csproj' './Minio/*.key' './Minio/*.crt'
-
       # Upload the normal artifacts
       - name: Upload the build output
         uses: actions/upload-artifact@v4
@@ -78,6 +72,7 @@ jobs:
             **/*.csproj
             **/*.key
             **/*.crt
+          overwrite: true
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -73,13 +73,6 @@ jobs:
             **/*.key
             **/*.crt
 
-      # # Upload the Nuget packages
-      # - name: Upload the Nuget packages output
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: nuget-packages
-      #     path: ./artifacts/*
-
   format-check:
     runs-on: ubuntu-latest
     

--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Remove 'artifact' directory
         if: ${{ matrix.os == 'windows-latest' }}
         run: |
-            sudo rm -rf './Minio/bin/Release' './Minio/obj/Release' './Minio/Minio.csproj' './Minio/*.key' './Minio/*.crt'
+            rm -rf './Minio/bin/Release' './Minio/obj/Release' './Minio/Minio.csproj' './Minio/*.key' './Minio/*.crt'
 
       # Upload the normal artifacts
       - name: Upload the build output


### PR DESCRIPTION
Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact).

Here is the [Deprecation Notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

We also need a migration change since `artifacts` mutable in v3 version became immutable in v4 and existing workflow re-uploads artifacts on its 2nd run for `windows`.