### PR TITLE
File upload performance improvement

### DIFF
--- a/Minio/Helper/S3utils.cs
+++ b/Minio/Helper/S3utils.cs
@@ -22,13 +22,15 @@ internal static class S3utils
 {
     internal static readonly Regex TrimWhitespaceRegex = new("\\s+", RegexOptions.None, TimeSpan.FromHours(1));
 
+    internal static readonly Regex AmazonEndpointRegex = new(
+        "^s3[.-]?(.*?)\\.amazonaws\\.com$",
+        RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture | RegexOptions.CultureInvariant,
+        TimeSpan.FromHours(1)
+    );
+
     internal static bool IsAmazonEndPoint(string endpoint)
     {
-        if (IsAmazonChinaEndPoint(endpoint)) return true;
-        var rgx = new Regex("^s3[.-]?(.*?)\\.amazonaws\\.com$", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture,
-            TimeSpan.FromHours(1));
-        var matches = rgx.Matches(endpoint);
-        return matches.Count > 0;
+        return AmazonEndpointRegex.IsMatch(endpoint);
     }
 
     // IsAmazonChinaEndpoint - Match if it is exactly Amazon S3 China endpoint.


### PR DESCRIPTION
When uploading files, too much memory is allocated. We can use `MemoryPool<byte>` to reduce memory allocation and improve performance.

Below is the performance comparison before and after optimization.

#### MinioClient.ReadFullAsync
.NET SDK 9.0.302
  [Host]   : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  .NET 9.0 : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL

Job=.NET 9.0  Runtime=.NET 9.0  


| Method            | Size     | Mean       | Error     | StdDev     | Ratio | RatioSD | Gen0     | Gen1     | Gen2     | Allocated  | Alloc Ratio |
|------------------ |--------- |-----------:|----------:|-----------:|------:|--------:|---------:|---------:|---------:|-----------:|------------:|
| **ReadFullAsync**     | **65536**    |   **4.532 μs** | **0.0585 μs** |  **0.0488 μs** |  **1.00** |    **0.01** |   **3.7994** |        **-** |        **-** |    **65816 B** |       **1.000** |
| ReadFullAsync_New | 65536    |   1.495 μs | 0.0069 μs |  0.0077 μs |  0.33 |    0.00 |   0.0153 |        - |        - |      264 B |       0.004 |
|                   |          |            |           |            |       |         |          |          |          |            |             |
| **ReadFullAsync**     | **1048576**  |  **52.505 μs** | **0.2932 μs** |  **0.2599 μs** |  **1.00** |    **0.01** | **333.3130** | **333.3130** | **333.3130** |  **1049064 B** |       **1.000** |
| ReadFullAsync_New | 1048576  |   1.600 μs | 0.0151 μs |  0.0142 μs |  0.03 |    0.00 |   0.0153 |        - |        - |      264 B |       0.000 |
|                   |          |            |           |            |       |         |          |          |          |            |             |
| **ReadFullAsync**     | **16777216** | **477.361 μs** | **9.5429 μs** | **11.7195 μs** | **1.001** |    **0.03** | **666.0156** | **666.0156** | **666.0156** | **16777923 B** |       **1.000** |
| ReadFullAsync_New | 16777216 |   1.504 μs | 0.0158 μs |  0.0147 μs | 0.003 |    0.00 |   0.0153 |        - |        - |      264 B |       0.000 |

#### S3utils.IsAmazonEndPoint
.NET SDK 9.0.302
  [Host]   : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL
  .NET 9.0 : .NET 9.0.7 (9.0.725.31616), X64 RyuJIT AVX-512F+CD+BW+DQ+VL

Job=.NET 9.0  Runtime=.NET 9.0  

 Method               | Mean       | Error    | StdDev   | Ratio | Rank | Gen0   | Allocated | Alloc Ratio |
--------------------- |-----------:|---------:|---------:|------:|-----:|-------:|----------:|------------:|
 IsAmazonEndPoint     | 4,762.6 ns | 39.81 ns | 33.24 ns |  1.00 |    2 | 0.3204 |    5584 B |        1.00 |
 IsAmazonEndPoint_New |   655.3 ns |  1.13 ns |  1.05 ns |  0.14 |    1 |      - |         - |        0.00 |

