### PR TITLE
Add x-amz-storage-class to supported header list

### DIFF
--- a/Minio/Helper/OperationsUtil.cs
+++ b/Minio/Helper/OperationsUtil.cs
@@ -25,7 +25,8 @@ public static class OperationsUtil
         "content-type",
         "x-amz-acl",
         "content-disposition",
-        "x-minio-extract"
+        "x-minio-extract",
+        "x-amz-storage-class"
     };
 
     private static readonly List<string> sSEHeaders = new()


### PR DESCRIPTION
can't change the storage class (f.e. to support Glacier storage on Scaleway) as the header always get's overwritten. this fixes that.

(i would propose to make the WithHeaders method to not overwrite headers with x-amz-meta- and instead create a WithMeta method for that, but that'd be a breaking change i assume)