### PR TITLE
Publish symbols in NuGet package and add license

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 MinIO .NET SDK - A modern C# client library for MinIO S3-compatible object storage. Multi-targeted for .NET 8.0 and later.
 
 ## Build Commands
-Make sure you have installed a recent .NET Core SDK.
+Make sure you have installed a recent .NET SDK.
 ```bash
 # Build
 dotnet build

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,10 @@
     <Copyright>Copyright 2023-$([System.DateTime]::Now.ToString(yyyy)) Minio</Copyright>
     <Configuration>Release build</Configuration>
     <Configuration Condition=" '$(Configuration)' == 'Debug' ">Debug build (INTERNAL USE ONLY)</Configuration>
-    <InformationalVersion>Unofficial developer build</InformationalVersion>
+    <PackageProjectUrl>https://github.com/minio/minio-dotnet</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/minio/minio-dotnet</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 </Project>

--- a/Minio/Minio.csproj
+++ b/Minio/Minio.csproj
@@ -1,6 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <Title>MinIO SDK for .NET</Title>
+        <OutputType>Library</OutputType>
+        <PackageId>Minio</PackageId>
+        <PackageTags>MinIO;AIStor;S3;ObjectStore</PackageTags>
+        <Description>MinIO SDK for .NET is used to access the MinIO/AIStor service</Description>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedAllSources>true</EmbedAllSources>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+        <IsPackable>true</IsPackable>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,6 +20,9 @@
       <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
       <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+      <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
+        <PrivateAssets>all</PrivateAssets>
+      </PackageReference>
       <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
       <PackageReference Include="System.Reactive" Version="6.1.0" />
     </ItemGroup>

--- a/minio-dotnet.sln
+++ b/minio-dotnet.sln
@@ -10,7 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution files", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
 		CLAUDE.md = CLAUDE.md
+		CODE_OF_CONDUCT.md = CODE_OF_CONDUCT.md
 		DEVELOPMENT.md = DEVELOPMENT.md
+		LICENSE = LICENSE
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Minio.IntegrationTests", "Minio.IntegrationTests\Minio.IntegrationTests.csproj", "{80DE6DB6-D10F-4324-8C17-A77E3E52DD03}"


### PR DESCRIPTION
Update NuGet package generation:
- Also publish source-code with the package to make debugging easier.
- Set license to Apache 2.0 in NuGet specification.