### PR TITLE
Set checkout@v3 fetch-depth=2 in workflow for SHA conflict

### DIFF
--- a/.github/workflows/minio-dotnet.yml
+++ b/.github/workflows/minio-dotnet.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       # Install .NET
       - name: Setup .NET ${{ matrix.dotnet-version }}
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 2
 
       # Install .NET
       - name: Setup .NET


### PR DESCRIPTION
Merged [PR#1260](https://github.com/minio/minio-dotnet/pull/1260) does not take effect due to SHA conflict, causing the old workflow to run into the same issue PR#1260 is created for.