### PR TITLE
Update BucketExistsAsync to throw error on invalid creds

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -80,9 +80,13 @@ public partial class MinioClient : IBucketOperations
             using var response =
                 await this.ExecuteTaskAsync(ResponseErrorHandlers, requestMessageBuilder,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
-            return response is not null &&
-                   (response.Exception is null ||
-                    response.Exception.GetType() != typeof(BucketNotFoundException));
+            if (response is not null &&
+                response.Exception is null)
+            {
+                return true;
+            }
+
+            throw response.Exception;
         }
         catch (InternalClientException ice)
         {


### PR DESCRIPTION
if BucketExists called with incorrect credentials or host, it still returns true