### PR TITLE
Do not use DateTime.Now to compute elapsed time.

### DIFF
--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -401,5 +401,4 @@ public static class RequestExtensions
         return TimeSpan.FromSeconds(seconds);
 #endif
     }
-
 }

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics.CodeAnalysis;
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Web;
 using Minio.Credentials;
@@ -80,7 +81,7 @@ public static class RequestExtensions
         bool isSts = false,
         CancellationToken cancellationToken = default)
     {
-        var startTime = DateTime.Now;
+        var startTime = Stopwatch.GetTimestamp();
         var v4Authenticator = new V4Authenticator(minioClient.Config.Secure,
             minioClient.Config.AccessKey, minioClient.Config.SecretKey, minioClient.Config.Region,
             minioClient.Config.SessionToken);
@@ -369,13 +370,13 @@ public static class RequestExtensions
     /// <param name="startTime"></param>
     private static void HandleIfErrorResponse(this IMinioClient minioClient, ResponseResult response,
         IEnumerable<IApiResponseErrorHandler> handlers,
-        DateTime startTime)
+        long startTime)
     {
         // Logs Response if HTTP tracing is enabled
         if (minioClient.Config.TraceHttp)
         {
-            var now = DateTime.Now;
-            minioClient.LogRequest(response.Request, response, (now - startTime).TotalMilliseconds);
+            var elapsed = GetElapsedTime(startTime);
+            minioClient.LogRequest(response.Request, response, elapsed.TotalMilliseconds);
         }
 
         if (response.Exception is not null)
@@ -388,4 +389,17 @@ public static class RequestExtensions
         else
             minioClient.DefaultErrorHandler.Handle(response);
     }
+
+    private static TimeSpan GetElapsedTime(long startTimestamp)
+    {
+#if NET8_0_OR_GREATER
+        return Stopwatch.GetElapsedTime(startTimestamp);
+#else
+        var endTimestamp = Stopwatch.GetTimestamp();
+        var elapsedTicks = endTimestamp - startTimestamp;
+        var seconds = (double)elapsedTicks / Stopwatch.Frequency;
+        return TimeSpan.FromSeconds(seconds);
+#endif
+    }
+
 }


### PR DESCRIPTION
Using `DateTime.Now` is problematic when computing elapsed time in the following ways:

- is required to apply time zone settings to calculate local date and time. This conversion takes time.
- The system clock is not guaranteed to be always increasing. Things like NTP can adjust clock forward or backwards.

Using `Stopwatch.GetTimestamp()` does not have these issues. 

Benchmarks

```cs
        [Benchmark]
        public long GetTimestamp()
        {
            return Stopwatch.GetTimestamp();
        }

        [Benchmark(Baseline = true)]
        public DateTime DateTimeNow()
        {
            return DateTime.Now;
        }
```

BenchmarkDotNet v0.15.0, Windows 11 (10.0.22631.5472/23H2/2023Update/SunValley3)
AMD Ryzen Threadripper PRO 3955WX 16-Cores 3.90GHz, 1 CPU, 32 logical and 16 physical cores
.NET SDK 9.0.300
  [Host]     : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX2
  Job-QHEYQX : .NET 8.0.17 (8.0.1725.26602), X64 RyuJIT AVX2

InvocationCount=1  UnrollFactor=1

| Method       | Mean       | Error     | StdDev    | Median     | Ratio | RatioSD | Allocated | Alloc Ratio |
|------------- |-----------:|----------:|----------:|-----------:|------:|--------:|----------:|------------:|
| GetTimestamp |   134.4 ns |  22.39 ns |  64.61 ns |   100.0 ns |  0.10 |    0.06 |     400 B |        1.00 |
| DateTimeNow  | 1,373.4 ns | 108.69 ns | 310.11 ns | 1,500.0 ns |  1.06 |    0.37 |     400 B |        1.00 |
