### PR TITLE
Use same lang version as target .NET

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,7 +20,7 @@
 
         <!--<Nullable>enable</Nullable>-->
         <ImplicitUsings>enable</ImplicitUsings>
-        <LangVersion>latest</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <NoWarn>$(NoWarn);CS1591</NoWarn>
         <Platform>AnyCPU</Platform>
 


### PR DESCRIPTION
Or it will fail with .NET 10 SDK with:

  Minio net8.0 failed with 2 error(s) (3.3s)
    /home/bjorn/code/minio-dotnet/Minio/DataModel/Result/ResponseResult.cs(26,5): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032)
    /home/bjorn/code/minio-dotnet/Minio/DataModel/Result/ResponseResult.cs(27,5): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032)
  Minio netstandard2.0 failed with 2 error(s) (3.1s)
    /home/bjorn/code/minio-dotnet/Minio/DataModel/Result/ResponseResult.cs(26,5): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032)
    /home/bjorn/code/minio-dotnet/Minio/DataModel/Result/ResponseResult.cs(27,5): error IDE0032: Use auto property (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0032)
