### PR TITLE
Fix Access Violation for Write Only Buckets

### DIFF
--- a/Minio.Examples/Cases/TokenExchangeProvider.cs
+++ b/Minio.Examples/Cases/TokenExchangeProvider.cs
@@ -24,7 +24,7 @@ namespace Minio.Examples.Cases;
 
 public class TokenExchangeProvider
 {
-    private IMinioClient minioClient;
+    private readonly IMinioClient minioClient;
     private readonly string tokenEndpoint = "http://192.168.86.151:8080/realms/master/protocol/openid-connect/token";
     private readonly string clientId = "minio-client";
     private readonly string clientSecret;

--- a/Minio/ApiEndpoints/ObjectOperations.cs
+++ b/Minio/ApiEndpoints/ObjectOperations.cs
@@ -1034,15 +1034,8 @@ public partial class MinioClient : IObjectOperations
 
             if (singleFile && args.Progress is not null)
             {
-                var statArgs = new StatObjectArgs()
-                    .WithBucket(args.BucketName)
-                    .WithObject(args.ObjectName);
-                var stat = await StatObjectAsync(statArgs, cancellationToken).ConfigureAwait(false);
-                if (response.StatusCode == HttpStatusCode.OK)
-                {
-                    progressReport.Percentage = 100;
-                    progressReport.TotalBytesTransferred = stat.Size;
-                }
+                progressReport.Percentage = 100;
+                progressReport.TotalBytesTransferred = args.ObjectSize;
 
                 args.Progress.Report(progressReport);
             }

--- a/Minio/DataModel/Args/ListenBucketNotificationsArgs.cs
+++ b/Minio/DataModel/Args/ListenBucketNotificationsArgs.cs
@@ -74,27 +74,25 @@ public class ListenBucketNotificationsArgs : BucketArgs<ListenBucketNotification
         requestMessageBuilder.ResponseWriter = async (responseStream, cancellationToken) =>
         {
             using var sr = new StreamReader(responseStream);
-            while (!sr.EndOfStream)
-                try
-                {
-                    var line = await sr.ReadLineAsync(cancellationToken).ConfigureAwait(false);
-                    if (string.IsNullOrEmpty(line))
-                        break;
+            var line = await sr.ReadLineAsync(cancellationToken).ConfigureAwait(false);
 
-                    if (EnableTrace)
-                    {
-                        Console.WriteLine("== ListenBucketNotificationsAsync read line ==");
-                        Console.WriteLine(line);
-                        Console.WriteLine("==============================================");
-                    }
-
-                    var trimmed = line.Trim();
-                    if (trimmed.Length > 2) NotificationObserver.OnNext(new MinioNotificationRaw(trimmed));
-                }
-                catch
-                {
+            while (line != null)
+            {
+                if (string.IsNullOrEmpty(line))
                     break;
+
+                if (EnableTrace)
+                {
+                    Console.WriteLine("== ListenBucketNotificationsAsync read line ==");
+                    Console.WriteLine(line);
+                    Console.WriteLine("==============================================");
                 }
+
+                var trimmed = line.Trim();
+                if (trimmed.Length > 2) NotificationObserver.OnNext(new MinioNotificationRaw(trimmed));
+
+                line = await sr.ReadLineAsync(cancellationToken).ConfigureAwait(false);
+            }
         };
         return requestMessageBuilder;
     }


### PR DESCRIPTION
MinioClient.PutObjectAsync currently calls StatObjectAsync after successfully executing the PUT request to verify the size of the file. StatObjectAsync issues a HEAD request to the S3 service which is only available for buckets which allow s3:GetObject. For buckets that only allow s3:PutObject, this request fails and an exception is thrown despite the fact the object was successfully put. This pull request removes the StatObjectAsync call and simply returns the size specified in the PutObjectArgs.

This fixes issue #1377.