### PR TITLE
Allow for custom namespaces

### DIFF
--- a/Minio/ApiEndpoints/BucketOperations.cs
+++ b/Minio/ApiEndpoints/BucketOperations.cs
@@ -221,7 +221,7 @@ public partial class MinioClient : IBucketOperations
             .WithHeaders(args.Headers)
             .WithVersionIdMarker(string.Empty);
 
-        XNamespace ns = "http://s3.amazonaws.com/doc/2006-03-01/";
+        XNamespace ns = args.Namespace ?? "http://s3.amazonaws.com/doc/2006-03-01/";
         var tag = ns + (args.Versions ? "Version" : "Contents");
 
         while (true)

--- a/Minio/DataModel/Args/ListObjectsArgs.cs
+++ b/Minio/DataModel/Args/ListObjectsArgs.cs
@@ -30,6 +30,7 @@ public class ListObjectsArgs : BucketArgs<ListObjectsArgs>
     internal bool Versions { get; private set; }
     internal bool IncludeUserMetadata { get; private set; }
     internal bool UseV2 { get; private set; }
+    internal string Namespace { get; private set; }
 
     public ListObjectsArgs WithPrefix(string prefix)
     {
@@ -58,6 +59,12 @@ public class ListObjectsArgs : BucketArgs<ListObjectsArgs>
     public ListObjectsArgs WithListObjectsV1(bool useV1)
     {
         UseV2 = !useV1;
+        return this;
+    }
+  
+    public ListObjectsArgs WithNamespace(string ns)
+    {
+        Namespace = ns;
         return this;
     }
 }


### PR DESCRIPTION
There are some cases where the XML returned via the `ListObjectsEnumAsync` method doesn't have the Amazon S3 namespace. This is causing the code to return an empty list every time. This is a small change to allow for custom namespaces when using S3 that don't use the Amazon namespace.

I've purposely made it opt-in, so that the original functionality is preserved.