### PR TITLE
Also publish symbols in NuGet package and add license

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,11 +16,14 @@
   
   <PropertyGroup>
     <Version>0.0.0</Version>
-    <Product>Minio SDK for .NET</Product>
+    <Product>Minio SDK for .NET Core</Product>
     <Company>Minio</Company>
     <Copyright>Copyright 2023-$([System.DateTime]::Now.ToString(yyyy)) Minio</Copyright>
     <Configuration>Release build</Configuration>
     <Configuration Condition=" '$(Configuration)' == 'Debug' ">Debug build (INTERNAL USE ONLY)</Configuration>
-    <InformationalVersion>Unofficial developer build</InformationalVersion>
+    <PackageProjectUrl>https://github.com/minio/minio-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/minio/minio-dotnet</RepositoryUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -1,9 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Title>MinIO SDK for .NET Core</Title>
+        <OutputType>Library</OutputType>
+        <PackageId>MinIO</PackageId>
+        <PackageTags>MinIO AIStor S3 ObjectStore</PackageTags>
+        <Description>MinIO SDK for .NET Core is used to access the MinIO/AIStor service</Description>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <IsPackable>true</IsPackable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All"/>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />

--- a/minio-dotnet.sln
+++ b/minio-dotnet.sln
@@ -10,7 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution files", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		CLAUDE.md = CLAUDE.md
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		DEVELOPMENT.md = DEVELOPMENT.md
+		LICENSE = LICENSE
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.IntegrationTests", "Minio.IntegrationTests\Minio.IntegrationTests.csproj", "{80DE6DB6-D10F-4324-8C17-A77E3E52DD03}"


### PR DESCRIPTION
Update NuGet package generation:
- Also pubish source-code with the package to make debugging easier.
- Set license to Apache 2.0 in NuGet specification.