### PR TITLE
Fix: Allow PartialContent (used in GetObject and StatObject)

### DIFF
--- a/Minio/MinioClient.cs
+++ b/Minio/MinioClient.cs
@@ -141,7 +141,7 @@ public partial class MinioClient : IMinioClient
         )
             foreach (var exception in statusCodeStrs)
             {
-                if (response.StatusCode is not HttpStatusCode.OK)
+                if (!(response.Response?.IsSuccessStatusCode ?? false))
                 {
                     ParseWellKnownErrorNoContent(response);
                     break;

--- a/Minio/RequestExtensions.cs
+++ b/Minio/RequestExtensions.cs
@@ -70,7 +70,7 @@ public static class RequestExtensions
             handler.Handle(responseResult);
         }
 
-        if (responseResult.StatusCode is not HttpStatusCode.OK)
+        if (!(responseResult.Response?.IsSuccessStatusCode ?? false))
         {
             if (responseResult.StatusCode == HttpStatusCode.NoContent
                 && responseResult.Request.Method == HttpMethod.Delete)


### PR DESCRIPTION
closes https://github.com/minio/minio-dotnet/issues/1342

I tested the changes on my end and with it the requests with range headers work again.

@ebozduman please check, if this does not conflict with your changes in https://github.com/minio/minio-dotnet/pull/1320