### PR TITLE
Fix condition on nullable property

### DIFF
--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -177,7 +177,7 @@ public partial class MinioClient : IMinioClient
         var resourceSplits = pathAndQuery.Split(separator, 2, StringSplitOptions.RemoveEmptyEntries);
 
         if (response.StatusCode.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.Ordinal) ||
-            response.Exception.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.Ordinal))
+            response.Exception?.ToString().Contains(nameof(HttpStatusCode.NotFound), StringComparison.Ordinal) == true)
         {
             var pathLength = resourceSplits.Length;
             var isAWS = host.EndsWith("s3.amazonaws.com", StringComparison.OrdinalIgnoreCase);


### PR DESCRIPTION
`ResponseResult.Exception` is nullable by usages. We have to check that nullability for standard Error cas.
eg when the Minio client SecretKey is invalid, the error is handled by this method and no exception is present in the ResponseResult object.

This fix the null point exception that is thrown at this line and allow to properly retrieve the error message.